### PR TITLE
WIP: Qemu q35 v0.1.0 rc5

### DIFF
--- a/keywords.robot
+++ b/keywords.robot
@@ -1886,7 +1886,7 @@ Remove Entry From List
 
 Get Secure Boot Configuration Submenu Construction
     [Documentation]    Keyword allows to get and return Secure Boot menu construction.
-    ${menu}=    Read From Terminal Until    Reset Secure Boot Keys
+    ${menu}=    Read From Terminal Until    Secure Boot Mode
     @{menu_lines}=    Split To Lines    ${menu}
     # TODO: make it a generic keyword, to remove all possible control strings
     # from menu constructions

--- a/self-tests/secure-boot.robot
+++ b/self-tests/secure-boot.robot
@@ -36,14 +36,35 @@ Enter Secure Boot Menu
     Should Contain    ${out}    Secure Boot Configuration
     Should Contain    ${out}    Current Secure Boot State
 
+Check If Enable Secure Boot Can Be Selected
+    [Documentation]    Test Check If Enable Secure Boot Can Be Selected kwd
+    Power On
+    ${setup_menu}=    Enter Setup Menu Tianocore And Return Construction
+    ${device_mgr_menu}=    Enter Submenu From Snapshot And Return Construction
+    ...    ${setup_menu}
+    ...    Device Manager
+    ${secure_boot_menu}=    Enter Submenu From Snapshot And Return Construction
+    ...    ${device_mgr_menu}
+    ...    Secure Boot Configuration
+    ${ret}=    Check If Enable Secure Boot Can Be Selected    ${secure_boot_menu}
+    IF    '${config}' != 'qemu'
+        Should Be True    ${ret}
+    ELSE
+        Should Not Be True    ${ret}
+    END
+
 Enter Secure Boot Menu And Return Construction
     [Documentation]    Test Enter Secure Boot Menu And Return Construction kwd
     Power On
     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
     Should Not Contain    ${sb_menu}    Secure Boot Configuration
     Should Match Regexp    ${sb_menu}[0]    ^Current Secure Boot State.*$
-    Should Match Regexp    ${sb_menu}[1]    ^Enable Secure Boot \\[.\\].*$
-    Should Match Regexp    ${sb_menu}[2]    ^Secure Boot Mode \\<.*\\>.*$
+    IF    '${config}' != 'qemu'
+        Should Match Regexp    ${sb_menu}[1]    ^Enable Secure Boot \\[.\\].*$
+        Should Match Regexp    ${sb_menu}[2]    ^Secure Boot Mode \\<.*\\>.*$
+    ELSE
+        Should Match Regexp    ${sb_menu}[1]    ^Secure Boot Mode \\<.*\\>.*$
+    END
     Should Not Contain    ${sb_menu}    To enable Secure Boot, set Secure Boot Mode to
     Should Not Contain    ${sb_menu}    Custom and enroll the keys/PK first.
 


### PR DESCRIPTION
@macpijan I'm confused with the rebase of secure boot keywords. This PR consists of the changes I created on top of the previous version of the code. With those changes, I was able to enable a secure boot in QEMU by resetting keys successfully.

I thought I could address self-test failures mentioned here: https://github.com/Dasharo/open-source-firmware-validation/pull/95#issuecomment-1803857495

But I have no idea how lib keywords are related to those used in self-test. From what I see, those are different keywords. So, what is the purpose of self-test?