### PR TITLE
Cpu freq fixes

### DIFF
--- a/dasharo-performance/cpu-frequency.robot
+++ b/dasharo-performance/cpu-frequency.robot
@@ -345,9 +345,9 @@ CPU Runs On Expected Frequency (Ubuntu 22.04)
         @{frequencies}=    Get CPU Frequencies In Ubuntu
         FOR    ${frequency}    IN    @{frequencies}
             Run Keyword And Continue On Failure
-            ...    Should Be True    ${freq_max} > ${frequency}
+            ...    Should Be True    ${freq_max} >= ${frequency}
             Run Keyword And Continue On Failure
-            ...    Should Be True    ${freq_min} < ${frequency}
+            ...    Should Be True    ${freq_min} <= ${frequency}
         END
         Sleep    ${FREQUENCY_TEST_MEASURE_INTERVAL}m
         ${timer}=    Evaluate    ${timer} + ${FREQUENCY_TEST_MEASURE_INTERVAL}
@@ -380,9 +380,9 @@ CPU With Load Runs On Expected Frequency (Ubuntu 22.04)
         @{frequencies}=    Get CPU Frequencies In Ubuntu
         FOR    ${frequency}    IN    @{frequencies}
             Run Keyword And Continue On Failure
-            ...    Should Be True    ${freq_max} > ${frequency}
+            ...    Should Be True    ${freq_max} >= ${frequency}
             Run Keyword And Continue On Failure
-            ...    Should Be True    ${freq_min} < ${frequency}
+            ...    Should Be True    ${freq_min} <= ${frequency}
         END
         Sleep    ${FREQUENCY_TEST_MEASURE_INTERVAL}m
         ${timer}=    Evaluate    ${timer} + ${FREQUENCY_TEST_MEASURE_INTERVAL}

--- a/lib/CPU-performance-lib.robot
+++ b/lib/CPU-performance-lib.robot
@@ -92,7 +92,7 @@ Stress Test
     [Documentation]    Proceed with the stress test.
     [Arguments]    ${time}=60s
     Detect Or Install Package    stress-ng
-    Execute Command In Terminal    stress-ng --cpu 1 --timeout ${time} &> /dev/null &
+    Execute Command In Terminal    stress-ng --cpu 16 --timeout ${time} &> /dev/null &
 
 Check Power Supply
     ${laptop_platform}=    Check The Platform Is A Laptop

--- a/lib/CPU-performance-lib.robot
+++ b/lib/CPU-performance-lib.robot
@@ -85,7 +85,7 @@ Check CPU Frequency In Windows
         ${freq_current}=    Get Line    ${freq_current_info}    -1
         ${freq_current}=    Convert To Number    ${freq_current}
         Run Keyword And Continue On Failure
-        ...    Should Be True    ${freq_max} > ${freq_current}
+        ...    Should Be True    ${freq_max} >= ${freq_current}
     END
 
 Stress Test

--- a/lib/CPU-performance-lib.robot
+++ b/lib/CPU-performance-lib.robot
@@ -92,7 +92,7 @@ Stress Test
     [Documentation]    Proceed with the stress test.
     [Arguments]    ${time}=60s
     Detect Or Install Package    stress-ng
-    Execute Command In Terminal    stress-ng --cpu 16 --timeout ${time} &> /dev/null &
+    Execute Command In Terminal    stress-ng --cpu $(nproc) --timeout ${time} &> /dev/null &
 
 Check Power Supply
     ${laptop_platform}=    Check The Platform Is A Laptop


### PR DESCRIPTION
Fix for this false failure:

```
CPF004.005 CPU with load runs on expected frequency (Ubuntu 22.04)... | FAIL |
Several failures occurred:

1) '4400.0 > 4400.0' should be true.

2) '400.0 < 400.0' should be true.
```

Also bump the number of threads in CPU stress test to actually load the CPU