### PR TITLE
Qemu secure boot rebase pt1

### DIFF
--- a/dasharo-security/secure-boot.robot
+++ b/dasharo-security/secure-boot.robot
@@ -41,14 +41,11 @@ SBO001.001 Check Secure Boot default state (firmware)
     ${device_mgr_menu}=    Enter Submenu From Snapshot And Return Construction
     ...    ${setup_menu}
     ...    Device Manager
-    ${secure_boot_menu}=    Enter Submenu From Snapshot And Return Construction
+    ${sb_menu}=    Enter Submenu From Snapshot And Return Construction
     ...    ${device_mgr_menu}
     ...    Secure Boot Configuration
-
-    # The code below still needs fixes
-
-    ${sb_state}=    Get Option Value    Attempt Secure Boot    checkpoint=Save
-    Should Contain    ${sb_state}    [ ]
+    ${sb_state}=    Get Matches    ${sb_menu}    Current Secure Boot State*
+    Should Contain    ${sb_state}[0]    Disabled
 
     # Below is the full test code before the first fixes
 
@@ -69,6 +66,8 @@ SBO002.001 UEFI Secure Boot (Ubuntu 22.04)
 
     Power On
     Enable Secure Boot
+
+    Fail
 
     Boot System Or From Connected Disk    ubuntu
     Login To Linux
@@ -95,6 +94,7 @@ SBO002.002 UEFI Secure Boot (Windows 11)
 
     Power On
     Enable Secure Boot
+
     Login To Windows
     ${sb_status}=    Check Secure Boot In Windows
     Should Be True    ${sb_status}

--- a/dasharo-security/secure-boot.robot
+++ b/dasharo-security/secure-boot.robot
@@ -65,9 +65,21 @@ SBO002.001 UEFI Secure Boot (Ubuntu 22.04)
     Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    SBO002.001 not supported
 
     Power On
-    Enable Secure Boot
+
+    ${setup_menu}=    Enter Setup Menu Tianocore And Return Construction
+    ${device_mgr_menu}=    Enter Submenu From Snapshot And Return Construction
+    ...    ${setup_menu}
+    ...    Device Manager
+    Enter Submenu From Snapshot    ${device_mgr_menu}    Secure Boot Configuration
+    ${sb_menu}=    Get Secure Boot Menu Construction
+    Enter Custom Secure Boot Options    ${sb_menu}
+    Sleep    1s
+    ${out}=    Read From Terminal
+    Log    ${out}
 
     Fail
+
+    Enable Secure Boot
 
     Boot System Or From Connected Disk    ubuntu
     Login To Linux

--- a/keywords.robot
+++ b/keywords.robot
@@ -8,6 +8,7 @@ Resource        lib/usb-hid-msc-lib.robot
 Resource        lib/terminal.robot
 Resource        lib/esp-scanning-lib.robot
 Resource        lib/dl-cache.robot
+Resource        lib/self-tests.robot
 Variables       platform-configs/fan-curve-config.yaml
 
 

--- a/keywords.robot
+++ b/keywords.robot
@@ -1856,26 +1856,6 @@ Remove Entry From List
     END
     RETURN    ${output_list}
 
-Get Secure Boot Configuration Submenu Construction
-    [Documentation]    Keyword allows to get and return Secure Boot menu construction.
-    ${menu}=    Read From Terminal Until    Reset Secure Boot Keys
-    @{menu_lines}=    Split To Lines    ${menu}
-    # TODO: make it a generic keyword, to remove all possible control strings
-    # from menu constructions
-    @{menu_lines}=    Remove Entry From List    ${menu_lines}    .*Move Highlight.*
-    @{menu_lines}=    Remove Entry From List    ${menu_lines}    .*Secure Boot Configuration.*
-    @{menu_construction}=    Create List
-    FOR    ${line}    IN    @{menu_lines}
-        ${line}=    Remove String    ${line}    -    \\    \    /    |    <    >
-        ${line}=    Replace String Using Regexp    ${line}    ${SPACE}+    ${SPACE}
-        IF    "${line}"!="${EMPTY}" and "${line}"!=" "
-            ${line}=    Strip String    ${line}
-            Append To List    ${menu_construction}    ${line}
-        END
-    END
-    ${menu_construction}=    Get Slice From List    ${menu_construction}[1:]
-    RETURN    ${menu_construction}
-
 Generate 1GB File In Windows
     [Documentation]    Generates 1G file in Windows in .txt format.
     ${out}=    Execute Command In Terminal    fsutil file createnew test_file.txt 1073741824

--- a/lib/bios/menus.robot
+++ b/lib/bios/menus.robot
@@ -55,15 +55,15 @@ Get Setup Menu Construction
     #    0.0.0    128 MB RAM
     #    BOTTOM
     #    ^v=Move Highlight    <Enter>=Select Entry
-    ${construction}=    Get Menu Construction    ${checkpoint}    3    1
-    RETURN    ${construction}
+    ${menu}=    Get Menu Construction    ${checkpoint}    3    1
+    RETURN    ${menu}
 
 Get Menu Construction
     [Documentation]    Keyword allows to get and return setup menu construction.
-    [Arguments]    ${checkpoint}=Press ESC to exit.    ${lines_top}=1    ${lines_bot}=0
-    ${menu}=    Read From Terminal Until    ${checkpoint}
-    ${construction}=    Parse Menu Snapshot Into Construction    ${menu}    ${lines_top}    ${lines_bot}
-    RETURN    ${construction}
+    [Arguments]    ${checkpoint}=ESC=exit    ${lines_top}=1    ${lines_bot}=0
+    ${out}=    Read From Terminal Until    ${checkpoint}
+    ${menu}=    Parse Menu Snapshot Into Construction    ${out}    ${lines_top}    ${lines_bot}
+    RETURN    ${menu}
 
 Parse Menu Snapshot Into Construction
     [Documentation]    Breaks grabbed menu data into lines.

--- a/lib/bios/menus.robot
+++ b/lib/bios/menus.robot
@@ -350,22 +350,28 @@ Enter IPXE
     Set Prompt For Terminal    iPXE>
     Read From Terminal Until Prompt
 
+Exit From Current Menu
+    [Documentation]    Exits from current menu, refreshing screen.
+    # ESC itself does not "refresh" the data over serial. Only pressing
+    # other keys (such as arrow keys) makes the change caused by ESC
+    # (moving back one menu up) to be redrawn. Using either UP and then DOWN,
+    # or just LEFT / RIGHT (which does not impact any actual movement) should
+    # be safe to use here.
+    Press Key N Times    1    ${ESC}
+    # Before entering new menu, make sure we get rid of all leftovers
+    Sleep    1s
+    Read From Terminal
+    Press Key N Times    1    ${ARROW_LEFT}
+
 Reenter Menu
     [Documentation]    Returns to the previous menu and enters the same one
     ...    again
     [Arguments]    ${forward}=${FALSE}
     IF    ${forward} == True
         Press Enter
-        # ESC itself does not "refresh" the data over serial. Only pressing
-        # other keys (such as arrow keys) makes the change caused by ESC
-        # (moving back one menu up) to be redrawn. Using either UP and then DOWN,
-        # or just LEFT / RIGHT (which does not impact any actual movement) should
-        # be safe to use here.
-        Press Key N Times    1    ${ESC}
-        Press Key N Times    1    ${ARROW_LEFT}
+        Exit From Current Menu
     ELSE
-        Press Key N Times    1    ${ESC}
-        Press Key N Times    1    ${ARROW_LEFT}
+        Exit From Current Menu
         Press Enter
     END
 

--- a/lib/bios/menus.robot
+++ b/lib/bios/menus.robot
@@ -355,14 +355,26 @@ Reenter Menu
     ...    again
     [Arguments]    ${forward}=${FALSE}
     IF    ${forward} == True
-        Press Key N Times    1    ${ENTER}
-        Sleep    1s
+        Press Enter
+        # ESC itself does not "refresh" the data over serial. Only pressing
+        # other keys (such as arrow keys) makes the change caused by ESC
+        # (moving back one menu up) to be redrawn. Using either UP and then DOWN,
+        # or just LEFT / RIGHT (which does not impact any actual movement) should
+        # be safe to use here.
         Press Key N Times    1    ${ESC}
+        Press Key N Times    1    ${ARROW_LEFT}
     ELSE
         Press Key N Times    1    ${ESC}
-        Sleep    1s
-        Press Key N Times    1    ${ENTER}
+        Press Key N Times    1    ${ARROW_LEFT}
+        Press Enter
     END
+
+Reenter Menu And Return Construction
+    [Documentation]    Enters the same menu again, returning updated menu construction
+    [Arguments]    ${forward}=${FALSE}
+    Reenter Menu    ${forward}
+    ${menu}=    Get Submenu Construction
+    RETURN    ${menu}
 
 # This should stay, maybe improved if needed
 

--- a/lib/bios/menus.robot
+++ b/lib/bios/menus.robot
@@ -144,6 +144,11 @@ Enter Submenu From Snapshot And Return Construction
     ${submenu}=    Get Submenu Construction
     RETURN    ${submenu}
 
+Save BIOS Changes
+    [Documentation]    This keyword saves introduced changes
+    Press Key N Times    1    ${F10}
+    Write Bare Into Terminal    y
+
 Enter Dasharo System Features
     [Arguments]    ${setup_menu}
     ${dasharo_menu}=    Enter Submenu From Snapshot And Return Construction
@@ -214,6 +219,9 @@ Press Key N Times
             Sleep    1s
         ELSE
             Write Bare Into Terminal    ${key}
+            # May be useful to add sleep here when implementing test in QEMU
+            # to see how the movement looks like.
+            # Sleep    1s
         END
     END
 

--- a/lib/secure-boot-lib.robot
+++ b/lib/secure-boot-lib.robot
@@ -104,6 +104,26 @@ Disable Secure Boot
     ${sb_menu}=    Make Sure That Keys Are Provisioned    ${sb_menu}
     Set Option State    ${sb_menu}    Enable Secure Boot    ${FALSE}
 
+Check Secure Boot In Linux
+    [Documentation]    Keyword checks Secure Boot state in Linux.
+    ...    Returns True when Secure Boot is enabled
+    ...    and False when disabled.
+    ${out}=    Execute Linux Command    dmesg | grep secureboot
+    Should Contain Any    ${out}    disabled    enabled
+    ${sb_status}=    Run Keyword And Return Status
+    ...    Should Contain    ${out}    enabled
+    RETURN    ${sb_status}
+
+Check Secure Boot In Windows
+    [Documentation]    Keyword checks Secure Boot state in Windows.
+    ...    Returns True when Secure Boot is enabled
+    ...    and False when disabled.
+    ${out}=    Execute Command In Terminal    Confirm-SecureBootUEFI
+    Should Contain Any    ${out}    True    False
+    ${sb_status}=    Run Keyword And Return Status
+    ...    Should Contain    ${out}    True
+    RETURN    ${sb_status}
+
 # TODO Kwds below still needs review / rework after SB menu layout changes.
 # Only keywords above this line are fairly usabe and tested in self-tests/secure-boot.robot
 
@@ -254,31 +274,11 @@ Reset Secure Boot Keys
 Upload Required Images
     [Documentation]    Uploads the required images onto the PiKVM
     ${pikvm_ip}=    Get Variable Value    ${PIKVM_IP}
-    IF    ${pikvm_ip}
+    IF    "${DUT_CONNECTION_METHOD}" == "pikvm"
         Upload Image    ${pikvm_ip}    https://cloud.3mdeb.com/index.php/s/k9EcYGDTWQAwtGs/download/good_keys.img
         Upload Image    ${pikvm_ip}    https://cloud.3mdeb.com/index.php/s/LaZQKGizg8gQRMZ/download/not_signed.img
         Upload Image    ${pikvm_ip}    https://cloud.3mdeb.com/index.php/s/DpmnoBK8HBJDTY4/download/bad_keys.img
         Upload Image    ${pikvm_ip}    https://cloud.3mdeb.com/index.php/s/TnEWbqGZ83i6bHo/download/bad_format.img
     ELSE
-        Log    No PIKV_IP defined. Images for Secure Boot tests must be shipped via other backend.
+        Log    Images for Secure Boot tests must be shipped via other backend. Right now, only PiKVM is supported.
     END
-
-Check Secure Boot In Linux
-    [Documentation]    Keyword checks Secure Boot state in Linux.
-    ...    Returns True when Secure Boot is enabled
-    ...    and False when disabled.
-    ${out}=    Execute Linux Command    dmesg | grep secureboot
-    Should Contain Any    ${out}    disabled    enabled
-    ${sb_status}=    Run Keyword And Return Status
-    ...    Should Contain    ${out}    enabled
-    RETURN    ${sb_status}
-
-Check Secure Boot In Windows
-    [Documentation]    Keyword checks Secure Boot state in Windows.
-    ...    Returns True when Secure Boot is enabled
-    ...    and False when disabled.
-    ${out}=    Execute Command In Terminal    Confirm-SecureBootUEFI
-    Should Contain Any    ${out}    True    False
-    ${sb_status}=    Run Keyword And Return Status
-    ...    Should Contain    ${out}    True
-    RETURN    ${sb_status}

--- a/lib/secure-boot-lib.robot
+++ b/lib/secure-boot-lib.robot
@@ -19,12 +19,16 @@ Get Secure Boot Menu Construction
     ...    List Should Not Contain Value
     ...    ${menu}
     ...    To enable Secure Boot, set Secure Boot Mode to
+    # If we have a help message indicating keys are not provisioned,
+    # we drop this help message end Enable Secure Boot option (which is
+    # not selectable) from the menu construction.
     IF    ${enable_sb_can_be_selected} == ${FALSE}
         Remove Values From List
         ...    ${menu}
         ...    To enable Secure Boot, set Secure Boot Mode to
         ...    Custom and enroll the keys/PK first.
         ...    Enable Secure Boot [ ]
+        ...    Enable Secure Boot [X]
     END
     RETURN    ${menu}
 
@@ -48,6 +52,24 @@ Enter Advanced Secure Boot Keys Management
     Set Option State    ${sb_menu}    Secure Boot Mode    Custom Mode
     # After selecting Custom Mode, the Advanced Menu is one below
     Press Key N Times And Enter    1    ${ARROW_DOWN}
+
+Reset To Default Secure Boot Keys
+    [Documentation]    This keyword assumes that we are in the Advanced Secure
+    ...    Boot menu already. We assume here it will not change too often and
+    ...    that the menu layout is fixed. Reset to Default Secure Boot Keys is
+    ...    the first entry.
+    Press Enter
+    Read From Terminal Until    Are you sure?
+    Press Enter
+
+Erase All Secure Boot Keys
+    [Documentation]    This keyword assumes that we are in the Advanced Secure
+    ...    Boot menu already. We assume here it will not change too often and
+    ...    that the menu layout is fixed. Erase All Secure Boot Keys is the
+    ...    second entry.
+    Press Key N Times And Enter    1    ${ARROW_DOWN}
+    Read From Terminal Until    Are you sure?
+    Press Enter
 
 Return Secure Boot State
     [Documentation]    Returns the state of Secure Boot as reported in the Secure Boot Configuration menu

--- a/lib/secure-boot-lib.robot
+++ b/lib/secure-boot-lib.robot
@@ -250,7 +250,7 @@ Go To Secure Boot Menu Entry
     IF    not ${attempt_sb_can_be_selected}
         ${index}=    Evaluate    ${index} - 1
     END
-    Reenter Menu
+    ${sb_menu}=    Reenter Menu And Return Construction
     Press Key N Times And Enter    ${index}    ${ARROW_DOWN}
 
 Select Attempt Secure Boot Option
@@ -260,10 +260,10 @@ Select Attempt Secure Boot Option
 
     ${can_be_selected}=    Check If Attempt Secure Boot Can Be Selected    ${sb_menu}
     IF    not ${can_be_selected}
-        Reenter Menu
+        ${sb_menu}=    Reenter Menu And Return Construction
         Reset Secure Boot Keys    ${sb_menu}
     END
-    Reenter Menu
+    ${sb_menu}=    Reenter Menu And Return Construction
     Set Option State    ${sb_menu}    Attempt Secure Boot    ${TRUE}
     Fail
 
@@ -276,7 +276,7 @@ Clear Attempt Secure Boot Option
     IF    ${option_is_cleared}
         Log    Attempt Secure Boot option is already cleared, nothing to do.
     ELSE
-        Reenter Menu
+        ${sb_menu}=    Reenter Menu And Return Construction
         Go To Secure Boot Menu Entry    Attempt Secure Boot
         Read From Terminal Until    reset the platform to take effect!
         Press Key N Times    1    ${ENTER}

--- a/lib/self-tests.robot
+++ b/lib/self-tests.robot
@@ -1,0 +1,13 @@
+*** Keywords ***
+Menu Construction Should Not Contain Control Text
+    [Documentation]    Checks if parsed menu construction does not contain
+    ...    some unnecessary help text, which is not a valid entry.
+    [Arguments]    ${menu}
+    Should Not Contain Any
+    ...    ${menu}
+    ...    Esc\=Exit
+    ...    ^v\=Move High
+    ...    <Enter>\=Select Entry
+    ...    F9\=Reset to Defaults F10\=Save
+    ...    LCtrl+LAlt+F12\=Save screenshot
+    ...    <Spacebar>Toggle Checkbox

--- a/os-config/ubuntu-credentials.robot
+++ b/os-config/ubuntu-credentials.robot
@@ -1,5 +1,5 @@
 *** Variables ***
-${UBUNTU_USERNAME}=         ubuntu
+${UBUNTU_USERNAME}=         user
 ${UBUNTU_PASSWORD}=         ubuntu
-${UBUNTU_USER_PROMPT}=      ubuntu@3mdeb:~$
-${UBUNTU_ROOT_PROMPT}=      root@3mdeb:
+${UBUNTU_USER_PROMPT}=      user@user-3mdeb:~$
+${UBUNTU_ROOT_PROMPT}=      root@user-3mdeb:

--- a/platform-configs/qemu.robot
+++ b/platform-configs/qemu.robot
@@ -1,5 +1,6 @@
 *** Settings ***
 Library     ../lib/QemuMonitor.py    /tmp/qmp-socket
+Resource    ../os-config/ubuntu-credentials.robot
 
 
 *** Variables ***
@@ -66,10 +67,10 @@ ${DEVICE_USB_ROOT_PROMPT}=                          root@user-VP4630:/home/user#
 
 ${DEVICE_WINDOWS_USERNAME}=                         user
 ${DEVICE_WINDOWS_PASSWORD}=                         windows
-${DEVICE_UBUNTU_USERNAME}=                          user
-${DEVICE_UBUNTU_PASSWORD}=                          ubuntu
-${DEVICE_UBUNTU_USER_PROMPT}=                       user@user-VP4630:~$
-${DEVICE_UBUNTU_ROOT_PROMPT}=                       root@user-VP4630:/home/user#
+${DEVICE_UBUNTU_USERNAME}=                          ${UBUNTU_USERNAME}
+${DEVICE_UBUNTU_PASSWORD}=                          ${UBUNTU_PASSWORD}
+${DEVICE_UBUNTU_USER_PROMPT}=                       ${UBUNTU_USER_PROMPT}
+${DEVICE_UBUNTU_ROOT_PROMPT}=                       ${UBUNTU_ROOT_PROMPT}
 ${3_MDEB_WIFI_NETWORK}=                             3mdeb_abr
 
 ${DMIDECODE_SERIAL_NUMBER}=                         N/A

--- a/platform-configs/qemu.robot
+++ b/platform-configs/qemu.robot
@@ -173,7 +173,7 @@ ${DOCKING_STATION_SD_CARD_READER_SUPPORT}=          ${FALSE}
 ${RESET_TO_DEFAULTS_SUPPORT}=                       ${TRUE}
 ${MEMORY_PROFILE_SUPPORT}=                          ${TRUE}
 ${DEFAULT_POWER_STATE_AFTER_FAIL}=                  Powered Off
-${ESP_SCANNING_SUPPORT}=                            ${FALSE}
+${ESP_SCANNING_SUPPORT}=                            ${TRUE}
 
 # Test module: dasharo-security
 ${TPM_SUPPORT}=                                     ${TRUE}

--- a/scripts/ci/qemu-self-test.sh
+++ b/scripts/ci/qemu-self-test.sh
@@ -5,3 +5,4 @@ robot -L TRACE -v config:qemu -v rte_ip:127.0.0.1 -v snipeit:no self-tests/dasha
 robot -L TRACE -v config:qemu -v rte_ip:127.0.0.1 -v snipeit:no self-tests/boolean-options.robot
 robot -L TRACE -v config:qemu -v rte_ip:127.0.0.1 -v snipeit:no self-tests/numerical-options.robot
 robot -L TRACE -v config:qemu -v rte_ip:127.0.0.1 -v snipeit:no self-tests/list-options.robot
+robot -L TRACE -v config:qemu -v rte_ip:127.0.0.1 -v snipeit:no self-tests/secure-boot.robot

--- a/self-tests/dasharo-system-features-menus.robot
+++ b/self-tests/dasharo-system-features-menus.robot
@@ -44,6 +44,7 @@ Parse Dasharo System Features Menu
     ${setup_menu}=    Enter Setup Menu Tianocore And Return Construction
     ${dasharo_menu}=    Enter Dasharo System Features    ${setup_menu}
     List Should Contain Value    ${dasharo_menu}    > Serial Port Configuration
+    Menu Construction Should Not Contain Control Text    ${dasharo_menu}
 
 Enter Dasharo Security Options
     [Documentation]    Check if Dasharo Security Options menu can be entered.
@@ -56,6 +57,7 @@ Parse Dasharo Security Options
     List Should Contain Value    ${security_menu}    > Enter Firmware Update Mode
     # Second line from "Enable SMM BIOS write protection" should not be there
     List Should Not Contain Value    ${security_menu}    protection
+    Menu Construction Should Not Contain Control Text    ${security_menu}
 
 Enter Networking Options
     [Documentation]    Check if Networking Options menu can be entered.
@@ -67,6 +69,7 @@ Parse Networking Options
     ${networking_entries}=    Get Length    ${networking_menu}
     Should Be Equal As Integers    ${networking_entries}    1
     Should Match Regexp    ${networking_menu}[0]    ^Enable network boot \\[.\\].*$
+    Menu Construction Should Not Contain Control Text    ${networking_menu}
 
 Enter USB Configuration
     [Documentation]    Check if USB Configuration menu can be entered.
@@ -81,6 +84,7 @@ Parse USB Configuration
     Should Match Regexp    ${usb_menu}[1]    ^Enable USB Mass Storage \\[.\\].*$
     # Second line from "Enable USB Mass Storage driver" should not be there
     List Should Not Contain Value    ${usb_menu}    driver
+    Menu Construction Should Not Contain Control Text    ${usb_menu}
 
 Enter Intel Management Engine Options
     [Documentation]    Check if Intel Management Engine menu can be entered.
@@ -92,6 +96,7 @@ Parse Intel Management Engine Options
     ${me_entries}=    Get Length    ${me_menu}
     Should Be Equal As Integers    ${me_entries}    1
     Should Match Regexp    ${me_menu}[0]    ^Intel ME mode <.*>.*$
+    Menu Construction Should Not Contain Control Text    ${me_menu}
 
 Enter Chipset Configuration
     [Documentation]    Check if Chipset Configuration menu can be entered.
@@ -103,6 +108,7 @@ Parse Chipset Configuration
     ${chipset_entries}=    Get Length    ${chipset_menu}
     Should Be Equal As Integers    ${chipset_entries}    3
     Should Match Regexp    ${chipset_menu}[0]    ^Enable PS2 Controller \\[.\\].*$
+    Menu Construction Should Not Contain Control Text    ${chipset_menu}
 
 Enter Power Management Options
     [Documentation]    Check if Power Management Options menu can be entered.
@@ -116,6 +122,7 @@ Parse Power Management Options
     Should Match Regexp    ${power_menu}[0]    ^Fan profile <.*>.*$
     # Second line from Batter Start/Stop Chare Threshold should not be there
     List Should Not Contain Value    ${power_menu}    Threshold
+    Menu Construction Should Not Contain Control Text    ${power_menu}
 
 Enter PCI/PCIe Configuration
     [Documentation]    Check if PCI/PCIe Configuration menu can be entered.
@@ -129,6 +136,7 @@ Parse PCI/PCIe Configuration
     Should Match Regexp    ${pci_menu}[0]    ^Enable PCIe Resizeable \\[.\\].*$
     # Second line from Enable PCIe Resizeable BARs should not be there
     List Should Not Contain Value    ${pci_menu}    BARs
+    Menu Construction Should Not Contain Control Text    ${pci_menu}
 
 Enter Memory Configuration
     [Documentation]    Check if Memory Configuration menu can be entered.
@@ -143,6 +151,7 @@ Parse Memory Configuration
     # Second line from profile should not be there
     List Should Not Contain Value    ${memory_menu}    non-overclocked default)>
     List Should Not Contain Value    ${memory_menu}    extreme memory profile)>
+    Menu Construction Should Not Contain Control Text    ${memory_menu}
 
 Enter Serial Port Configuration
     [Documentation]    Check if Serial Port Configuration menu can be entered.
@@ -156,6 +165,7 @@ Parse Serial Port Configuration
     Should Match Regexp    ${serial_menu}[0]    ^Enable Serial Port \\[.\\].*$
     # Second line from Enable Serial Port Console Redirection should not be there
     List Should Not Contain Value    ${serial_menu}    Console Redirection
+    Menu Construction Should Not Contain Control Text    ${serial_menu}
 
 
 *** Keywords ***

--- a/self-tests/secure-boot.robot
+++ b/self-tests/secure-boot.robot
@@ -42,8 +42,7 @@ Enter Secure Boot Menu And Return Construction
     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
     Should Not Contain    ${sb_menu}    Secure Boot Configuration
     Should Match Regexp    ${sb_menu}[0]    ^Current Secure Boot State.*$
-    Should Match Regexp    ${sb_menu}[1]    ^Enable Secure Boot \\[.\\].*$
-    Should Match Regexp    ${sb_menu}[2]    ^Secure Boot Mode \\<.*\\>.*$
+    Should Match Regexp    ${sb_menu}[-1]    ^Secure Boot Mode \\<.*\\>.*$
     Should Not Contain    ${sb_menu}    To enable Secure Boot, set Secure Boot Mode to
     Should Not Contain    ${sb_menu}    Custom and enroll the keys/PK first.
 
@@ -57,12 +56,74 @@ Enter Advanced Secure Boot Keys Management
     Should Contain    ${out}    Reset to default Secure Boot Keys
     Should Contain    ${out}    Erase all Secure Boot Keys
 
+Reset To Default Secure Boot Keys
+    [Documentation]    Test Reset To Default Secure Boot Keys kwd
+    Power On
+    ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+    Enter Advanced Secure Boot Keys Management    ${sb_menu}
+    Reset To Default Secure Boot Keys
+    Save Changes And Reset    3
+
+    Enter Secure Boot Menu
+    ${out}=    Read From Terminal Until    Esc=Exit
+    Should Not Contain    ${out}    To enable Secure Boot, set Secure Boot Mode to
+    Should Not Contain    ${out}    Custom and enroll the keys/PK first.
+
+Erase All Secure Boot Keys
+    [Documentation]    Test Erase All Secure Boot Keys kwd
+    Power On
+    ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+    Enter Advanced Secure Boot Keys Management    ${sb_menu}
+    Erase All Secure Boot Keys
+    Save Changes And Reset    3
+
+    Enter Secure Boot Menu
+    ${out}=    Read From Terminal Until    Esc=Exit
+    Should Contain    ${out}    To enable Secure Boot, set Secure Boot Mode to
+    Should Contain    ${out}    Custom and enroll the keys/PK first.
+
+Secure Boot Menu Parsing With Default Keys
+    Power On
+    ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+    Enter Advanced Secure Boot Keys Management    ${sb_menu}
+    Reset To Default Secure Boot Keys
+    Save Changes And Reset    3
+
+    ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+    Should Not Contain    ${sb_menu}    Secure Boot Configuration
+    Should Match Regexp    ${sb_menu}[0]    ^Current Secure Boot State.*$
+    Should Match Regexp    ${sb_menu}[1]    ^Enable Secure Boot \\[.\\].*$
+    Should Match Regexp    ${sb_menu}[2]    ^Secure Boot Mode \\<.*\\>.*$
+    Should Not Contain    ${sb_menu}    To enable Secure Boot, set Secure Boot Mode to
+    Should Not Contain    ${sb_menu}    Custom and enroll the keys/PK first.
+
+Secure Boot Menu Parsing With Erased Keys
+    [Documentation]    Test Enter Secure Boot Menu And Return Construction kwd
+    Power On
+    ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+    Enter Advanced Secure Boot Keys Management    ${sb_menu}
+    Erase All Secure Boot Keys
+    Reset To Default Secure Boot Keys
+    Save Changes And Reset    3
+
+    ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+    Should Not Contain    ${sb_menu}    Secure Boot Configuration
+    Should Match Regexp    ${sb_menu}[0]    ^Current Secure Boot State.*$
+    Should Match Regexp    ${sb_menu}[1]    ^Secure Boot Mode \\<.*\\>.*$
+    Should Not Contain    ${sb_menu}    To enable Secure Boot, set Secure Boot Mode to
+    Should Not Contain    ${sb_menu}    Custom and enroll the keys/PK first.
+
 Return Secure Boot State
     [Documentation]    Test Return Secure Boot State kwd
     Power On
     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
     ${sb_state}=    Return Secure Boot State    ${sb_menu}
     Should Contain Any    ${sb_state}    Enabled    Disabled
+
+# TODO: This fails with: Option Enable Secure Boot not found in the list
+# if the keys were not provisioned first. The question is, should we "hide"
+# restoring keys to default in the keywords like enable/disable SB, or the
+# test scenarios should rather take care of this?
 
 Enable Secure Boot
     [Documentation]    Test Enable Secure Boot kwd

--- a/self-tests/secure-boot.robot
+++ b/self-tests/secure-boot.robot
@@ -1,0 +1,107 @@
+*** Settings ***
+Documentation       This suite verifies the correct operation of keywords parsing Secure Boot menus from the lib/secure-boot-lib.robot.
+
+Library             Collections
+Library             OperatingSystem
+Library             Process
+Library             String
+Library             Telnet    timeout=30 seconds    connection_timeout=120 seconds
+Library             SSHLibrary    timeout=90 seconds
+Library             RequestsLibrary
+# TODO: maybe have a single file to include if we need to include the same
+# stuff in all test cases
+Resource            ../sonoff-rest-api/sonoff-api.robot
+Resource            ../rtectrl-rest-api/rtectrl.robot
+Resource            ../variables.robot
+Resource            ../keywords.robot
+Resource            ../keys.robot
+Resource            ../pikvm-rest-api/pikvm_comm.robot
+
+# TODO:
+# - document which setup/teardown keywords to use and what are they doing
+# - go threough them and make sure they are doing what the name suggest (not
+# exactly the case right now)
+Suite Setup         Run Keyword
+...                     Prepare Test Suite
+Suite Teardown      Run Keyword
+...                     Log Out And Close Connection
+
+
+*** Test Cases ***
+Enter Secure Boot Menu
+    [Documentation]    Test Enter Secure Boot Menu kwd
+    Power On
+    Enter Secure Boot Menu
+    ${out}=    Read From Terminal Until    Esc=Exit
+    Should Contain    ${out}    Secure Boot Configuration
+    Should Contain    ${out}    Current Secure Boot State
+
+Enter Secure Boot Menu And Return Construction
+    [Documentation]    Test Enter Secure Boot Menu And Return Construction kwd
+    Power On
+    ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+    Should Not Contain    ${sb_menu}    Secure Boot Configuration
+    Should Match Regexp    ${sb_menu}[0]    ^Current Secure Boot State.*$
+    Should Match Regexp    ${sb_menu}[1]    ^Enable Secure Boot \\[.\\].*$
+    Should Match Regexp    ${sb_menu}[2]    ^Secure Boot Mode \\<.*\\>.*$
+    Should Not Contain    ${sb_menu}    To enable Secure Boot, set Secure Boot Mode to
+    Should Not Contain    ${sb_menu}    Custom and enroll the keys/PK first.
+
+Enter Advanced Secure Boot Keys Management
+    [Documentation]    Test Enter Advanced Secure Boot Keys Management kwd
+    Power On
+    ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+    Enter Advanced Secure Boot Keys Management    ${sb_menu}
+    ${out}=    Read From Terminal Until    Esc=Exit
+    Should Contain    ${out}    Advanced Secure Boot Keys Management
+    Should Contain    ${out}    Reset to default Secure Boot Keys
+    Should Contain    ${out}    Erase all Secure Boot Keys
+
+Return Secure Boot State
+    [Documentation]    Test Return Secure Boot State kwd
+    Power On
+    ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+    ${sb_state}=    Return Secure Boot State    ${sb_menu}
+    Should Contain Any    ${sb_state}    Enabled    Disabled
+
+Enable Secure Boot
+    [Documentation]    Test Enable Secure Boot kwd
+    Power On
+    ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+    Set Option State    ${sb_menu}    Enable Secure Boot    ${TRUE}
+    Save Changes And Reset    2
+
+    ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+    ${sb_state}=    Return Secure Boot State    ${sb_menu}
+    Should Contain    ${sb_state}    Enabled
+
+Disable Secure Boot
+    [Documentation]    Test Disable Secure Boot kwd
+    Power On
+    ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+    Set Option State    ${sb_menu}    Enable Secure Boot    ${FALSE}
+    Save Changes And Reset    2
+
+    ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+    ${sb_state}=    Return Secure Boot State    ${sb_menu}
+    Should Contain    ${sb_state}    Disabled
+
+Enable and Disable Secure Boot Multiple Times
+    [Documentation]    Test Enabling and Disabling Secure Boot 5 times
+    Power On
+    ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+    FOR    ${index}    IN RANGE    5
+        Set Option State    ${sb_menu}    Enable Secure Boot    ${TRUE}
+        Save Changes And Reset    2
+
+        ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+        ${sb_state}=    Return Secure Boot State    ${sb_menu}
+        Should Contain    ${sb_state}    Enabled
+
+        Set Option State    ${sb_menu}    Enable Secure Boot    ${FALSE}
+        Save Changes And Reset    2
+
+        ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+        ${sb_state}=    Return Secure Boot State    ${sb_menu}
+        Should Contain    ${sb_state}    Disabled
+    END

--- a/self-tests/secure-boot.robot
+++ b/self-tests/secure-boot.robot
@@ -120,16 +120,37 @@ Return Secure Boot State
     ${sb_state}=    Return Secure Boot State    ${sb_menu}
     Should Contain Any    ${sb_state}    Enabled    Disabled
 
-# TODO: This fails with: Option Enable Secure Boot not found in the list
-# if the keys were not provisioned first. The question is, should we "hide"
-# restoring keys to default in the keywords like enable/disable SB, or the
-# test scenarios should rather take care of this?
+Make Sure That Keys Are Provisioned
+    [Documentation]    Test Make Sure That Keys Are Provisioned kwd
+    # 1. Erase All SB keys
+    Power On
+    ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+    Enter Advanced Secure Boot Keys Management    ${sb_menu}
+    Erase All Secure Boot Keys
+    Exit From Current Menu
+    ${sb_menu}=    Get Secure Boot Menu Construction
+    Should Not Contain Any    ${sb_menu}    Enable Secure Boot [ ]    Enable Secure Boot [X]
+
+    # 2. Call tke kwd and make sure that the keys are provisioned
+    ${sb_menu}=    Make Sure That Keys Are Provisioned    ${sb_menu}
+    Should Contain Any    ${sb_menu}    Enable Secure Boot [ ]    Enable Secure Boot [X]
+
+    # 3. Restore default SB keys
+    Enter Advanced Secure Boot Keys Management    ${sb_menu}
+    Reset To Default Secure Boot Keys
+    Exit From Current Menu
+    ${sb_menu}=    Get Secure Boot Menu Construction
+    Should Contain Any    ${sb_menu}    Enable Secure Boot [ ]    Enable Secure Boot [X]
+
+    # 4. Call tke kwd and make sure that the keys are still provisioned
+    ${sb_menu}=    Make Sure That Keys Are Provisioned    ${sb_menu}
+    Should Contain Any    ${sb_menu}    Enable Secure Boot [ ]    Enable Secure Boot [X]
 
 Enable Secure Boot
     [Documentation]    Test Enable Secure Boot kwd
     Power On
     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
-    Set Option State    ${sb_menu}    Enable Secure Boot    ${TRUE}
+    Enable Secure Boot    ${sb_menu}
     Save Changes And Reset    2
 
     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
@@ -140,7 +161,7 @@ Disable Secure Boot
     [Documentation]    Test Disable Secure Boot kwd
     Power On
     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
-    Set Option State    ${sb_menu}    Enable Secure Boot    ${FALSE}
+    Disable Secure Boot    ${sb_menu}
     Save Changes And Reset    2
 
     ${sb_menu}=    Enter Secure Boot Menu And Return Construction

--- a/self-tests/setup-and-boot-menus.robot
+++ b/self-tests/setup-and-boot-menus.robot
@@ -43,6 +43,7 @@ Enter Boot Menu Tianocore And Return Construction
     ${menu}=    Enter Boot Menu Tianocore And Return Construction
     List Should Not Contain Value    ${menu}    Please select boot device:
     List Should Contain Value    ${menu}    Setup
+    Menu Construction Should Not Contain Control Text    ${menu}
 
 Enter Setup Menu Tianocore
     [Documentation]    Test Enter Setup Menu Tianocore kwd
@@ -66,6 +67,7 @@ Enter Setup Menu Tianocore And Return Construction
     List Should Contain Value    ${setup_menu}    > Dasharo System Features
     List Should Contain Value    ${setup_menu}    > One Time Boot
     List Should Contain Value    ${setup_menu}    > Boot Maintenance Manager
+    Menu Construction Should Not Contain Control Text    ${setup_menu}
 
 Enter User Password Management Menu
     [Documentation]    Test entering into User Password Management menu
@@ -86,6 +88,7 @@ Parse User Password Management Menu
     Should Be Equal As Strings    ${password_menu}[1]    Change Admin Password
     ${password_menu_entries}=    Get Length    ${password_menu}
     Should Be Equal As Integers    ${password_menu_entries}    2
+    Menu Construction Should Not Contain Control Text    ${password_menu}
 
 Enter Device Manager Menu
     [Documentation]    Test entering into User Password Management menu
@@ -107,6 +110,34 @@ Parse Device Manager Menu
     ...    Device Manager
     Should Not Contain    ${device_menu}[0]    Devices List
     List Should Contain Value    ${device_menu}    > Driver Health Manager
+    List Should Contain Value    ${device_menu}    Press ESC to exit.
+    Menu Construction Should Not Contain Control Text    ${device_menu}
+
+Enter Secure Boot Menu
+    [Documentation]    Test entering into User Password Management menu
+    Power On
+    ${setup_menu}=    Enter Setup Menu Tianocore And Return Construction
+    ${device_menu}=    Enter Submenu From Snapshot And Return Construction
+    ...    ${setup_menu}
+    ...    Device Manager
+    Enter Submenu From Snapshot    ${device_menu}    Secure Boot Configuration
+    ${out}=    Read From Terminal Until    Esc=Exit
+    Should Contain    ${out}    Secure Boot Configuration
+    Should Contain    ${out}    Current Secure Boot State
+
+Parse Secure Boot Menu
+    [Documentation]    Test entering into User Password Management menu
+    Power On
+    ${setup_menu}=    Enter Setup Menu Tianocore And Return Construction
+    ${device_menu}=    Enter Submenu From Snapshot And Return Construction
+    ...    ${setup_menu}
+    ...    Device Manager
+    ${sb_menu}=    Enter Submenu From Snapshot And Return Construction    ${device_menu}    Secure Boot Configuration
+    Should Match Regexp    ${sb_menu}[0]    ^Current Secure Boot State.*$
+    Should Match Regexp    ${sb_menu}[1]    ^Attempt Secure Boot \\[.\\].*$
+    Should Match Regexp    ${sb_menu}[2]    ^Secure Boot Mode \\<.*\\>.*$
+    Should Match Regexp    ${sb_menu}[3]    ^Reset Secure Boot Keys$
+    Menu Construction Should Not Contain Control Text    ${sb_menu}
 
 Enter One Time Boot Menu
     [Documentation]    Test entering into User Password Management menu
@@ -124,6 +155,7 @@ Parse One Time Boot Menu
     ...    ${setup_menu}
     ...    One Time Boot
     List Should Contain Value    ${otb_menu}    UEFI Shell
+    Menu Construction Should Not Contain Control Text    ${otb_menu}
 
 Enter Boot Maintenance Manager Menu
     [Documentation]    Test entering into User Password Management menu
@@ -146,6 +178,7 @@ Parse Boot Maintenance Manager Menu
     Should Be Equal As Strings    ${boot_mgr_menu}[3]    > Boot From File
     Should Match Regexp    ${boot_mgr_menu}[4]    ^Boot Next Value <.*>$
     Should Match Regexp    ${boot_mgr_menu}[5]    ^Auto Boot Time-out \\[\\d+\\]$
+    Menu Construction Should Not Contain Control Text    ${boot_mgr_menu}
 
 Enter Invalid Option in Setup Menu
     [Documentation]    Test if keyword fails (rather than silently continuing) when


### PR DESCRIPTION
SBO002.001 can succeed:

```
robot  -t "SBO002.001*" -L TRACE -v config:qemu -v rte_ip:127.0.0.1 -v snipeit:no dasharo-security/secure-boot.robot        
==============================================================================
Secure-Boot                                                                   
==============================================================================
SBO002.001 UEFI Secure Boot (Ubuntu 22.04) :: This test verifies t... | PASS |
------------------------------------------------------------------------------
Secure-Boot                                                           | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Output:  /home/macpijan/projects/github/dasharo/open-source-firmware-validation/output.xml
Log:     /home/macpijan/projects/github/dasharo/open-source-firmware-validation/log.html
Report:  /home/macpijan/projects/github/dasharo/open-source-firmware-validation/report.html
```

Together with:
- https://github.com/Dasharo/open-source-firmware-validation/pull/116
- https://github.com/Dasharo/edk2/pull/111

Requires OS installed first with serial enabled. Involves manual installation right now.