### PR TITLE
dasharo-security/tpm2-commands.robot: added missing unseal check

### DIFF
--- a/dasharo-security/tpm2-commands.robot
+++ b/dasharo-security/tpm2-commands.robot
@@ -235,6 +235,7 @@ TPMCMD012.001 Sealing and Unsealing the file without Policy (Ubuntu 22.04)
     Execute Linux Tpm2 Tools Command    tpm2_evictcontrol --hierarchy owner --object-context seal.ctx -o seal.handle
     Execute Linux Tpm2 Tools Command    tpm2_unseal -c seal.handle > unsealed.dat
     ${out2}=    Execute Linux Command    cat unsealed.dat
+    Should Be Equal As Strings    ${out1}    ${out2}
 
 TPMCMD013.001 Sealing and Unsealing with Policy - Password Only (Ubuntu 22.04)
     [Documentation]    Check whether the TPM supports sealing and unsealing


### PR DESCRIPTION
The line that checks if the file was properly unsealed is missing. Right now the test only fails if [one of the previous commands fails](https://github.com/Dasharo/open-source-firmware-validation/blob/ami-encrypted-rootfs-tests/dasharo-security/tpm2-commands.robot#L233-L236).