### PR TITLE
Fix cbmem003.001

### DIFF
--- a/dasharo-performance/boot-time-measure.robot
+++ b/dasharo-performance/boot-time-measure.robot
@@ -84,10 +84,10 @@ CBMEM003.001 Serial boot time measure: coreboot booting time after system reboot
         ${boot_time}=    Get Boot Time From Cbmem
         Log To Console    (${index}) Boot time: ${boot_time} s)
         ${average}=    Evaluate    ${average}+${boot_time}
+        Execute Reboot Command
     END
     ${average}=    Evaluate    ${average}/${ITERATIONS}
     Log To Console    \nCoreboot average booting time: ${average} s\n
-    Execute Reboot Command
 
 
 *** Keywords ***

--- a/lib/CPU-performance-lib.robot
+++ b/lib/CPU-performance-lib.robot
@@ -89,7 +89,7 @@ Stress Test
     [Documentation]    Proceed with the stress test.
     [Arguments]    ${time}=60s
     Detect Or Install Package    stress-ng
-    Execute Command In Terminal    stress-ng --cpu $(nproc) --timeout ${time} &> /dev/null &
+    Execute Command In Terminal    stress-ng --cpu $(nproc) --timeout ${time} &> /dev/null & disown
 
 Check Power Supply
     ${laptop_platform}=    Check The Platform Is A Laptop


### PR DESCRIPTION
Reboot should be called in each iteration, not at the end of the test. Fixes: https://github.com/Dasharo/open-source-firmware-validation/issues/238
