### PR TITLE
QEMU

### DIFF
--- a/.github/workflows/qemu-self-test.yml
+++ b/.github/workflows/qemu-self-test.yml
@@ -1,0 +1,55 @@
+name: Keywords self-tests with QEMU
+
+on: [push, pull_request]
+
+jobs:
+  qemu:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+
+    - name: Set up QEMU
+      run: |
+         sudo apt-get update
+         sudo apt-get install qemu-system-x86-64
+
+    - name: Download firmware files for QEMU
+      run: |
+        wget -O OVMF_CODE.fd https://cloud.3mdeb.com/index.php/s/iXmyJxKLBB2Eb94/download
+        wget -O OVMF_VARS.fd https://cloud.3mdeb.com/index.php/s/Mn2n92DZLnZQZ8N/download
+
+    - name: Start QEMU in background
+      run: |
+        qemu-system-x86_64 -machine q35,smm=on \
+          -global driver=cfi.pflash01,property=secure,value=on \
+          -drive if=pflash,format=raw,unit=0,file=OVMF_CODE.fd,readonly=on \
+          -drive if=pflash,format=raw,unit=1,file=OVMF_VARS.fd \
+          -debugcon file:debug.log -global isa-debugcon.iobase=0x402 \
+          -global ICH9-LPC.disable_s3=1 \
+          -qmp unix:/tmp/qmp-socket,server,nowait \
+          -net none \
+          -serial telnet:localhost:1234,server,nowait \
+          -nographic &
+
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Start keywords self-tests with QEMU
+      run: |
+        scripts/ci/qemu-self-test.sh

--- a/keywords.robot
+++ b/keywords.robot
@@ -246,10 +246,12 @@ Open Connection And Log In
     ...    REST API, serial connection and checkout used asset in
     ...    SnipeIt
     Check Provided Ip
-    SSHLibrary.Set Default Configuration    timeout=60 seconds
-    SSHLibrary.Open Connection    ${RTE_IP}    prompt=~#
-    SSHLibrary.Login    ${USERNAME}    ${PASSWORD}
-    RTE REST API Setup    ${RTE_IP}    ${HTTP_PORT}
+    IF    '${CONFIG}' != 'qemu'
+        SSHLibrary.Set Default Configuration    timeout=60 seconds
+        SSHLibrary.Open Connection    ${RTE_IP}    prompt=~#
+        SSHLibrary.Login    ${USERNAME}    ${PASSWORD}
+        RTE REST API Setup    ${RTE_IP}    ${HTTP_PORT}
+    END
     IF    'sonoff' == '${POWER_CTRL}'
         ${sonoff_ip}=    Get Current RTE Param    sonoff_ip
         Sonoff API Setup    ${sonoff_ip}
@@ -1121,8 +1123,12 @@ Prepare To Serial Connection
     ...    sections if the communication with the platform based on
     ...    the serial connection
     Open Connection And Log In
-    ${platform}=    Get Current RTE Param    platform
-    Set Global Variable    ${PLATFORM}
+    IF    '${CONFIG}' == 'qemu'
+        Set Global Variable    ${PLATFORM}    qemu
+    ELSE
+        ${platform}=    Get Current RTE Param    platform
+        Set Global Variable    ${PLATFORM}
+    END
     Get DUT To Start State
 
 Prepare To OBMC Connection
@@ -1201,8 +1207,10 @@ Get DUT To Start State
     [Documentation]    Clears telnet buffer and get Device Under Test to start
     ...    state (RTE Relay On).
     Telnet.Read
-    ${result}=    Get Power Supply State
-    IF    '${result}'=='low'    Turn On Power Supply
+    IF    '${CONFIG}' != 'qemu'
+        ${result}=    Get Power Supply State
+        IF    '${result}'=='low'    Turn On Power Supply
+    END
 
 Turn On Power Supply
     ${pc}=    Get Variable Value    ${POWER_CTRL}

--- a/keywords.robot
+++ b/keywords.robot
@@ -1,7 +1,6 @@
 *** Settings ***
 Library         Collections
 Library         keywords.py
-Library         osfv-scripts/osfv_cli/osfv_cli/snipeit_robot.py
 Resource        keys-and-keywords/flashrom.robot
 Resource        pikvm-rest-api/pikvm_comm.robot
 Resource        lib/bios/menus.robot
@@ -1097,6 +1096,9 @@ Prepare Test Suite
     END
     IF    '${CONFIG}' == 'rpi-3b'
         Verify Number Of Connected SD Wire Devices
+    END
+    IF    '${SNIPEIT}' == 'yes'
+        Import Library    osfv-scripts/osfv_cli/osfv_cli/snipeit_robot.py
     END
 
 Prepare To SSH Connection

--- a/lib/QemuMonitor.py
+++ b/lib/QemuMonitor.py
@@ -1,0 +1,41 @@
+import json
+import socket
+
+from robot.api.deco import keyword, library
+
+
+@library
+class QemuMonitor:
+    def __init__(self, socket_path):
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.sock.connect(socket_path)
+        greeting = self.sock.recv(4096)
+        self.qmp_capabilities()
+
+    def _send(self, command, **args):
+        msg = {"execute": command, "arguments": args}
+        self.sock.sendall(json.dumps(msg).encode())
+        response = self.sock.recv(4096).decode()
+        json_objects = [
+            json.loads(line) for line in response.splitlines() if line.strip()
+        ]
+        if len(json_objects) > 1:
+            return {"ack": json_objects[0], "event": json_objects[1]}
+        else:
+            return json_objects[0]
+
+    @keyword
+    def qmp_capabilities(self):
+        return self._send("qmp_capabilities")
+
+    @keyword
+    def system_powerdown(self):
+        return self._send("system_powerdown")
+
+    @keyword
+    def system_reset(self):
+        return self._send("system_reset")
+
+    @keyword
+    def quit(self):
+        return self._send("quit")

--- a/platform-configs/qemu.robot
+++ b/platform-configs/qemu.robot
@@ -1,0 +1,309 @@
+*** Settings ***
+Library     ../lib/QemuMonitor.py    /tmp/qmp-socket
+
+
+*** Variables ***
+${DUT_CONNECTION_METHOD}=                           Telnet
+${PAYLOAD}=                                         tianocore
+${RTE_S2_N_PORT}=                                   1234
+${FLASH_SIZE}=                                      ${16*1024*1024}
+${FLASH_LENGTH}=                                    ${EMPTY}
+${TIANOCORE_STRING}=                                to boot directly
+${BOOT_MENU_KEY}=                                   ${ESC}
+${SETUP_MENU_KEY}=                                  ${F2}
+${BOOT_MENU_STRING}=                                Please select boot device
+${SETUP_MENU_STRING}=                               Select Entry
+${PAYLOAD_STRING}=                                  ${EMPTY}
+${IPXE_BOOT_ENTRY}=                                 ${EMPTY}
+${IPXE_STRING}=                                     ${EMPTY}
+${IPXE_STRING2}=                                    ${EMPTY}
+${IPXE_KEY}=                                        ${EMPTY}
+${EDK2_IPXE_STRING}=                                Network Boot and Utilities
+${EDK2_IPXE_CHECKPOINT}=                            Advanced
+${EDK2_IPXE_START_POS}=                             2
+${NET_BOOT_KEY}=                                    ${EMPTY}
+${SOL_STRING}=                                      ${EMPTY}
+${SN_PATTERN}=                                      ${EMPTY}
+${MANUFACTURER}=                                    ${EMPTY}
+${CPU}=                                             ${EMPTY}
+${POWER_CTRL}=                                      RteCtrl
+${FLASH_VERIFY_METHOD}=                             ${EMPTY}
+${INCORRECT_SIGNATURES_FIRMWARE}=                   ${EMPTY}
+${WIFI_CARD_UBUNTU}=                                Intel(R) Wi-Fi 6 AX200
+${LTE_CARD}=                                        ME906s LTE
+# ${ecc_string}    Single-bit ECC
+# ${IOMMU_string}    (XEN) AMD-Vi: IOMMU 0 Enable
+# ${dram_size}    ${4096}
+# ${def_cores}    4
+# ${def_threads}    1
+# ${def_cpu}    4
+# ${def_online_cpu}    0-3
+# ${def_sockets}    1
+# ${wol_interface}    enp3s0
+# ${SD_DEV_LINUX}    /dev/mmcblk0
+# ${nic_number}    ${4}
+${DEVICE_USB_KEYBOARD}=                             Dell Computer Corp. KB216
+${DEVICE_NVME_DISK}=                                Samsung Electronics Co Ltd NVMe
+${DEVICE_AUDIO1}=                                   ALC897
+${DEVICE_AUDIO2}=                                   Kabylake HDMI
+${DEVICE_AUDIO1_WIN}=                               High Definition Audio Device
+${INITIAL_CPU_FREQUENCY}=                           2600
+${WIN_USB_STICK}=                                   Kingston DataTraveler
+${USB_SHORT_NAME}=                                  USB
+${ME_INTERFACE}=                                    Intel Corporation Comet Lake Management Engine Interface
+${INITIAL_FAN_RPM}=                                 6995
+${ACCEPTED_%_NEAR_INITIAL_RPM}=                     20
+
+# eMMC driver support
+${E_MMC_NAME}=                                      MMC AJTD4R
+${E_MMC_PARTITION_TABLE}=                           gpt
+
+# Platform flashing flags
+${FLASHING_BASIC_METHOD}=                           external
+
+${USB_LIVE}=                                        USB SanDisk 3.2Gen1
+${DEVICE_USB_USERNAME}=                             user
+${DEVICE_USB_PASSWORD}=                             ubuntu
+${DEVICE_USB_PROMPT}=                               user@user-VP4630:~$
+${DEVICE_USB_ROOT_PROMPT}=                          root@user-VP4630:/home/user#
+@{ATTACHED_USB}=                                    ${USB_LIVE}
+
+${DEVICE_WINDOWS_USERNAME}=                         user
+${DEVICE_WINDOWS_PASSWORD}=                         windows
+${DEVICE_UBUNTU_USERNAME}=                          user
+${DEVICE_UBUNTU_PASSWORD}=                          ubuntu
+${DEVICE_UBUNTU_USER_PROMPT}=                       user@user-VP4630:~$
+${DEVICE_UBUNTU_ROOT_PROMPT}=                       root@user-VP4630:/home/user#
+${3_MDEB_WIFI_NETWORK}=                             3mdeb_abr
+
+${DMIDECODE_SERIAL_NUMBER}=                         N/A
+${DMIDECODE_FIRMWARE_VERSION}=                      Dasharo (coreboot+UEFI) v1.0.19
+${DMIDECODE_PRODUCT_NAME}=                          VP4630
+${DMIDECODE_RELEASE_DATE}=                          12/08/2022
+${DMIDECODE_MANUFACTURER}=                          Protectli
+${DMIDECODE_VENDOR}=                                3mdeb
+${DMIDECODE_FAMILY}=                                N/A
+${DMIDECODE_TYPE}=                                  N/A
+
+${FLASHING_VBOOT_BADKEYS}=                          ${FALSE}
+${SECURE_BOOT_DEFAULT_STATE}=                       Disabled
+
+# Supported test environments
+${TESTS_IN_FIRMWARE_SUPPORT}=                       ${TRUE}
+${TESTS_IN_UBUNTU_SUPPORT}=                         ${TRUE}
+${TESTS_IN_DEBIAN_SUPPORT}=                         ${TRUE}
+${TESTS_IN_WINDOWS_SUPPORT}=                        ${FALSE}
+${TESTS_IN_UBUNTU_SERVER_SUPPORT}=                  ${TRUE}
+${TESTS_IN_PROXMOX_VE_SUPPORT}=                     ${TRUE}
+${TESTS_IN_PFSENSE_SERIAL_SUPPORT}=                 ${TRUE}
+${TESTS_IN_PFSENSE_VGA_SUPPORT}=                    ${TRUE}
+${TESTS_IN_OPNSENSE_SERIAL_SUPPORT}=                ${TRUE}
+${TESTS_IN_OPNSENSE_VGA_SUPPORT}=                   ${TRUE}
+${TESTS_IN_FREEBSD_SUPPORT}=                        ${TRUE}
+
+# Regression test flags
+# Test module: dasharo-compatibility
+${BASE_PORT_BOOTBLOCK_SUPPORT}=                     ${FALSE}
+${BASE_PORT_ROMSTAGE_SUPPORT}=                      ${FALSE}
+${BASE_PORT_POSTCAR_SUPPORT}=                       ${FALSE}
+${BASE_PORT_RAMSTAGE_SUPPORT}=                      ${FALSE}
+${BASE_PORT_ALLOCATOR_V4_SUPPORT}=                  ${FALSE}
+${PETITBOOT_PAYLOAD_SUPPORT}=                       ${FALSE}
+${HEADS_PAYLOAD_SUPPORT}=                           ${FALSE}
+${CUSTOM_BOOT_MENU_KEY_SUPPORT}=                    ${TRUE}
+${CUSTOM_SETUP_MENU_KEY_SUPPORT}=                   ${TRUE}
+${CUSTOM_NETWORK_BOOT_ENTRIES_SUPPORT}=             ${TRUE}
+${COREBOOT_FAN_CONTROL_SUPPORT}=                    ${FALSE}
+${INTERNAL_LCD_DISPLAY_SUPPORT}=                    ${FALSE}
+${EXTERNAL_HDMI_DISPLAY_SUPPORT}=                   ${TRUE}
+${EXTERNAL_DISPLAY_PORT_SUPPORT}=                   ${TRUE}
+${EC_AND_SUPER_IO_SUPPORT}=                         ${FALSE}
+${CUSTOM_LOGO_SUPPORT}=                             ${TRUE}
+${USB_DISKS_DETECTION_SUPPORT}=                     ${TRUE}
+${USB_KEYBOARD_DETECTION_SUPPORT}=                  ${TRUE}
+${USB_CAMERA_DETECTION_SUPPORT}=                    ${FALSE}
+${USB_TYPE_C_DISPLAY_SUPPORT}=                      ${FALSE}
+${UEFI_SHELL_SUPPORT}=                              ${TRUE}
+${UEFI_COMPATIBLE_INTERFACE_SUPPORT}=               ${TRUE}
+${IPXE_BOOT_SUPPORT}=                               ${FALSE}
+${NETBOOT_UTILITIES_SUPPORT}=                       ${TRUE}
+${NVME_DISK_SUPPORT}=                               ${TRUE}
+${SD_CARD_READER_SUPPORT}=                          ${FALSE}
+${WIRELESS_CARD_SUPPORT}=                           ${TRUE}
+${WIRELESS_CARD_WIFI_SUPPORT}=                      ${TRUE}
+${WIRELESS_CARD_BLUETOOTH_SUPPORT}=                 ${TRUE}
+${MINI_PC_IE_SLOT_SUPPORT}=                         ${FALSE}
+${NVIDIA_GRAPHICS_CARD_SUPPORT}=                    ${FALSE}
+${USB_C_CHARGING_SUPPORT}=                          ${FALSE}
+${THUNDERBOLT_CHARGING_SUPPORT}=                    ${FALSE}
+${USB_C_DISPLAY_SUPPORT}=                           ${FALSE}
+${AUDIO_SUBSYSTEM_SUPPORT}=                         ${TRUE}
+${SUSPEND_AND_RESUME_SUPPORT}=                      ${FALSE}
+${SERIAL_NUMBER_VERIFICATION}=                      ${FALSE}
+${SERIAL_FROM_MAC}=                                 ${FALSE}
+${FIRMWARE_NUMBER_VERIFICATION}=                    ${TRUE}
+${FIRMWARE_FROM_BINARY}=                            ${FALSE}
+${PRODUCT_NAME_VERIFICATION}=                       ${TRUE}
+${RELEASE_DATE_VERIFICATION}=                       ${TRUE}
+${RELEASE_DATE_FROM_SOL}=                           ${FALSE}
+${MANUFACTURER_VERIFICATION}=                       ${TRUE}
+${VENDOR_VERIFICATION}=                             ${TRUE}
+${FAMILY_VERIFICATION}=                             ${FALSE}
+${TYPE_VERIFICATION}=                               ${FALSE}
+${HARDWARE_WP_SUPPORT}=                             ${FALSE}
+${DOCKING_STATION_USB_SUPPORT}=                     ${FALSE}
+${DOCKING_STATION_KEYBOARD_SUPPORT}=                ${FALSE}
+${DOCKING_STATION_USB_C_CHARGING_SUPPORT}=          ${FALSE}
+${DOCKING_STATION_DETECT_SUPPORT}=                  ${FALSE}
+${DOCKING_STATION_AUDIO_SUPPORT}=                   ${FALSE}
+${EMMC_SUPPORT}=                                    ${TRUE}
+${DTS_SUPPORT}=                                     ${FALSE}
+${FIRMWARE_BUILDING_SUPPORT}=                       ${FALSE}
+${DOCKING_STATION_NET_INTERFACE}=                   ${FALSE}
+${DOCKING_STATION_HDMI}=                            ${FALSE}
+${DOCKING_STATION_DISPLAY_PORT}=                    ${FALSE}
+${UPLOAD_ON_USB_SUPPORT}=                           ${TRUE}
+${DOCKING_STATION_UPLOAD_SUPPORT}=                  ${FALSE}
+${THUNDERBOLT_DOCKING_STATION_SUPPORT}=             ${FALSE}
+${THUNDERBOLT_DOCKING_STATION_USB_SUPPORT}=         ${FALSE}
+${THUNDERBOLT_DOCKING_STATION_KEYBOARD_SUPPORT}=    ${FALSE}
+${THUNDERBOLT_DOCKING_STATION_UPLOAD_SUPPORT}=      ${FALSE}
+${THUNDERBOLT_DOCKING_STATION_NET_INTERFACE}=       ${FALSE}
+${THUNDERBOLT_DOCKING_STATION_HDMI}=                ${FALSE}
+${THUNDERBOLT_DOCKING_STATION_DISPLAY_PORT}=        ${FALSE}
+${THUNDERBOLT_DOCKING_STATION_AUDIO_SUPPORT}=       ${FALSE}
+${DOCKING_STATION_SD_CARD_READER_SUPPORT}=          ${FALSE}
+${RESET_TO_DEFAULTS_SUPPORT}=                       ${FALSE}
+
+# Test module: dasharo-security
+${TPM_SUPPORT}=                                     ${TRUE}
+${VBOOT_KEYS_GENERATING_SUPPORT}=                   ${TRUE}
+${VERIFIED_BOOT_SUPPORT}=                           ${TRUE}
+${VERIFIED_BOOT_POPUP_SUPPORT}=                     ${TRUE}
+${MEASURED_BOOT_SUPPORT}=                           ${TRUE}
+${SECURE_BOOT_SUPPORT}=                             ${TRUE}
+${ME_NEUTER_SUPPORT}=                               ${TRUE}
+${USB_STACK_SUPPORT}=                               ${TRUE}
+${USB_MASS_STORAGE_SUPPORT}=                        ${TRUE}
+${TCG_OPAL_DISK_PASSWORD_SUPPORT}=                  ${FALSE}
+${BIOS_LOCK_SUPPORT}=                               ${FALSE}
+${SMM_WRITE_PROTECTION_SUPPORT}=                    ${FALSE}
+${WIFI_BLUETOOTH_CARD_SWITCH_SUPPORT}=              ${FALSE}
+${CAMERA_SWITCH_SUPPORT}=                           ${FALSE}
+${EARLY_BOOT_DMA_SUPPORT}=                          ${FALSE}
+${UEFI_PASSWORD_SUPPORT}=                           ${FALSE}
+
+# Test module: dasharo-performance
+${SERIAL_BOOT_MEASURE}=                             ${TRUE}
+${DEVICE_BOOT_MEASURE_SUPPORT}=                     ${FALSE}
+${CPU_FREQUENCY_MEASURE}=                           ${TRUE}
+${CPU_TEMPERATURE_MEASURE}=                         ${TRUE}
+${PLATFORM_STABILITY_CHECKING}=                     ${TRUE}
+${TEST_FAN_SPEED}=                                  ${FALSE}
+${CUSTOM_FAN_CURVE_SILENT_MODE_SUPPORT}=            ${FALSE}
+${CUSTOM_FAN_CURVE_PERFORMANCE_MODE_SUPPORT}=       ${FALSE}
+${UBUNTU_BOOTING}=                                  ${TRUE}
+${DEBIAN_BOOTING}=                                  ${TRUE}
+${UBUNTU_SERVER_BOOTING}=                           ${TRUE}
+${PROXMOX_VE_BOOTING}=                              ${TRUE}
+${PFSENSE_SERIAL_BOOTING}=                          ${TRUE}
+${PFSENSE_VGA_BOOTING}=                             ${TRUE}
+${OPNSENSE_SERIAL_BOOTING}=                         ${TRUE}
+${OPNSENSE_VGA_BOOTING}=                            ${TRUE}
+${FREEBSD_BOOTING}=                                 ${TRUE}
+${WINDOWS_BOOTING}=                                 ${TRUE}
+
+# Test module: dasharo-stability
+${M2_WIFI_SUPPORT}=                                 ${FALSE}
+${NVME_DETECTION_SUPPORT}=                          ${FALSE}
+${USB_TYPE-A_DEVICES_DETECTION_SUPPORT}=            ${FALSE}
+${TPM_DETECT_SUPPORT}=                              ${FALSE}
+
+# Supported OS installation variants
+${INSTALL_DEBIAN_USB_SUPPORT}=                      ${FALSE}
+${INSTALL_UBUNTU_USB_SUPPORT}=                      ${FALSE}
+
+# Test cases iterations number
+# Booting OS from USB stick test cases
+${BOOT_FROM_USB_ITERATIONS_NUMBER}=                 5
+# Sticks detection test cases
+${USB_DETECTION_ITERATIONS_NUMBER}=                 5
+# Platform boot measure test cases
+${DEVICE_BOOT_MEASURE_ITTERATIONS}=                 3
+
+# Other platform flags and counters
+# Cooling procedure iterations
+${COOLING_PROCEDURE_ITERATIONS}=                    0
+# Stability tests duration in minutes
+${STABILITY_TEST_DURATION}=                         300
+# Interval between the following readings in stability tests
+${STABILITY_TEST_MEASURE_INTERVAL}=                 10
+# Frequency measure test duration
+${FREQUENCY_TEST_DURATION}=                         60
+# Interval between the following readings in frequency measure tests
+${FREQUENCY_TEST_MEASURE_INTERVAL}=                 1
+# Temperature measure test duration
+${TEMPERATURE_TEST_DURATION}=                       60
+# Interval between the following readings in temperature measure tests
+${TEMPERATURE_TEST_MEASURE_INTERVAL}=               1
+# Fan control measure tests duration in minutes
+${FAN_CONTROL_TEST_DURATION}=                       30
+# Interval between the following readings in fan control tests
+${FAN_CONTROL_MEASURE_INTERVAL}=                    3
+# Custom fan curve tests duration in minutes
+${CUSTOM_FAN_CURVE_TEST_DURATION}=                  30
+# Interval between the following readings in custom fan curve tests
+${CUSTOM_FAN_CURVE_MEASURE_INTERVAL}=               1
+# Maximum fails during during performing test suite usb-boot.robot
+${ALLOWED_FAILS_USB_BOOT}=                          0
+# Maximum fails during during performing test suite usb-detect.robot
+${ALLOWED_FAILS_USB_DETECT}=                        0
+# Number of suspend and resume cycles performed during suspend test
+${SUSPEND_ITERATIONS_NUMBER}=                       15
+# Maximum number of fails during performing suspend and resume cycles
+${SUSPEND_ALLOWED_FAILS}=                           0
+# Number of Ubuntu booting iterations
+${UBUNTU_BOOTING_ITERATIONS}=                       5
+# Number of Debian booting iterations
+${DEBIAN_BOOTING_ITERATIONS}=                       5
+# Number of Ubuntu Server booting iterations
+${UBUNTU_SERVER_BOOTING_ITERATIONS}=                5
+# Number of Proxmox VE booting iterations
+${PROXMOX_VE_BOOTING_ITERATIONS}=                   5
+# Number of pfSense (serial output) booting iterations
+${PFSENSE_SERIAL_BOOTING_ITERATIONS}=               5
+# Number of pfSense (VGA output) booting iterations
+${PFSENSE_VGA_BOOTING_ITERATIONS}=                  5
+# Number of OPNsense (serial output) booting iterations
+${OPNSENSE_SERIAL_BOOTING_ITERATIONS}=              5
+# Number of OPNsense (VGA output) booting iterations
+${OPNSENSE_VGA_BOOTING_ITERATIONS}=                 5
+# Number of FreeBSD booting iterations
+${FREEBSD_BOOTING_ITERATIONS}=                      5
+# Number of Windows booting iterations
+${WINDOWS_BOOTING_ITERATIONS}=                      5
+# Maximum fails during performing booting OS tests
+${ALLOWED_BOOTING_FAILS}=                           0
+# Number of docking station detection iterations after reboot
+${DOCKING_STATION_REBOOT_ITERATIONS}=               2
+# Number of docking station detection iterations after warmboot
+${DOCKING_STATION_WARMBOOT_ITERATIONS}=             2
+# Number of docking station detection iterations after coldboot
+${DOCKING_STATION_COLDBOOT_ITERATIONS}=             2
+# Maximum fails during performing docking station detect tests
+${ALLOWED_DOCKING_STATION_DETECT_FAILS}=            0
+# Number of M.2 Wi-fi card checking iterations after suspension
+${M2_WIFI_ITERATIONS}=                              5
+# Number of NVMe disk detection iterations after suspension
+${NVME_DETECTION_ITERATIONS}=                       5
+# Number of USB Type-A devices detection iterations after suspension
+${USB_TYPE-A_DEVICES_DETECTION_ITERATIONS}=         5
+
+
+*** Keywords ***
+Power On
+    [Documentation]    Keyword clears telnet buffer and sets Device Under Test
+    ...    into Power On state using RTE OC buffers. Implementation
+    ...    must be compatible with the theory of operation of a
+    ...    specific platform.
+    Qemu Monitor.System Reset

--- a/scripts/ci/qemu-self-test.sh
+++ b/scripts/ci/qemu-self-test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+robot -L TRACE -v config:qemu -v rte_ip:127.0.0.1 -v snipeit:no self-tests/keywords-bios.robot

--- a/self-tests/keywords-bios.robot
+++ b/self-tests/keywords-bios.robot
@@ -1,0 +1,81 @@
+*** Settings ***
+Library             Collections
+Library             OperatingSystem
+Library             Process
+Library             String
+Library             Telnet    timeout=30 seconds    connection_timeout=120 seconds
+Library             SSHLibrary    timeout=90 seconds
+Library             RequestsLibrary
+# TODO: maybe have a single file to include if we need to include the same
+# stuff in all test cases
+Resource            ../sonoff-rest-api/sonoff-api.robot
+Resource            ../rtectrl-rest-api/rtectrl.robot
+Resource            ../variables.robot
+Resource            ../keywords.robot
+Resource            ../keys.robot
+Resource            ../pikvm-rest-api/pikvm_comm.robot
+
+# TODO:
+# - document which setup/teardown keywords to use and what are they doing
+# - go threough them and make sure they are doing what the name suggest (not
+# exactly the case right now)
+Suite Setup         Run Keyword
+...                     Prepare Test Suite
+Suite Teardown      Run Keyword
+...                     Log Out And Close Connection
+
+
+*** Test Cases ***
+Enter Boot Menu
+    [Documentation]    Test Enter Boot Menu kwd
+    Power On
+    Enter Boot Menu
+    ${out}=    Read From Terminal Until    exit
+    Should Contain    ${out}    Please select boot device:
+
+Enter Setup Menu Tianocore
+    [Documentation]    Test Enter Setup Menu Tianocore kwd
+    Power On
+    Enter Setup Menu Tianocore
+    ${out}=    Read From Terminal Until    Select Entry
+    Should Contain    ${out}    Select Language
+
+Get Setup Menu Construction
+    [Documentation]    Test Get Setup Menu Construction kwd
+    Power On
+    Enter Setup Menu Tianocore
+    ${menu_construction}=    Get Setup Menu Construction
+    # TODO: Fix kwd so it does not unnecessarily remove 1st character in these
+    # First entry should be always language selection
+    Should Be Equal As Strings    ${menu_construction}[0]    elect Language Standard English
+    # The next entries should not start with ">" (it should be stripped)
+    Should Not Contain    ${menu_construction}[1]    >
+    Should Not Contain    ${menu_construction}[2]    >
+    # Two last entris should be: Continue, Reset
+    Should Be Equal As Strings    ${menu_construction}[-2]    ontinue
+    # Last entry should be always: Reset
+    Should Be Equal As Strings    ${menu_construction}[-1]    eset
+
+Enter Dasharo System Features
+    [Documentation]    Test Enter Dasharo System Features Submenu kwd
+    Power On
+    Enter Dasharo System Features
+    ${out}=    Read From Terminal Until    Esc=Exit
+    Should Contain    ${out}    Dasharo System Features
+
+Enter Device Manager Submenu
+    [Documentation]    Test Enter Device Manager Submenu kwd
+    Power On
+    Enter Setup Menu Tianocore
+    Enter Device Manager Submenu
+    ${out}=    Read From Terminal Until    Esc=Exit
+    Should Contain    ${out}    Device Manager
+
+# TODO: fix this kwd
+# Enter Secure Boot Configuration Submenu
+#    [Documentation]    Test Enter Secure Boot Configuration Submenu kwd
+#    Power On
+#    Enter Setup Menu Tianocore
+#    Enter Secure Boot Configuration Submenu
+#    ${out}=    Read From Terminal Until    Esc=Exit
+#    Should Contain    ${out}    Secure Boot Configuration

--- a/variables.robot
+++ b/variables.robot
@@ -181,6 +181,10 @@ ${OS_UBUNTU}=               ubuntu
 &{RTE47}=                   ip=192.168.10.65    cpuid=02c00042a0dd0cd0    pcb_rev=a22082
 ...                         platform=RPi-3-model-B-V1.2    sonoff_ip=192.168.10.27
 ...                         env=dev    platform_vendor=element14    firmware_type=yocto
+# QEMU
+&{RTE48}=                   ip=127.0.0.1    cpuid=02c0014296737c0d    pcb_rev=1.1.0
+...                         platform=qemu    board-revision=1.01    env=dev
+...                         platform_vendor=qemu
 
 @{RTE_LIST}=                &{RTE01}    &{RTE02}    &{RTE03}    &{RTE04}    &{RTE05}
 ...                         &{RTE06}    &{RTE07}    &{RTE08}    &{RTE09}    &{RTE10}
@@ -191,7 +195,7 @@ ${OS_UBUNTU}=               ubuntu
 ...                         &{RTE31}    &{RTE32}    &{RTE33}    &{RTE34}    &{RTE35}
 ...                         &{RTE36}    &{RTE37}    &{RTE38}    &{RTE39}    &{RTE40}
 ...                         &{RTE41}    &{RTE42}    &{RTE43}    &{RTE44}    &{RTE45}
-...                         &{RTE46}    &{RTE47}
+...                         &{RTE46}    &{RTE47}    &{RTE48}
 
 # hardware database:
 # -----------------------------------------------------------------------------
@@ -382,6 +386,7 @@ ${OS_UBUNTU}=               ubuntu
 @{CONFIG37}=                &{RTE45}
 @{CONFIG38}=                &{RTE46}    &{USB13}    &{SSD08}
 @{CONFIG39}=                &{RTE47}
+@{CONFIG40}=                &{RTE48}
 
 @{CONFIG_LIST}=             @{CONFIG01}    @{CONFIG02}    @{CONFIG03}    @{CONFIG04}
 ...                         @{CONFIG05}    @{CONFIG06}    @{CONFIG08}    @{CONFIG09}


### PR DESCRIPTION
1. Start QEMU with (fw from: https://docs.dasharo.com/variants/qemu_q35/building-manual/#procedure)

```
#!/usr/bin/env bash

qemu-system-x86_64 \
  -machine q35 \
  -drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE.fd \
  -drive if=pflash,format=raw,file=/tmp/OVMF_VARS.fd \
  -net none \
  -qmp unix:/tmp/qmp-socket,server,nowait \
  -serial telnet:localhost:1234,server,nowait \
  -nographic
  ```

2. Start test with

```
robot -L TRACE -v config:qemu -v rte_ip:127.0.0.1 -v snipeit:no dasharo-compatibility/uefi-shell.robot

==============================================================================
Uefi-Shell                                                                    
==============================================================================
USH001.001 UEFI Shell :: Check whether the DUT has the ability to ... | PASS |
------------------------------------------------------------------------------
Uefi-Shell                                                            | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Output:  /home/macpijan/projects/github/dasharo/open-source-firmware-validation/output.xml
Log:     /home/macpijan/projects/github/dasharo/open-source-firmware-validation/log.html
Report:  /home/macpijan/projects/github/dasharo/open-source-firmware-validation/report.html
```

Current problems:
- we are really tied to the RTE in our setup - we expect each platform uses it, we expect we are able to SSH into it, verify CPU ID and stuff,
- we use OVMF, not edk2 payload, and intial phase of boot looks different on serial - especially the `Press KEY to enter setup` etc is not printed, so all our keywords won't work; current FW boots straight into EFI shell (we can interrupt with DEL, but there is no message printed about such possibility on serial)