### PR TITLE
lib/power-after-fail-lib.robot: wait 15 seconds before power on

### DIFF
--- a/lib/dl-cache.robot
+++ b/lib/dl-cache.robot
@@ -23,9 +23,7 @@ Download To Host Cache
     END
     Log    Downloading ${url} ...
     ${wget_rc}=    Run And Return RC    wget -O ${local_path} ${url}
-    IF    ${wget_rc} != 0
-        Fail    Download failed with exit code: ${wget_rc}
-    END
+    IF    ${wget_rc} != 0    Fail    Download failed with exit code: ${wget_rc}
 
 Calculate SHA256 Sum
     [Arguments]    ${file_path}

--- a/lib/power-after-fail-lib.robot
+++ b/lib/power-after-fail-lib.robot
@@ -7,14 +7,18 @@ Documentation       Collection of keywords related to the Power State After
 Simulate Power Failure
     [Documentation]    This keyword simulates a power failure to the DUT,
     ...    preferably using sonoff. If it's unavailable, the fallback is RTE.
+    # Use 15 seconds delay because if power is absent for less than roughly 10
+    # seconds the platform powers on regardless of the settings (original
+    # firmware behaves the same) and waiting 10 seconds doesn't produce stable
+    # results.
     IF    'sonoff' == '${POWER_CTRL}'
         Sonoff Power Off
-        Sleep    10s
+        Sleep    15s
         Read From Terminal
         Sonoff Power On
     ELSE
         RteCtrl Relay
-        Sleep    10s
+        Sleep    15s
         Read From Terminal
         RteCtrl Relay
     END


### PR DESCRIPTION
Use 15 seconds delay because if power is absent for less than roughly 10 seconds the platform powers on regardless of the settings (original firmware behaves the same) and waiting 10 seconds doesn't produce stable results.

Fixes https://github.com/Dasharo/dasharo-issues/issues/557.