### PR TITLE
dasharo-security/tpm2-commands.robot: add tests for file sealing with policies

### DIFF
--- a/dasharo-security/tpm2-commands.robot
+++ b/dasharo-security/tpm2-commands.robot
@@ -257,11 +257,11 @@ TPMCMD013.002 Sealing and Unsealing with Policy - PCR Only (Ubuntu 22.04)
     Execute Linux Command    echo "PCR policy sealed data" > seal.dat
     ${out1}=    Execute Linux Command    cat seal.dat
     Execute Linux Tpm2 Tools Command    tpm2_startauthsession -S session.dat
-    Execute Linux Tpm2 Tools Command    tpm2_policypcr -S session.dat -l "sha1:0,1,2,3" -L policy.dat
+    Execute Linux Tpm2 Tools Command    tpm2_policypcr -S session.dat -l "sha1:0,1,2,3,7" -L policy.dat
     Execute Linux Tpm2 Tools Command    tpm2_create -Q -u key.pub -r key.priv -C primary.ctx -L policy.dat -i seal.dat
     Execute Linux Tpm2 Tools Command    tpm2_load -C primary.ctx -u key.pub -r key.priv -n seal.name -c seal.ctx
     Execute Linux Tpm2 Tools Command    tpm2_startauthsession --policy-session -S session.dat
-    Execute Linux Tpm2 Tools Command    tpm2_policypcr -S session.dat -l "sha1:0,1,2,3" -L policy.dat
+    Execute Linux Tpm2 Tools Command    tpm2_policypcr -S session.dat -l "sha1:0,1,2,3,7" -L policy.dat
     ${out2}=    Execute Linux Tpm2 Tools Command    tpm2_unseal -p session:session.dat -c seal.ctx
     Should Be Equal As Strings    ${out1}    ${out2}
 
@@ -272,13 +272,13 @@ TPMCMD013.003 Sealing and unsealing with Policy - Password and PCR (Ubuntu 22.04
     ${out1}=    Execute Linux Command    cat seal.dat
     Execute Linux Tpm2 Tools Command    tpm2_startauthsession -S session.dat
     Execute Linux Tpm2 Tools Command    tpm2_policypassword -S session.dat -L policy.dat
-    Execute Linux Tpm2 Tools Command    tpm2_policypcr -S session.dat -l "sha1:0,1,2,3" -L policy.dat
+    Execute Linux Tpm2 Tools Command    tpm2_policypcr -S session.dat -l "sha1:0,1,2,3,7" -L policy.dat
     Execute Linux Tpm2 Tools Command
     ...    tpm2_create -Q -u key.pub -r key.priv -C primary.ctx -L policy.dat -i seal.dat -p policypswd
     Execute Linux Tpm2 Tools Command    tpm2_load -C primary.ctx -u key.pub -r key.priv -n seal.name -c seal.ctx
     Execute Linux Tpm2 Tools Command    tpm2_startauthsession --policy-session -S session.dat
     Execute Linux Tpm2 Tools Command    tpm2_policypassword -S session.dat -L policy.dat
-    Execute Linux Tpm2 Tools Command    tpm2_policypcr -S session.dat -l "sha1:0,1,2,3" -L policy.dat
+    Execute Linux Tpm2 Tools Command    tpm2_policypcr -S session.dat -l "sha1:0,1,2,3,7" -L policy.dat
     ${out2}=    Execute Linux Tpm2 Tools Command    tpm2_unseal -p session:session.dat+policypswd -c seal.ctx
     Should Be Equal As Strings    ${out1}    ${out2}
 

--- a/dasharo-security/tpm2-commands.robot
+++ b/dasharo-security/tpm2-commands.robot
@@ -237,7 +237,8 @@ TPMCMD012.001 Sealing and Unsealing the file without Policy (Ubuntu 22.04)
     ${out2}=    Execute Linux Command    cat unsealed.dat
 
 TPMCMD013.001 Sealing and Unsealing with Policy - Password Only (Ubuntu 22.04)
-    [Documentation]    Check whether the TPM supports sealing and unsealing using password policy.
+    [Documentation]    Check whether the TPM supports sealing and unsealing
+    ...    using password policy.
     Execute Linux Tpm2 Tools Command    tpm2_createprimary -C e -g sha256 -G ecc -c primary.ctx
     Execute Linux Command    echo "password policy sealed data" > seal.dat
     ${out1}=    Execute Linux Command    cat seal.dat
@@ -252,7 +253,8 @@ TPMCMD013.001 Sealing and Unsealing with Policy - Password Only (Ubuntu 22.04)
     Should Be Equal As Strings    ${out1}    ${out2}
 
 TPMCMD013.002 Sealing and Unsealing with Policy - PCR Only (Ubuntu 22.04)
-    [Documentation]    Check whether the TPM supports sealing and unsealing using PCR policy.
+    [Documentation]    Check whether the TPM supports sealing and unsealing
+    ...    using PCR policy.
     Execute Linux Tpm2 Tools Command    tpm2_createprimary -C e -g sha256 -G ecc -c primary.ctx
     Execute Linux Command    echo "PCR policy sealed data" > seal.dat
     ${out1}=    Execute Linux Command    cat seal.dat
@@ -266,7 +268,8 @@ TPMCMD013.002 Sealing and Unsealing with Policy - PCR Only (Ubuntu 22.04)
     Should Be Equal As Strings    ${out1}    ${out2}
 
 TPMCMD013.003 Sealing and unsealing with Policy - Password and PCR (Ubuntu 22.04)
-    [Documentation]    Check whether the TPM supports sealing and unsealing using PCR and password policy at the same time.
+    [Documentation]    Check whether the TPM supports sealing and unsealing
+    ...    using PCR and password policy at the same time.
     Execute Linux Tpm2 Tools Command    tpm2_createprimary -C e -g sha256 -G ecc -c primary.ctx
     Execute Linux Command    echo "policy sealed data" > seal.dat
     ${out1}=    Execute Linux Command    cat seal.dat

--- a/dasharo-security/tpm2-commands.robot
+++ b/dasharo-security/tpm2-commands.robot
@@ -235,6 +235,51 @@ TPMCMD012.001 Sealing and Unsealing the file without Policy (Ubuntu 22.04)
     Execute Linux Tpm2 Tools Command    tpm2_evictcontrol --hierarchy owner --object-context seal.ctx -o seal.handle
     Execute Linux Tpm2 Tools Command    tpm2_unseal -c seal.handle > unsealed.dat
     ${out2}=    Execute Linux Command    cat unsealed.dat
+
+TPMCMD013.001 Sealing and Unsealing with Policy - Password Only (Ubuntu 22.04)
+    [Documentation]    Check whether the TPM supports sealing and unsealing using password policy.
+    Execute Linux Tpm2 Tools Command    tpm2_createprimary -C e -g sha256 -G ecc -c primary.ctx
+    Execute Linux Command    echo "password policy sealed data" > seal.dat
+    ${out1}=    Execute Linux Command    cat seal.dat
+    Execute Linux Tpm2 Tools Command    tpm2_startauthsession -S session.dat
+    Execute Linux Tpm2 Tools Command    tpm2_policypassword -S session.dat -L policy.dat
+    Execute Linux Tpm2 Tools Command
+    ...    tpm2_create -Q -u key.pub -r key.priv -C primary.ctx -L policy.dat -i seal.dat -p policypswd
+    Execute Linux Tpm2 Tools Command    tpm2_load -C primary.ctx -u key.pub -r key.priv -n seal.name -c seal.ctx
+    Execute Linux Tpm2 Tools Command    tpm2_startauthsession --policy-session -S session.dat
+    Execute Linux Tpm2 Tools Command    tpm2_policypassword -S session.dat -L policy.dat
+    ${out2}=    Execute Linux Tpm2 Tools Command    tpm2_unseal -p session:session.dat+policypswd -c seal.ctx
+    Should Be Equal As Strings    ${out1}    ${out2}
+
+TPMCMD013.002 Sealing and Unsealing with Policy - PCR Only (Ubuntu 22.04)
+    [Documentation]    Check whether the TPM supports sealing and unsealing using PCR policy.
+    Execute Linux Tpm2 Tools Command    tpm2_createprimary -C e -g sha256 -G ecc -c primary.ctx
+    Execute Linux Command    echo "PCR policy sealed data" > seal.dat
+    ${out1}=    Execute Linux Command    cat seal.dat
+    Execute Linux Tpm2 Tools Command    tpm2_startauthsession -S session.dat
+    Execute Linux Tpm2 Tools Command    tpm2_policypcr -S session.dat -l "sha1:0,1,2,3" -L policy.dat
+    Execute Linux Tpm2 Tools Command    tpm2_create -Q -u key.pub -r key.priv -C primary.ctx -L policy.dat -i seal.dat
+    Execute Linux Tpm2 Tools Command    tpm2_load -C primary.ctx -u key.pub -r key.priv -n seal.name -c seal.ctx
+    Execute Linux Tpm2 Tools Command    tpm2_startauthsession --policy-session -S session.dat
+    Execute Linux Tpm2 Tools Command    tpm2_policypcr -S session.dat -l "sha1:0,1,2,3" -L policy.dat
+    ${out2}=    Execute Linux Tpm2 Tools Command    tpm2_unseal -p session:session.dat -c seal.ctx
+    Should Be Equal As Strings    ${out1}    ${out2}
+
+TPMCMD013.003 Sealing and unsealing with Policy - Password and PCR (Ubuntu 22.04)
+    [Documentation]    Check whether the TPM supports sealing and unsealing using PCR and password policy at the same time.
+    Execute Linux Tpm2 Tools Command    tpm2_createprimary -C e -g sha256 -G ecc -c primary.ctx
+    Execute Linux Command    echo "policy sealed data" > seal.dat
+    ${out1}=    Execute Linux Command    cat seal.dat
+    Execute Linux Tpm2 Tools Command    tpm2_startauthsession -S session.dat
+    Execute Linux Tpm2 Tools Command    tpm2_policypassword -S session.dat -L policy.dat
+    Execute Linux Tpm2 Tools Command    tpm2_policypcr -S session.dat -l "sha1:0,1,2,3" -L policy.dat
+    Execute Linux Tpm2 Tools Command
+    ...    tpm2_create -Q -u key.pub -r key.priv -C primary.ctx -L policy.dat -i seal.dat -p policypswd
+    Execute Linux Tpm2 Tools Command    tpm2_load -C primary.ctx -u key.pub -r key.priv -n seal.name -c seal.ctx
+    Execute Linux Tpm2 Tools Command    tpm2_startauthsession --policy-session -S session.dat
+    Execute Linux Tpm2 Tools Command    tpm2_policypassword -S session.dat -L policy.dat
+    Execute Linux Tpm2 Tools Command    tpm2_policypcr -S session.dat -l "sha1:0,1,2,3" -L policy.dat
+    ${out2}=    Execute Linux Tpm2 Tools Command    tpm2_unseal -p session:session.dat+policypswd -c seal.ctx
     Should Be Equal As Strings    ${out1}    ${out2}
 
 


### PR DESCRIPTION
Checks support of TPM for Sealing/Unsealing with additional policies (password, PCR and both at the same time)