### PR TITLE
Ncm mkc fixes

### DIFF
--- a/dasharo-compatibility/display-ports-and-lcd-support.robot
+++ b/dasharo-compatibility/display-ports-and-lcd-support.robot
@@ -24,6 +24,18 @@ Suite Teardown      Log Out And Close Connection
 
 
 *** Test Cases ***
+DSP001.002 - Internal display in OS (Ubuntu 22.04)
+    [Documentation]    Check whether an internal display is visible in
+    ...    Ubuntu.
+    Skip If    not ${INTERNAL_LCD_DISPLAY_SUPPORT}    DSP001.002 not supported
+    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    DSP001.002 not supported
+    Power On
+    Boot System Or From Connected Disk    ubuntu
+    Login To Linux
+    Switch To Root User
+    Check Internal LCD Linux
+    Exit From Root User
+
 DSP001.003 - Internal display in OS (Windows 11)
     [Documentation]    Check whether an internal display is visible in
     ...    Windows OS.

--- a/keywords.robot
+++ b/keywords.robot
@@ -927,6 +927,7 @@ Check DP Windows
 
 Check Internal LCD Linux
     [Documentation]    Check if internal LCD is recognized by Linux OS.
+    # Assumption: Intel iGPU
     ${out}=    Execute Linux Command    cat /sys/devices/pci0000:00/0000:00:02.0/drm/card*/*eDP-1/status
     Should Contain    ${out}    connected
 

--- a/keywords.robot
+++ b/keywords.robot
@@ -925,6 +925,11 @@ Check DP Windows
         Should Contain Any    ${out}    VideoOutputTechnology : 10    VideoOutputTechnology : 11
     END
 
+Check Internal LCD Linux
+    [Documentation]    Check if internal LCD is recognized by Linux OS.
+    ${out}=    Execute Linux Command    cat /sys/devices/pci0000:00/0000:00:02.0/drm/card*/*eDP-1/status
+    Should Contain    ${out}    connected
+
 Check Internal LCD Windows
     [Documentation]    Check if internal LCD is recognized by Windows OS.
     ${out}=    Check Displays Windows
@@ -933,7 +938,8 @@ Check Internal LCD Windows
 Check External HDMI In Linux
     [Documentation]    Keyword checks if an external HDMI device is visible
     ...    in Linux OS.
-    ${out}=    Execute Linux Command    cat /sys/class/drm/card0/*HDMI*/status
+    ${out}=    Execute Linux Command    cat /sys/devices/pci0000:00/0000:00:02.0/drm/card*/*HDMI*/status
+
     Should Contain    ${out}    connected
 
 Check External DP In Linux


### PR DESCRIPTION
right now all tests are assuming displays are connected to gpu `card0`, this is wrong on several levels:
- newer kernels start numbering at `card1`
- on multi-gpu systems this changes depending on driver load order

so find the right node by PCI device path. 00:02.0 is iGPU on Intel, probably won't work on AMD.

also, the dock tests try to find a specific DP output number, this is incorrect, as new connectors are created when a MST hub is connected and this will change pretty randomly. The hub may also work in SST mode and you'll need to check the toplevel port instead... it's complex. we should get the output list from the MST topology: `/sys/kernel/debug/dri/0/i915_dp_mst_info`

for example - 2 monitors connected via two MST hubs in series:
```
MST Source Port [ENCODER:253:DDI TC1/PHY TC1]
	mstb - [000000006e513ba4]: num_ports: 4
	port 3 - [00000000cef6a8a6] (output - NONE): ddps: 0, ldps: 0, sdp: 0/0, fec: false, conn: 000000004138eea3
	port 2 - [0000000010923a78] (output - MST BRANCHING): ddps: 1, ldps: 0, sdp: 0/0, fec: false, conn: 000000008de74612
		mstb - [000000007ea15161]: num_ports: 3
		port 1 - [000000005d61556d] (output - SST SINK): ddps: 1, ldps: 0, sdp: 0/0, fec: false, conn: 000000006ab82c2a
		port 8 - [0000000055cf02fa] (output - SST SINK): ddps: 1, ldps: 0, sdp: 1/2, fec: false, conn: 0000000032abdd15
		port 0 - [0000000044a8328c] (input - NONE): ddps: 1, ldps: 0, sdp: 0/0, fec: false, conn: 0000000000000000
	port 1 - [00000000465a26c2] (output - NONE): ddps: 0, ldps: 0, sdp: 0/0, fec: false, conn: 00000000d61c1018
	port 0 - [00000000260f7223] (input - NONE): ddps: 1, ldps: 0, sdp: 0/0, fec: false, conn: 0000000000000000

*** Atomic state info ***
payload_mask: 3, max_payloads: 3, start_slot: 1, pbn_div: 30

| idx | port | vcpi | slots | pbn | dsc |     sink name     |
     1      1      1 01 - 18   532     N         DELL P2414H
     2      8      2 19 - 37   551     N          DELL U2413
```