### PR TITLE
Tpm support

### DIFF
--- a/.github/workflows/qemu-self-test.yml
+++ b/.github/workflows/qemu-self-test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up QEMU
       run: |
          sudo apt-get update
-         sudo apt-get install qemu-system-x86-64
+         sudo apt-get install qemu-system-x86-64 swtpm
 
     - name: Start QEMU in background
       run: |


### PR DESCRIPTION
Result with:

```
./scripts/ci/qemu-run.sh graphic os        

robot -L TRACE -v config:qemu -v rte_ip:127.0.0.1 -v snipeit:no dasharo-security/tpm2-commands.robot
==============================================================================
Tpm2-Commands                                                                 
==============================================================================

Checking if tpm2-tools is installed...

Package tpm2-tools is installed
TPMCMD001.001 Check if both SHA1 and SHA256 PCRs are enabled (Ubun... | PASS |
------------------------------------------------------------------------------
TPMCMD002.001 PCRREAD Function Verification (Ubuntu 22.04) :: This... | PASS |
------------------------------------------------------------------------------
TPMCMD003.001 PCREXTEND And PCRRESET Functions (Ubuntu 22.04) :: T... | PASS |
------------------------------------------------------------------------------
TPMCMD003.002 PCREXTEND And PCRRESET Functions - locality protecti... | PASS |
------------------------------------------------------------------------------
TPMCMD004.001 PCREVENT Function (Ubuntu 22.04) :: This test aims t... | PASS |
------------------------------------------------------------------------------
TPMCMD005.001 CREATEPRIMARY Function Verification (Ubuntu 22.04) :... | PASS |
------------------------------------------------------------------------------
TPMCMD006.001 NVDEFINE and NVUNDEFINE Functions Verification (Ubun... | PASS |
------------------------------------------------------------------------------
TPMCMD007.001 CREATE Function (Ubuntu 22.04) :: This test aims to ... | PASS |
------------------------------------------------------------------------------
TPMCMD007.002 CREATELOADED Function (Ubuntu 22.04) :: This test ai... | PASS |
------------------------------------------------------------------------------
TPMCMD008.001 Signing the file (Ubuntu 22.04) :: Check whether the... | PASS |
------------------------------------------------------------------------------
TPMCMD009.001 Encryption and Decryption of the file (Ubuntu 22.04)... | SKIP |
TPM doesn't supports TPM2_EncryptDecrypt nor TPM2_EncryptDecrypt2
------------------------------------------------------------------------------
TPMCMD010.001 Hashing the file (Ubuntu 22.04) :: Check whether the... | PASS |
------------------------------------------------------------------------------
TPMCMD011.001 Performing HMAC operation on the file (Ubuntu 22.04)... | PASS |
------------------------------------------------------------------------------
Tpm2-Commands                                                         | PASS |
13 tests, 12 passed, 0 failed, 1 skipped
==============================================================================
Output:  /home/macpijan/projects/github/dasharo/open-source-firmware-validation/output.xml
Log:     /home/macpijan/projects/github/dasharo/open-source-firmware-validation/log.html
Report:  /home/macpijan/projects/github/dasharo/open-source-firmware-validation/report.html
```

The swtpm pacakge is also available in ubuntu, so it is the easiest one to go for in the CI as well.

The CI with QEMU still starts: https://github.com/Dasharo/open-source-firmware-validation/actions/runs/7221463998/job/19676481422 but we have no firmware-level TPM tests as of now AFAIK, so we do not really check the TPM feature in CI as of know.

The TPM details are visible in setup menu under `Device Manager -> TCG2 Configuration`, so we could design some tests around that I suppose @TomaszAIR .

![image](https://github.com/Dasharo/open-source-firmware-validation/assets/19353650/28ba48a3-317d-4c84-a728-83a515ca0a97)
