### PR TITLE
[NEEDS TESTING] fix keyword Setup Intel ME Mode

### DIFF
--- a/dasharo-security/me-neuter.robot
+++ b/dasharo-security/me-neuter.robot
@@ -48,7 +48,7 @@ MNE002.001 Intel ME mode option Enabled works correctly (Ubuntu 22.04)
     IF    '${actual_state}' != 'Enabled'
         Setup Intel ME Mode    ${actual_state}    Enabled
     END
-    Power On
+    Save Changes And Reset
     Boot System Or From Connected Disk    ubuntu
     Login To Linux
     Switch To Root User
@@ -67,7 +67,7 @@ MNE003.001 Intel ME mode option Disable (Soft) works correctly (Ubuntu 22.04)
     IF    '${actual_state}' != 'Disabled (Soft)'
         Setup Intel ME Mode    ${actual_state}    Disabled (Soft)
     END
-    Power On
+    Save Changes And Reset
     Boot System Or From Connected Disk    ubuntu
     Login To Linux
     Switch To Root User
@@ -86,7 +86,7 @@ MNE004.001 Intel ME mode option Disable (HAP) works correctly (Ubuntu 22.04)
     IF    '${actual_state}' != 'Disabled (HAP)'
         Setup Intel ME Mode    ${actual_state}    Disabled (HAP)
     END
-    Power On
+    Save Changes And Reset
     Boot System Or From Connected Disk    ubuntu
     Login To Linux
     Switch To Root User
@@ -106,7 +106,7 @@ MNE006.001 Check Intel ME version (Ubuntu 22.04)
     IF    '${actual_state}' != 'Enabled'
         Setup Intel ME Mode    ${actual_state}    Enabled
     END
-    Power On
+    Save Changes And Reset
     Boot System Or From Connected Disk    ubuntu
     Login To Linux
     Switch To Root User

--- a/keywords.robot
+++ b/keywords.robot
@@ -2495,52 +2495,25 @@ Setup Intel ME Mode
     [Documentation]    Sets the state of Intel ME mode based on the current
     ...    state.
     [Arguments]    ${actual_state}    ${tested_state}
-    IF    '${DUT_CONNECTION_METHOD}' == 'pikvm'
-        Single Key PiKVM    Enter
-        IF    '${actual_state}' == 'Enabled'
-            IF    '${tested_state}' == 'Disabled (Soft)'
-                Press Key N Times And Enter    1    ${ARROW_DOWN}
-            ELSE IF    '${tested_state}' == 'Disabled (HAP)'
-                Press Key N Times And Enter    2    ${ARROW_DOWN}
-            END
-        ELSE IF    '${actual_state}' == 'Disabled (Soft)'
-            IF    '${tested_state}' == 'Enabled'
-                Press Key N Times And Enter    1    ${ARROW_UP}
-            ELSE IF    '${tested_state}' == 'Disabled (HAP)'
-                Press Key N Times And Enter    1    ${ARROW_DOWN}
-            END
-        ELSE IF    '${actual_state}' == 'Disabled (HAP)'
-            IF    '${tested_state}' == 'Enabled'
-                Press Key N Times And Enter    2    ${ARROW_UP}
-            ELSE IF    '${tested_state}' == 'Disabled (Soft)'
-                Press Key N Times And Enter    1    ${ARROW_UP}
-            END
+    Single Key PiKVM    Enter
+    IF    '${actual_state}' == 'Enabled'
+        IF    '${tested_state}' == 'Disabled (Soft)'
+            Press Key N Times And Enter    1    ${ARROW_DOWN}
+        ELSE IF    '${tested_state}' == 'Disabled (HAP)'
+            Press Key N Times And Enter    2    ${ARROW_DOWN}
         END
-        Single Key PiKVM    F10
-        Single Key PiKVM    KeyY
-    ELSE
-        Write Bare Into Terminal    ${ENTER}
-        IF    '${actual_state}' == 'Enabled'
-            IF    '${tested_state}' == 'Disabled (Soft)'
-                Press Key N Times And Enter    1    ${ARROW_DOWN}
-            ELSE IF    '${tested_state}' == 'Disabled (HAP)'
-                Press Key N Times And Enter    2    ${ARROW_DOWN}
-            END
-        ELSE IF    '${actual_state}' == 'Disabled (Soft)'
-            IF    '${tested_state}' == 'Enabled'
-                Press Key N Times And Enter    1    ${ARROW_UP}
-            ELSE IF    '${tested_state}' == 'Disabled (HAP)'
-                Press Key N Times And Enter    1    ${ARROW_DOWN}
-            END
-        ELSE IF    '${actual_state}' == 'Disabled (HAP)'
-            IF    '${tested_state}' == 'Enabled'
-                Press Key N Times And Enter    2    ${ARROW_UP}
-            ELSE IF    '${tested_state}' == 'Disabled (Soft)'
-                Press Key N Times And Enter    1    ${ARROW_UP}
-            END
+    ELSE IF    '${actual_state}' == 'Disabled (Soft)'
+        IF    '${tested_state}' == 'Enabled'
+            Press Key N Times And Enter    1    ${ARROW_UP}
+        ELSE IF    '${tested_state}' == 'Disabled (HAP)'
+            Press Key N Times And Enter    1    ${ARROW_DOWN}
         END
-        Write Bare Into Terminal    ${F10}
-        Write Bare Into Terminal    ${Y}
+    ELSE IF    '${actual_state}' == 'Disabled (HAP)'
+        IF    '${tested_state}' == 'Enabled'
+            Press Key N Times And Enter    2    ${ARROW_UP}
+        ELSE IF    '${tested_state}' == 'Disabled (Soft)'
+            Press Key N Times And Enter    1    ${ARROW_UP}
+        END
     END
 
 Return Intel ME Options


### PR DESCRIPTION
Fix `Setup Intel ME Mode` by refactor the keyword and remove the undefined ${Y} variable.

fix issue: https://github.com/Dasharo/open-source-firmware-validation/issues/57

Note: Although it looks correct, no actual test has been performed. Prior merging, this shall be executed on platform where tests [MNE002.001/MNE003.001/MNE004.001/MNE006.001](
https://docs.dasharo.com/unified-test-documentation/dasharo-security/20F-me-neuter/) should work.
