### PR TITLE
added yocto-base/01_base_os.robot, as well as a keyword in lib/linux.…

### DIFF
--- a/lib/linux.robot
+++ b/lib/linux.robot
@@ -21,5 +21,7 @@ Get Utility Version
     [Arguments]    ${utility}
     ${output}=    Telnet.Execute Command    ${utility} --version | head -1
     ${output}=    Get Line    ${output}    0
-    Should Not Contain    ${output}    command not found
     Log    ${output}
+    ${output}=    Telnet.Execute Command    echo $?
+    ${output}=    Get Line    ${output}    0
+    Should Be Equal As Strings    ${output}    0

--- a/lib/linux.robot
+++ b/lib/linux.robot
@@ -4,7 +4,7 @@ Library     ../keywords.py
 
 *** Keywords ***
 Get Linux Version ID
-    [Documentation]    This keyword return the linux version
+    [Documentation]    This keyword returns the linux version.
     IF    '${DUT_CONNECTION_METHOD}' == 'SSH'
         ${output}=    SSHLibrary.Execute Command    sh -c "cat /etc/os-release | grep VERSION_ID | cut -d '=' -f 2"
     ELSE IF    '${DUT_CONNECTION_METHOD}' == 'Telnet'
@@ -16,8 +16,8 @@ Get Linux Version ID
     RETURN    ${output}
 
 Get Utility Version
-    [Documentation]    This keyword checks whether a utility is available
-    ...    fails if its not, but if it is the version gets logged.
+    [Documentation]    This keyword checks whether a utility is available in the
+    ...    system and logs it's version.
     [Arguments]    ${utility}
     ${output}=    Telnet.Execute Command    ${utility} --version
     Log    ${output}

--- a/lib/linux.robot
+++ b/lib/linux.robot
@@ -19,8 +19,7 @@ Get Utility Version
     [Documentation]    This keyword checks whether a utility is available
     ...    fails if its not, but if it is the version gets logged.
     [Arguments]    ${utility}
-    ${output}=    Telnet.Execute Command    ${utility} --version | head -1
-    ${output}=    Get Line    ${output}    0
+    ${output}=    Telnet.Execute Command    ${utility} --version
     Log    ${output}
     ${output}=    Telnet.Execute Command    echo $?
     ${output}=    Get Line    ${output}    0

--- a/lib/linux.robot
+++ b/lib/linux.robot
@@ -14,3 +14,12 @@ Get Linux Version ID
         FAIL    Connection method not supported for checking version
     END
     RETURN    ${output}
+
+Get Utility Version
+    [Documentation]    This keyword checks whether a utility is available
+    ...    fails if its not, but if it is the version gets logged.
+    [Arguments]    ${utility}
+    ${output}=    Telnet.Execute Command    ${utility} --version | head -1
+    ${output}=    Get Line    ${output}    0
+    Should Not Contain    ${output}    command not found
+    Log    ${output}

--- a/yocto-base/01_base_os.robot
+++ b/yocto-base/01_base_os.robot
@@ -19,9 +19,7 @@ Suite Teardown      Log Out And Close Connection
 Y003.1 Platform boots
     [Documentation]    This test verifies booting of the device.
     Variable Should Exist    ${DUT_PASSWORD}
-    Sonoff Power Off
-    Sleep    5s
-    Sonoff Power On
+    Power Cycle On
     Serial Root Login Linux    ${DUT_PASSWORD}
 
 Y003.2 Basic Packages are installed
@@ -33,18 +31,18 @@ Y003.2 Basic Packages are installed
 Y003.3 USB devices are visible
     [Documentation]    check whether we can see a USB stick that's plugged in.
     ...    Also checks whether we mount/umount it and write/read.
-    ${output}=    Telnet.Execute Command    lsblk | grep sda | wc -l
-    ${output}=    Get Line    ${output}    0
-    Should Be Equal As Strings    ${output}    2
-    Telnet.Execute Command    mount /dev/sda1 /mnt
+    ${partition}=    Telnet.Execute Command
+    ...    dmesg | grep -F "USB Mass Storage device detected" --context=10 | grep 'sd[^[:space:]]' | tail -1 | awk '{gsub(/[\\[\\]]/, "", $5); print $5}'
+    ${partition}=    Get Line    ${partition}    0
+    Telnet.Execute Command    mount /dev/${partition}1 /mnt
     Telnet.Execute Command    echo hi > /mnt/something.txt
-    Telnet.Execute Command    umount /dev/sda*
-    Telnet.Execute Command    mount /dev/sda1 /mnt
+    Telnet.Execute Command    umount /dev/${partition}*
+    Telnet.Execute Command    mount /dev/${partition}1 /mnt
     ${output}=    Telnet.Execute Command    cat /mnt/something.txt
     ${output}=    Get Line    ${output}    0
     Should Be Equal As Strings    ${output}    hi
     Telnet.Execute Command    rm /mnt/something.txt
-    Telnet.Execute Command    umount /dev/sda*
+    Telnet.Execute Command    umount /dev/${partition}*
 
 Y003.4 Ethernet connection is supported
     [Documentation]    tests whether we have an internet connection

--- a/yocto-base/01_base_os.robot
+++ b/yocto-base/01_base_os.robot
@@ -54,6 +54,5 @@ USB
 
 Ethernet
     [Documentation]    tests whether we have an internet connection
-    ${output}=    Telnet.Execute Command    ping 8.8.8.8 -c 5 | grep -F " 0% packet loss" | wc -l
-    ${output}=    Get Line    ${output}    0
-    Should Be Equal As Strings    ${output}    1
+    ${output}=    Telnet.Execute Command    ping -c 5 8.8.8.8
+    Should Contain    ${output}    , 0% packet loss

--- a/yocto-base/01_base_os.robot
+++ b/yocto-base/01_base_os.robot
@@ -23,12 +23,6 @@ Booting Platform
     Sleep    5s
     Sonoff Power On
     Serial Root Login Linux    ${DUT_PASSWORD}
-    ${output}=    Telnet.Execute Command    echo hi
-    ${output}=    Get Line    ${output}    0
-    Should Be Equal As Strings    ${output}    hi
-    IF    "${output}" != "hi"
-        Fatal Error
-    END
 
 Basic Packages
     [Documentation]    checks whether tar, time and chronyc utilities exist.

--- a/yocto-base/01_base_os.robot
+++ b/yocto-base/01_base_os.robot
@@ -54,5 +54,4 @@ USB
 
 Ethernet
     [Documentation]    tests whether we have an internet connection
-    ${output}=    Telnet.Execute Command    ping -c 5 8.8.8.8
-    Should Contain    ${output}    , 0% packet loss
+    Check Internet Connection On Linux

--- a/yocto-base/01_base_os.robot
+++ b/yocto-base/01_base_os.robot
@@ -16,21 +16,21 @@ Suite Teardown      Log Out And Close Connection
 
 
 *** Test Cases ***
-Booting Platform
-    [Documentation]    This test aims to see whether the device can boot.
+Y003.1 Platform boots
+    [Documentation]    This test verifies booting of the device.
     Variable Should Exist    ${DUT_PASSWORD}
     Sonoff Power Off
     Sleep    5s
     Sonoff Power On
     Serial Root Login Linux    ${DUT_PASSWORD}
 
-Basic Packages
+Y003.2 Basic Packages are installed
     [Documentation]    checks whether tar, time and chronyc utilities exist.
     Get Utility Version    tar
     Get Utility Version    time
     Get Utility Version    chronyc
 
-USB
+Y003.3 USB devices are visible
     [Documentation]    check whether we can see a USB stick that's plugged in.
     ...    Also checks whether we mount/umount it and write/read.
     ${output}=    Telnet.Execute Command    lsblk | grep sda | wc -l
@@ -46,6 +46,6 @@ USB
     Telnet.Execute Command    rm /mnt/something.txt
     Telnet.Execute Command    umount /dev/sda*
 
-Ethernet
+Y003.4 Ethernet connection is supported
     [Documentation]    tests whether we have an internet connection
     Check Internet Connection On Linux

--- a/yocto-base/01_base_os.robot
+++ b/yocto-base/01_base_os.robot
@@ -1,0 +1,59 @@
+*** Settings ***
+Library             Collections
+Library             String
+Library             Telnet    timeout=20 seconds    connection_timeout=120 seconds
+Library             SSHLibrary    timeout=90 seconds
+Library             RequestsLibrary
+Resource            ../../sonoff-rest-api/sonoff-api.robot
+Resource            ../../rtectrl-rest-api/rtectrl.robot
+Resource            ../../variables.robot
+Resource            ../../keywords.robot
+Resource            ../lib/sd-wire.robot
+Resource            ../lib/linux.robot
+
+Suite Setup         Prepare Test Suite
+Suite Teardown      Log Out And Close Connection
+
+
+*** Test Cases ***
+Boot
+    [Documentation]    This test aims to see whether the device can boot.
+    Variable Should Exist    ${DUT_PASSWORD}
+    Sonoff Power Off
+    Sleep    5s
+    Sonoff Power On
+    Serial Root Login Linux    ${DUT_PASSWORD}
+    ${output}=    Telnet.Execute Command    echo hi
+    ${output}=    Get Line    ${output}    0
+    Should Be Equal As Strings    ${output}    hi
+    IF    "${output}" != "hi"
+        Fatal Error
+    END
+
+Utilities
+    [Documentation]    checks whether tar, time and chronyc utilities exist.
+    Get Utility Version    tar
+    Get Utility Version    time
+    Get Utility Version    chronyc
+
+USB
+    [Documentation]    check whether we can see a USB stick that's plugged in.
+    ...    Also checks whether we mount/umount it and write/read.
+    ${output}=    Telnet.Execute Command    lsblk | grep sda | wc -l
+    ${output}=    Get Line    ${output}    0
+    Should Be Equal As Strings    ${output}    2
+    Telnet.Execute Command    mount /dev/sda1 /mnt
+    Telnet.Execute Command    echo hi > /mnt/something.txt
+    Telnet.Execute Command    umount /dev/sda*
+    Telnet.Execute Command    mount /dev/sda1 /mnt
+    ${output}=    Telnet.Execute Command    cat /mnt/something.txt
+    ${output}=    Get Line    ${output}    0
+    Should Be Equal As Strings    ${output}    hi
+    Telnet.Execute Command    rm /mnt/something.txt
+    Telnet.Execute Command    umount /dev/sda*
+
+Ethernet
+    [Documentation]    tests whether we have an internet connection
+    ${output}=    Telnet.Execute Command    ping 8.8.8.8 -c 5 | grep -F " 0% packet loss" | wc -l
+    ${output}=    Get Line    ${output}    0
+    Should Be Equal As Strings    ${output}    1

--- a/yocto-base/01_base_os.robot
+++ b/yocto-base/01_base_os.robot
@@ -16,7 +16,7 @@ Suite Teardown      Log Out And Close Connection
 
 
 *** Test Cases ***
-Boot
+Booting Platform
     [Documentation]    This test aims to see whether the device can boot.
     Variable Should Exist    ${DUT_PASSWORD}
     Sonoff Power Off
@@ -30,7 +30,7 @@ Boot
         Fatal Error
     END
 
-Utilities
+Basic Packages
     [Documentation]    checks whether tar, time and chronyc utilities exist.
     Get Utility Version    tar
     Get Utility Version    time


### PR DESCRIPTION
This is a first "real" test that tests the funtionality of the os. I guess I should mark it as Draft for now and later, when the `rpi-sd-wire` branch gets merged, only then unmark it as draft, and change the PR to merge into main?