### PR TITLE
[WIP] Rework terminal kwds qemu sb

### DIFF
--- a/dasharo-security/secure-boot.robot
+++ b/dasharo-security/secure-boot.robot
@@ -41,14 +41,11 @@ SBO001.001 Check Secure Boot default state (firmware)
     ${device_mgr_menu}=    Enter Submenu From Snapshot And Return Construction
     ...    ${setup_menu}
     ...    Device Manager
-    ${secure_boot_menu}=    Enter Submenu From Snapshot And Return Construction
+    ${sb_menu}=    Enter Submenu From Snapshot And Return Construction
     ...    ${device_mgr_menu}
     ...    Secure Boot Configuration
-
-    # The code below still needs fixes
-
-    ${sb_state}=    Get Option Value    Attempt Secure Boot    checkpoint=Save
-    Should Contain    ${sb_state}    [ ]
+    ${sb_state}=    Get Matches    ${sb_menu}    Current Secure Boot State*
+    Should Contain    ${sb_state}[0]    Disabled
 
     # Below is the full test code before the first fixes
 
@@ -69,6 +66,8 @@ SBO002.001 UEFI Secure Boot (Ubuntu 22.04)
 
     Power On
     Enable Secure Boot
+
+    Fail
 
     Boot System Or From Connected Disk    ubuntu
     Login To Linux
@@ -95,6 +94,7 @@ SBO002.002 UEFI Secure Boot (Windows 11)
 
     Power On
     Enable Secure Boot
+
     Boot System Or From Connected Disk    ${OS_WINDOWS}
     Login To Windows
     ${sb_status}=    Check Secure Boot In Windows

--- a/keywords.robot
+++ b/keywords.robot
@@ -6,6 +6,7 @@ Resource        lib/bios/menus.robot
 Resource        lib/secure-boot-lib.robot
 Resource        lib/usb-hid-msc-lib.robot
 Resource        lib/terminal.robot
+Resource        lib/self-tests.robot
 Variables       platform-configs/fan-curve-config.yaml
 
 

--- a/lib/bios/menus.robot
+++ b/lib/bios/menus.robot
@@ -354,14 +354,26 @@ Reenter Menu
     ...    again
     [Arguments]    ${forward}=${FALSE}
     IF    ${forward} == True
-        Press Key N Times    1    ${ENTER}
-        Sleep    1s
+        Press Enter
+        # ESC itself does not "refresh" the data over serial. Only pressing
+        # other keys (such as arrow keys) makes the change caused by ESC
+        # (moving back one menu up) to be redrawn. Using either UP and then DOWN,
+        # or just LEFT / RIGHT (which does not impact any actual movement) should
+        # be safe to use here.
         Press Key N Times    1    ${ESC}
+        Press Key N Times    1    ${ARROW_LEFT}
     ELSE
         Press Key N Times    1    ${ESC}
-        Sleep    1s
-        Press Key N Times    1    ${ENTER}
+        Press Key N Times    1    ${ARROW_LEFT}
+        Press Enter
     END
+
+Reenter Menu And Return Construction
+    [Documentation]    Enters the same menu again, returning updated menu construction
+    [Arguments]    ${forward}=${FALSE}
+    Reenter Menu    ${forward}
+    ${menu}=    Get Submenu Construction
+    RETURN    ${menu}
 
 # This should stay, maybe improved if needed
 

--- a/lib/bios/menus.robot
+++ b/lib/bios/menus.robot
@@ -94,6 +94,19 @@ Parse Menu Snapshot Into Construction
     END
     Log    ${construction}
     ${construction}=    Get Slice From List    ${construction}    ${slice_start}    ${slice_end}
+    # TODO: Improve parsing of the menu into construction. It can probably be
+    # simplified, but at least we have this only in one kewyrod not in multiple
+    # ones.
+    # Make sure to remove control help text appearing in the screen if somehow
+    # they are still there.
+    Remove Values From List
+    ...    ${construction}
+    ...    Esc\=Exit
+    ...    ^v\=Move High
+    ...    <Enter>\=Select Entry
+    ...    F9\=Reset to Defaults F10\=Save
+    ...    LCtrl+LAlt+F12\=Save screenshot
+    ...    <Spacebar>Toggle Checkbox
     RETURN    ${construction}
 
 Enter Setup Menu Tianocore And Return Construction
@@ -129,6 +142,11 @@ Enter Submenu From Snapshot And Return Construction
     Enter Submenu From Snapshot    ${menu}    ${option}
     ${submenu}=    Get Submenu Construction
     RETURN    ${submenu}
+
+Save BIOS Changes
+    [Documentation]    This keyword saves introduced changes
+    Press Key N Times    1    ${F10}
+    Write Bare Into Terminal    y
 
 Enter Dasharo System Features
     [Arguments]    ${setup_menu}
@@ -200,6 +218,9 @@ Press Key N Times
             Sleep    1s
         ELSE
             Write Bare Into Terminal    ${key}
+            # May be useful to add sleep here when implementing test in QEMU
+            # to see how the movement looks like.
+            # Sleep    1s
         END
     END
 

--- a/lib/secure-boot-lib.robot
+++ b/lib/secure-boot-lib.robot
@@ -250,7 +250,7 @@ Go To Secure Boot Menu Entry
     IF    not ${attempt_sb_can_be_selected}
         ${index}=    Evaluate    ${index} - 1
     END
-    Reenter Menu
+    ${sb_menu}=    Reenter Menu And Return Construction
     Press Key N Times And Enter    ${index}    ${ARROW_DOWN}
 
 Select Attempt Secure Boot Option
@@ -260,10 +260,10 @@ Select Attempt Secure Boot Option
 
     ${can_be_selected}=    Check If Attempt Secure Boot Can Be Selected    ${sb_menu}
     IF    not ${can_be_selected}
-        Reenter Menu
+        ${sb_menu}=    Reenter Menu And Return Construction
         Reset Secure Boot Keys    ${sb_menu}
     END
-    Reenter Menu
+    ${sb_menu}=    Reenter Menu And Return Construction
     Set Option State    ${sb_menu}    Attempt Secure Boot    ${TRUE}
     Fail
 
@@ -276,7 +276,7 @@ Clear Attempt Secure Boot Option
     IF    ${option_is_cleared}
         Log    Attempt Secure Boot option is already cleared, nothing to do.
     ELSE
-        Reenter Menu
+        ${sb_menu}=    Reenter Menu And Return Construction
         Go To Secure Boot Menu Entry    Attempt Secure Boot
         Read From Terminal Until    reset the platform to take effect!
         Press Key N Times    1    ${ENTER}

--- a/lib/self-tests.robot
+++ b/lib/self-tests.robot
@@ -1,0 +1,13 @@
+*** Keywords ***
+Menu Construction Should Not Contain Control Text
+    [Documentation]    Checks if parsed menu construction does not contain
+    ...    some unnecessary help text, which is not a valid entry.
+    [Arguments]    ${menu}
+    Should Not Contain Any
+    ...    ${menu}
+    ...    Esc\=Exit
+    ...    ^v\=Move High
+    ...    <Enter>\=Select Entry
+    ...    F9\=Reset to Defaults F10\=Save
+    ...    LCtrl+LAlt+F12\=Save screenshot
+    ...    <Spacebar>Toggle Checkbox

--- a/self-tests/dasharo-system-features-menus.robot
+++ b/self-tests/dasharo-system-features-menus.robot
@@ -44,6 +44,7 @@ Parse Dasharo System Features Menu
     ${setup_menu}=    Enter Setup Menu Tianocore And Return Construction
     ${dasharo_menu}=    Enter Dasharo System Features    ${setup_menu}
     List Should Contain Value    ${dasharo_menu}    > Serial Port Configuration
+    Menu Construction Should Not Contain Control Text    ${dasharo_menu}
 
 Enter Dasharo Security Options
     [Documentation]    Check if Dasharo Security Options menu can be entered.
@@ -56,6 +57,7 @@ Parse Dasharo Security Options
     List Should Contain Value    ${security_menu}    > Enter Firmware Update Mode
     # Second line from "Enable SMM BIOS write protection" should not be there
     List Should Not Contain Value    ${security_menu}    protection
+    Menu Construction Should Not Contain Control Text    ${security_menu}
 
 Enter Networking Options
     [Documentation]    Check if Networking Options menu can be entered.
@@ -67,6 +69,7 @@ Parse Networking Options
     ${networking_entries}=    Get Length    ${networking_menu}
     Should Be Equal As Integers    ${networking_entries}    1
     Should Match Regexp    ${networking_menu}[0]    ^Enable network boot \\[.\\].*$
+    Menu Construction Should Not Contain Control Text    ${networking_menu}
 
 Enter USB Configuration
     [Documentation]    Check if USB Configuration menu can be entered.
@@ -81,6 +84,7 @@ Parse USB Configuration
     Should Match Regexp    ${usb_menu}[1]    ^Enable USB Mass Storage \\[.\\].*$
     # Second line from "Enable USB Mass Storage driver" should not be there
     List Should Not Contain Value    ${usb_menu}    driver
+    Menu Construction Should Not Contain Control Text    ${usb_menu}
 
 Enter Intel Management Engine Options
     [Documentation]    Check if Intel Management Engine menu can be entered.
@@ -92,6 +96,7 @@ Parse Intel Management Engine Options
     ${me_entries}=    Get Length    ${me_menu}
     Should Be Equal As Integers    ${me_entries}    1
     Should Match Regexp    ${me_menu}[0]    ^Intel ME mode <.*>.*$
+    Menu Construction Should Not Contain Control Text    ${me_menu}
 
 Enter Chipset Configuration
     [Documentation]    Check if Chipset Configuration menu can be entered.
@@ -103,6 +108,7 @@ Parse Chipset Configuration
     ${chipset_entries}=    Get Length    ${chipset_menu}
     Should Be Equal As Integers    ${chipset_entries}    3
     Should Match Regexp    ${chipset_menu}[0]    ^Enable PS2 Controller \\[.\\].*$
+    Menu Construction Should Not Contain Control Text    ${chipset_menu}
 
 Enter Power Management Options
     [Documentation]    Check if Power Management Options menu can be entered.
@@ -116,6 +122,7 @@ Parse Power Management Options
     Should Match Regexp    ${power_menu}[0]    ^Fan profile <.*>.*$
     # Second line from Batter Start/Stop Chare Threshold should not be there
     List Should Not Contain Value    ${power_menu}    Threshold
+    Menu Construction Should Not Contain Control Text    ${power_menu}
 
 Enter PCI/PCIe Configuration
     [Documentation]    Check if PCI/PCIe Configuration menu can be entered.
@@ -129,6 +136,7 @@ Parse PCI/PCIe Configuration
     Should Match Regexp    ${pci_menu}[0]    ^Enable PCIe Resizeable \\[.\\].*$
     # Second line from Enable PCIe Resizeable BARs should not be there
     List Should Not Contain Value    ${pci_menu}    BARs
+    Menu Construction Should Not Contain Control Text    ${pci_menu}
 
 Enter Memory Configuration
     [Documentation]    Check if Memory Configuration menu can be entered.
@@ -143,6 +151,7 @@ Parse Memory Configuration
     # Second line from profile should not be there
     List Should Not Contain Value    ${memory_menu}    non-overclocked default)>
     List Should Not Contain Value    ${memory_menu}    extreme memory profile)>
+    Menu Construction Should Not Contain Control Text    ${memory_menu}
 
 Enter Serial Port Configuration
     [Documentation]    Check if Serial Port Configuration menu can be entered.
@@ -156,6 +165,7 @@ Parse Serial Port Configuration
     Should Match Regexp    ${serial_menu}[0]    ^Enable Serial Port \\[.\\].*$
     # Second line from Enable Serial Port Console Redirection should not be there
     List Should Not Contain Value    ${serial_menu}    Console Redirection
+    Menu Construction Should Not Contain Control Text    ${serial_menu}
 
 
 *** Keywords ***

--- a/self-tests/setup-and-boot-menus.robot
+++ b/self-tests/setup-and-boot-menus.robot
@@ -43,6 +43,7 @@ Enter Boot Menu Tianocore And Return Construction
     ${menu}=    Enter Boot Menu Tianocore And Return Construction
     List Should Not Contain Value    ${menu}    Please select boot device:
     List Should Contain Value    ${menu}    Setup
+    Menu Construction Should Not Contain Control Text    ${menu}
 
 Enter Setup Menu Tianocore
     [Documentation]    Test Enter Setup Menu Tianocore kwd
@@ -66,6 +67,7 @@ Enter Setup Menu Tianocore And Return Construction
     List Should Contain Value    ${setup_menu}    > Dasharo System Features
     List Should Contain Value    ${setup_menu}    > One Time Boot
     List Should Contain Value    ${setup_menu}    > Boot Maintenance Manager
+    Menu Construction Should Not Contain Control Text    ${setup_menu}
 
 Enter User Password Management Menu
     [Documentation]    Test entering into User Password Management menu
@@ -86,6 +88,7 @@ Parse User Password Management Menu
     Should Be Equal As Strings    ${password_menu}[1]    Change Admin Password
     ${password_menu_entries}=    Get Length    ${password_menu}
     Should Be Equal As Integers    ${password_menu_entries}    2
+    Menu Construction Should Not Contain Control Text    ${password_menu}
 
 Enter Device Manager Menu
     [Documentation]    Test entering into User Password Management menu
@@ -107,6 +110,34 @@ Parse Device Manager Menu
     ...    Device Manager
     Should Not Contain    ${device_menu}[0]    Devices List
     List Should Contain Value    ${device_menu}    > Driver Health Manager
+    List Should Contain Value    ${device_menu}    Press ESC to exit.
+    Menu Construction Should Not Contain Control Text    ${device_menu}
+
+Enter Secure Boot Menu
+    [Documentation]    Test entering into User Password Management menu
+    Power On
+    ${setup_menu}=    Enter Setup Menu Tianocore And Return Construction
+    ${device_menu}=    Enter Submenu From Snapshot And Return Construction
+    ...    ${setup_menu}
+    ...    Device Manager
+    Enter Submenu From Snapshot    ${device_menu}    Secure Boot Configuration
+    ${out}=    Read From Terminal Until    Esc=Exit
+    Should Contain    ${out}    Secure Boot Configuration
+    Should Contain    ${out}    Current Secure Boot State
+
+Parse Secure Boot Menu
+    [Documentation]    Test entering into User Password Management menu
+    Power On
+    ${setup_menu}=    Enter Setup Menu Tianocore And Return Construction
+    ${device_menu}=    Enter Submenu From Snapshot And Return Construction
+    ...    ${setup_menu}
+    ...    Device Manager
+    ${sb_menu}=    Enter Submenu From Snapshot And Return Construction    ${device_menu}    Secure Boot Configuration
+    Should Match Regexp    ${sb_menu}[0]    ^Current Secure Boot State.*$
+    Should Match Regexp    ${sb_menu}[1]    ^Attempt Secure Boot \\[.\\].*$
+    Should Match Regexp    ${sb_menu}[2]    ^Secure Boot Mode \\<.*\\>.*$
+    Should Match Regexp    ${sb_menu}[3]    ^Reset Secure Boot Keys$
+    Menu Construction Should Not Contain Control Text    ${sb_menu}
 
 Enter One Time Boot Menu
     [Documentation]    Test entering into User Password Management menu
@@ -124,6 +155,7 @@ Parse One Time Boot Menu
     ...    ${setup_menu}
     ...    One Time Boot
     List Should Contain Value    ${otb_menu}    UEFI Shell
+    Menu Construction Should Not Contain Control Text    ${otb_menu}
 
 Enter Boot Maintenance Manager Menu
     [Documentation]    Test entering into User Password Management menu
@@ -146,6 +178,7 @@ Parse Boot Maintenance Manager Menu
     Should Be Equal As Strings    ${boot_mgr_menu}[3]    > Boot From File
     Should Match Regexp    ${boot_mgr_menu}[4]    ^Boot Next Value <.*>$
     Should Match Regexp    ${boot_mgr_menu}[5]    ^Auto Boot Time-out \\[\\d+\\]$
+    Menu Construction Should Not Contain Control Text    ${boot_mgr_menu}
 
 Enter Invalid Option in Setup Menu
     [Documentation]    Test if keyword fails (rather than silently continuing) when


### PR DESCRIPTION
- SB tests added to self-tests/setup-and-boot-menus.robot
  and should work
- The SBO001.001 should work in QEMU
- The SBO002.001 must be worked on - currently, the keys are correctly
  reset when needed (so option to enable SB becomes available), but
  this option does not work in QEMU (Attempt Secure Boot never becomes
  accessible, which must be fixed first)
- Then, we should continue with reworking the rest of the keywords
  in lib/secure-boot.robot
- Another problem is this suite was prepared for PiKVM only - we need
  to find another way for provifing USB disk images with signed/unsigned
  EFI files for testing
