### PR TITLE
dasharo-security/secure-boot.robot: SBO009 added

### DIFF
--- a/dasharo-security/secure-boot.robot
+++ b/dasharo-security/secure-boot.robot
@@ -437,7 +437,7 @@ SBO012.001 Boot OS Signed And Enrolled From Inside System (Ubuntu 22.04)
     Remove Old Secure Boot Keys In OS
     ${sb_status}=    Generate Secure Boot Keys In OS
     Should Be True    ${sb_status}
-    ${sb_status}=    Enroll Secure Boot Keys In OS
+    ${sb_status}=    Enroll Secure Boot Keys In OS    True
     Should Be True    ${sb_status}
 
     # 3. Sign all components
@@ -529,7 +529,7 @@ SBO014.001 Enroll certificates using sbctl
     # 3. Create and enroll keys
     ${out}=    Generate Secure Boot Keys In Os
     Should Be True    ${out}
-    ${out}=    Enroll Secure Boot Keys In Os
+    ${out}=    Enroll Secure Boot Keys In Os    True
     Should Be True    ${out}
 
     # 4. Verify that it is impossible to boot Ubuntu with the keys
@@ -551,6 +551,31 @@ SBO014.001 Enroll certificates using sbctl
     Switch To Root User
     ${out}=    Execute Command In Terminal    rm -rf /usr/share/secureboot
     Log To Console    ${out}\n
+
+SBO015.001 Attempt to enroll the key in the incorrect format (OS)
+    [Documentation]    This test verifies that it is impossible to load
+    ...    a certificate in the wrong file format from the operating system
+    ...    while using sbctl.
+    Skip If    not ${SECURE_BOOT_SUPPORT}    SBO015.001 not supported
+    Skip If    not ${TESTS_IN_FIRMWARE_SUPPORT}    SBO015.001 not supported
+    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    SBO015.001 not supported
+    Power On
+    ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+    ${advanced_menu}=    Enter Advanced Secure Boot Keys Management And Return Construction    ${sb_menu}
+    Erase All Secure Boot Keys    ${advanced_menu}
+    Save Changes And Reset    3    5
+    Boot System Or From Connected Disk    ubuntu
+    Login To Linux
+    Switch To Root User
+    # recreate sbctl keys directory structure
+    Execute Linux Command    rm -rf /usr/share/secureboot
+    ${out}=    Generate Secure Boot Keys In Os
+    Should Be True    ${out}
+    Generate Wrong Format Keys And Move Them    db    /usr/share/secureboot/keys/db/
+    Generate Wrong Format Keys And Move Them    PK    /usr/share/secureboot/keys/PK/
+    Generate Wrong Format Keys And Move Them    KEK    /usr/share/secureboot/keys/KEK/
+    Enroll Secure Boot Keys In OS    False
+    Should Be True    ${out}
 
 
 *** Keywords ***

--- a/lib/secure-boot-lib.robot
+++ b/lib/secure-boot-lib.robot
@@ -312,3 +312,12 @@ Compare KEK Certificate Using Mokutil In DTS
 
     # 3. Compare the certificates
     Should Be Equal    ${first_certificate_string}    ${second_certificate_string}
+
+Generate Wrong Format Keys And Move Them
+    [Documentation]    Generates elliptic curve keys and moves them to the
+    ...    desired location.
+    [Arguments]    ${name}    ${location}
+    Execute Linux Command
+    ...    openssl ecparam -genkey -name secp384r1 -out ${name}.key && openssl req -new -x509 -key ${name}.key -out ${name}.pem -days 365 -subj "/CN=3mdeb_test"
+    Execute Linux Command    mv ${name}.key ${location}
+    Execute Linux Command    mv ${name}.pem ${location}

--- a/lib/secure-boot-lib.robot
+++ b/lib/secure-boot-lib.robot
@@ -260,10 +260,17 @@ Generate Secure Boot Keys In OS
 Enroll Secure Boot Keys In OS
     [Documentation]    Enrolls current keys to EFI using sbctl.
     ...    Returns true if succeeded.
+    [Arguments]    ${result}
     ${out}=    Execute Linux Command    sbctl enroll-keys --yes-this-might-brick-my-machine
-    ${sb_status}=    Run Keyword And Return Status
-    ...    Should Contain    ${out}    Enrolled keys to the EFI variables!
-    RETURN    ${sb_status}
+    IF    ${result} == True
+        ${sb_status}=    Run Keyword And Return Status
+        ...    Should Contain    ${out}    Enrolled keys to the EFI variables!
+        RETURN    ${sb_status}
+    ELSE
+        ${sb_status}=    Run Keyword And Return Status
+        ...    Should Contain    ${out}    failed to parse key
+        RETURN    ${sb_status}
+    END
 
 Sign All Boot Components In OS
     [Documentation]    Signs boot components with current keys using sbctl


### PR DESCRIPTION
This test first generates keys in incorrect formats, then attemps to enroll them with sbctl tool, which should be impossible.