### PR TITLE
lib/bios/menus.robot: improve reliability of parsing menu into constr…

### DIFF
--- a/lib/bios/menus.robot
+++ b/lib/bios/menus.robot
@@ -94,6 +94,19 @@ Parse Menu Snapshot Into Construction
     END
     Log    ${construction}
     ${construction}=    Get Slice From List    ${construction}    ${slice_start}    ${slice_end}
+    # TODO: Improve parsing of the menu into construction. It can probably be
+    # simplified, but at least we have this only in one kewyrod not in multiple
+    # ones.
+    # Make sure to remove control help text appearing in the screen if somehow
+    # they are still there.
+    Remove Values From List
+    ...    ${construction}
+    ...    Esc\=Exit
+    ...    ^v\=Move High
+    ...    <Enter>\=Select Entry
+    ...    F9\=Reset to Defaults F10\=Save
+    ...    LCtrl+LAlt+F12\=Save screenshot
+    ...    <Spacebar>Toggle Checkbox
     RETURN    ${construction}
 
 Enter Setup Menu Tianocore And Return Construction


### PR DESCRIPTION
…uction

We have added F9/F10 hotkeys to be available globally, which breaked some of the kwds. With the following change, we can properly parse both menu styles (before and after this change).