### PR TITLE
Dts update test

### DIFF
--- a/dasharo-compatibility/dts-update.robot
+++ b/dasharo-compatibility/dts-update.robot
@@ -13,12 +13,11 @@ Resource            ../sonoff-rest-api/sonoff-api.robot
 Resource            ../variables.robot
 
 Suite Setup         Run Keywords
-...                     Prepare Test Suite
+...                     Prepare Test Suite    AND
+...    Make Sure That Network Boot Is Enabled    AND
+...    Restore Initial DUT Connection Method
 Suite Teardown      Run Keyword
 ...                     Log Out And Close Connection
-# This must be in Test Setup, not Suite Setup, because of a known problem
-# with QEMU: https://github.com/Dasharo/open-source-firmware-validation/issues/132
-Test Setup          Run Keywords    Make Sure That Network Boot Is Enabled    AND    Restore Initial DUT Connection Method
 
 
 *** Test Cases ***

--- a/dasharo-compatibility/dts-update.robot
+++ b/dasharo-compatibility/dts-update.robot
@@ -1,0 +1,94 @@
+*** Settings ***
+Library             Collections
+Library             OperatingSystem
+Library             Process
+Library             String
+Library             Telnet    timeout=20 seconds    connection_timeout=120 seconds
+Library             SSHLibrary    timeout=90 seconds
+Library             RequestsLibrary
+Resource            ../keywords.robot
+Resource            ../keys.robot
+Resource            ../rtectrl-rest-api/rtectrl.robot
+Resource            ../sonoff-rest-api/sonoff-api.robot
+Resource            ../variables.robot
+
+Suite Setup         Run Keywords
+...                     Prepare Test Suite
+Suite Teardown      Run Keyword
+...                     Log Out And Close Connection
+# This must be in Test Setup, not Suite Setup, because of a known problem
+# with QEMU: https://github.com/Dasharo/open-source-firmware-validation/issues/132
+Test Setup          Run Keywords    Make Sure That Network Boot Is Enabled    AND    Restore Initial DUT Connection Method
+
+
+*** Test Cases ***
+DTS-2 NovaCustom Dasharo v1.7.2
+    [Documentation]    This test aims to verify that Dasharo v1.7.2 on NV4x_PZ
+    ...    eligible for updates to heads with heads DES and regular update
+    ...    works as expected
+    Skip If    not ${TESTS_IN_FIRMWARE_SUPPORT}    DTS005.001 not supported
+    Skip If    not ${DTS_SUPPORT}    DTS005.001 not supported
+
+    Power On
+    Boot Dasharo Tools Suite    iPXE
+    Write Into Terminal    9
+    Read From Terminal Until Regexp    bash-\\d\\.\\d#
+
+    # We have to do this so that dts-environment doesnt ruin our mock exports
+    # I am putting this in a script to break up the command and escape
+    # robotframeworks variable expansion. Unfortunately running this as one
+    # command is impossible.
+    # This could be removed once the new dts release contains this change
+    # (PR for this is submitted already)
+    Write Into Terminal    echo -n "#" > fix.sh
+    Write Into Terminal    echo -n "!" >> fix.sh
+    Write Into Terminal    echo -n "/" >> fix.sh
+    Write Into Terminal    echo "bin/bash" >> fix.sh
+    Write Into Terminal    echo -ne "sed -i 's/^\\\\([^=[:space:]]*\\\\)=\\\\(.*\\\\)$/\\\\1=\\\\" >> fix.sh
+    Write Into Terminal    echo -n "$" >> fix.sh
+    Write Into Terminal    echo -n "{" >> fix.sh
+    Write Into Terminal    echo -ne "\\\\1:=\\\\2}/' /usr/sbin/dts-environment.sh" >> fix.sh
+    Write Into Terminal    echo "" >> fix.sh
+    Write Into Terminal    chmod 755 fix.sh
+    Write Into Terminal    ./fix.sh
+    ${out}=    Read From Terminal Until Regexp    bash-\\d\\.\\d#
+    Log    ${out}
+
+    ${out}=    Write Into Terminal    export BOARD_VENDOR="Notebook"
+    ${out}=    Write Into Terminal    export SYSTEM_MODEL="NV4xPZ"
+    ${out}=    Write Into Terminal    export BOARD_MODEL="NV4xPZ"
+    ${out}=    Write Into Terminal    export BIOS_VERSION="Dasharo (coreboot+UEFI) v1.7.2"
+    ${out}=    Write Into Terminal    export TEST_DES=y
+    ${out}=    Write Into Terminal    export BIOS_VENDOR="3mdeb"
+
+    ${out}=    Write Into Terminal    echo $BIOS_VERSION
+    ${out}=    Read From Terminal Until Regexp    bash-\\d\\.\\d#
+    Log    ${out}
+
+    ${out}=    Write Into Terminal    ./usr/sbin/dts-boot
+
+    ${out}=    Read From Terminal Until    Enter an option:
+    Write Into Terminal    5
+    Log    ${out}
+
+    ${out}=    Read From Terminal Until    Would you like to switch to Dasharo heads firmware? (Y|n)
+    # test fails here, because it doesnt have the right cloud keys
+    Write Into Terminal    Y
+    Log    ${out}
+
+    ${out}=    Read From Terminal Until    Are you sure you want to proceed with update? (Y|n)
+    Write Into Terminal    Y
+    Log    ${out}
+
+    ${out}=    Read From Terminal Until    Does it match your actual specification? (Y|n)
+    Write Into Terminal    Y
+    Log    ${out}
+
+    ${out}=    Read From Terminal Until    Do you want to update Dasharo firmware on your hardware? (Y|n)
+    Write Into Terminal    Y
+    Log    ${out}
+
+    ${out}=    Read From Terminal Until    Press any key to continue
+    Write Into Terminal    1
+    Log    ${out}
+

--- a/dasharo-compatibility/dts-update.robot
+++ b/dasharo-compatibility/dts-update.robot
@@ -32,7 +32,12 @@ DTS-2 NovaCustom Dasharo v1.7.2
     Power On
     Boot Dasharo Tools Suite    iPXE
     Write Into Terminal    9
-    Read From Terminal Until Regexp    bash-\\d\\.\\d#
+    Set Prompt For Terminal    bash-5.1#
+    Read From Terminal Until Prompt
+
+    Write Into Terminal    echo hi
+    ${out}=    Read From Terminal Until Prompt
+    Log    ${out}
 
     # We have to do this so that dts-environment doesnt ruin our mock exports
     # I am putting this in a script to break up the command and escape
@@ -51,7 +56,7 @@ DTS-2 NovaCustom Dasharo v1.7.2
     Write Into Terminal    echo "" >> fix.sh
     Write Into Terminal    chmod 755 fix.sh
     Write Into Terminal    ./fix.sh
-    ${out}=    Read From Terminal Until Regexp    bash-\\d\\.\\d#
+    ${out}=    Read From Terminal Until Prompt
     Log    ${out}
 
     ${out}=    Write Into Terminal    export BOARD_VENDOR="Notebook"
@@ -62,7 +67,7 @@ DTS-2 NovaCustom Dasharo v1.7.2
     ${out}=    Write Into Terminal    export BIOS_VENDOR="3mdeb"
 
     ${out}=    Write Into Terminal    echo $BIOS_VERSION
-    ${out}=    Read From Terminal Until Regexp    bash-\\d\\.\\d#
+    ${out}=    Read From Terminal Until Prompt
     Log    ${out}
 
     ${out}=    Write Into Terminal    /usr/sbin/dts-boot

--- a/dasharo-compatibility/dts-update.robot
+++ b/dasharo-compatibility/dts-update.robot
@@ -34,10 +34,6 @@ DTS-2 NovaCustom Dasharo v1.7.2
     Set Prompt For Terminal    bash-5.1#
     Read From Terminal Until Prompt
 
-    Write Into Terminal    echo hi
-    ${out}=    Read From Terminal Until Prompt
-    Log    ${out}
-
     # We have to do this so that dts-environment doesnt ruin our mock exports
     # I am putting this in a script to break up the command and escape
     # robotframeworks variable expansion. Unfortunately running this as one

--- a/dasharo-compatibility/dts-update.robot
+++ b/dasharo-compatibility/dts-update.robot
@@ -37,10 +37,10 @@ DTS-2 NovaCustom Dasharo v1.7.2
     Set Prompt For Terminal    bash-5.1#
     Read From Terminal Until Prompt
 
-    Variable Should Exist    ${scripts}
+    # Variable Should Exist    ${scripts}
     # example value of scripts variable (should be passed through command line
     # when running the test):
-    # ${scripts}=    Set Variable    /home/wgrzywacz/Desktop/DYSK/cos/yocto/meta-dts
+    ${scripts}=    Set Variable    /home/wgrzywacz/dts-scripts
 
     ${arguments}=    Create List    -o
     ...        StrictHostKeyChecking=no
@@ -49,31 +49,34 @@ DTS-2 NovaCustom Dasharo v1.7.2
     ...        -O
     ...        -P
     ...        5222
-    ...        ${scripts}/unit_tests/dts-boot
-    ...        ${scripts}/meta-dts-distro/recipes-dts/dts/dts/dts-functions.sh
-    ...        ${scripts}/unit_tests/dts-environment.sh
-    ...        ${scripts}/meta-dts-distro/recipes-dts/reports/dasharo-hcl-report/dasharo-hcl-report
-    ...        ${scripts}/meta-dts-distro/recipes-dts/reports/touchpad-info/touchpad-info
-    ...        ${scripts}/meta-dts-distro/recipes-dts/dts/dts/cloud_list
-    ...        ${scripts}/meta-dts-distro/recipes-dts/dts/dasharo-deploy/dasharo-deploy
-    ...        ${scripts}/meta-dts-distro/recipes-dts/dts/dts/dts
-    ...        ${scripts}/meta-dts-distro/recipes-dts/dts/dts/ec_transition
-    ...        ${scripts}/meta-dts-distro/recipes-dts/dts/dts/dts-profile.sh
+    ...        ${scripts}/unit-tests/dts-boot
+    ...        ${scripts}/include/dts-functions.sh
+    ...        ${scripts}/include/dts-environment.sh
+    ...        ${scripts}/reports/dasharo-hcl-report
+    ...        ${scripts}/reports/touchpad-info
+    ...        ${scripts}/scripts/cloud_list
+    ...        ${scripts}/scripts/dasharo-deploy
+    ...        ${scripts}/scripts/dts
+    ...        ${scripts}/scripts/ec_transition
+    ...        ${scripts}/dts-profile.sh
     ...        root@127.0.0.1:/usr/sbin/
     ${output}=    Run Process    scp    @{arguments}    shell=True
     Log    ${output}
 
     ${out}=    Write Into Terminal    export BOARD_VENDOR="Notebook"
+    ${out}=    Write Into Terminal    export SYSTEM_VENDOR="Notebook"
     ${out}=    Write Into Terminal    export SYSTEM_MODEL="NV4xPZ"
     ${out}=    Write Into Terminal    export BOARD_MODEL="NV4xPZ"
     ${out}=    Write Into Terminal    export BIOS_VERSION="Dasharo (coreboot+UEFI) v1.7.2"
     ${out}=    Write Into Terminal    export TEST_DES=y
     ${out}=    Write Into Terminal    export BIOS_VENDOR="3mdeb"
+    ${out}=    Write Into Terminal    export SE_credential_file="/cloud-pass"
+    ${out}=    Write Into Terminal    export HAVE_EC="false"
 
     ${out}=    Write Into Terminal    /usr/sbin/dts-boot
 
-    ${out}=    Read From Terminal Until    Enter an option:
-    Write Into Terminal    5
+    ${out}=    Read From Terminal Until    K to stop SSH server
+    Write Into Terminal    2
     Log    ${out}
 
     ${out}=    Read From Terminal Until    Would you like to switch to Dasharo heads firmware? (Y|n)
@@ -92,7 +95,11 @@ DTS-2 NovaCustom Dasharo v1.7.2
     Write Into Terminal    Y
     Log    ${out}
 
-    ${out}=    Read From Terminal Until    Press any key to continue
+    ${out}=    Read From Terminal Until    Press enter to continue
+    Write Into Terminal    1
+    Log    ${out}
+
+    ${out}=    Read From Terminal Until    Press ENTER to continue.
     Write Into Terminal    1
     Log    ${out}
 

--- a/dasharo-compatibility/dts-update.robot
+++ b/dasharo-compatibility/dts-update.robot
@@ -65,7 +65,7 @@ DTS-2 NovaCustom Dasharo v1.7.2
     ${out}=    Read From Terminal Until Regexp    bash-\\d\\.\\d#
     Log    ${out}
 
-    ${out}=    Write Into Terminal    ./usr/sbin/dts-boot
+    ${out}=    Write Into Terminal    /usr/sbin/dts-boot
 
     ${out}=    Read From Terminal Until    Enter an option:
     Write Into Terminal    5

--- a/dasharo-compatibility/dts-update.robot
+++ b/dasharo-compatibility/dts-update.robot
@@ -37,10 +37,10 @@ DTS-2 NovaCustom Dasharo v1.7.2
     Set Prompt For Terminal    bash-5.1#
     Read From Terminal Until Prompt
 
-    # Variable Should Exist    ${scripts}
+    Variable Should Exist    ${scripts}
     # example value of scripts variable (should be passed through command line
     # when running the test):
-    ${scripts}=    Set Variable    /home/wgrzywacz/dts-scripts
+    # ${scripts}=    Set Variable    /home/wgrzywacz/dts-scripts
 
     ${arguments}=    Create List    -o
     ...        StrictHostKeyChecking=no


### PR DESCRIPTION
This test is a proof of concept.

The test scenario is the same as in https://github.com/Dasharo/meta-dts/pull/114

Unfortunately it fails because of lack of cloud keys. The `dts-boot` script thats in `unit-tests` of `meta-dts` contains a section thats responsible for getting the right keys. The release version of DTS obviously can't have that, and I think that further editing of `dts` script on qemu through robotframework is a bad idea.