### PR TITLE
Mem spd displayed v2

### DIFF
--- a/dasharo-compatibility/setup-menu-information.robot
+++ b/dasharo-compatibility/setup-menu-information.robot
@@ -1,0 +1,109 @@
+*** Settings ***
+Library             Collections
+Library             OperatingSystem
+Library             Process
+Library             String
+Library             Telnet    timeout=20 seconds    connection_timeout=120 seconds
+Library             SSHLibrary    timeout=90 seconds
+Library             RequestsLibrary
+# TODO: maybe have a single file to include if we need to include the same
+# stuff in all test cases
+Resource            ../sonoff-rest-api/sonoff-api.robot
+Resource            ../rtectrl-rest-api/rtectrl.robot
+Resource            ../variables.robot
+Resource            ../keywords.robot
+Resource            ../keys.robot
+
+# TODO:
+# - document which setup/teardown keywords to use and what are they doing
+# - go threough them and make sure they are doing what the name suggest (not
+# exactly the case right now)
+Suite Setup         Run Keywords
+...                     Prepare Test Suite
+...                     AND
+...                     Skip If    not ${UEFI_COMPATIBLE_INTERFACE_SUPPORT}    UEFI interface tests not supported
+Suite Teardown      Run Keyword
+...                     Log Out And Close Connection
+
+
+*** Test Cases ***
+SET001.001 CPU clock speed displayed in setup menu
+    [Documentation]    This test case verifies that CPU clock speed is
+    ...    correctly indicated in setup menu.
+
+    Power On
+    Enter Setup Menu Tianocore
+    ${out}=    Read From Terminal Until    <Enter>=Select Entry
+    ${cpu_line}=    Get Lines Matching Regexp    ${out}    .*GHz
+    Should Not Be Empty    ${cpu_line}    CPU clock speed not found
+
+    ${matches}=    Get Regexp Matches    ${cpu_line}    (\\d+\\.\\d+)\\s+GHz    1
+    Should Not Be Equal As Numbers    ${matches}[0]    0
+
+SET002.001 RAM speed displayed in setup menu
+    [Documentation]    This test case verifies that RAM speed is correctly
+    ...    indicated in setup menu.
+
+    Power On
+    Enter Setup Menu Tianocore
+    ${out}=    Read From Terminal Until    <Enter>=Select Entry
+    ${ram_line}=    Get Lines Matching Regexp    ${out}    .*RAM @ \\d+ MHz.*
+    Should Not Be Empty    ${ram_line}    RAM speed not found
+
+    ${matches}=    Get Regexp Matches    ${ram_line}    (\\d+)\\s*MHz    1
+    Should Not Be Equal As Numbers    ${matches}[0]    0
+
+SET003.001 RAM size displayed in setup menu
+    [Documentation]    This test case verifies that RAM size is correctly
+    ...    indicated in setup menu.
+
+    Power On
+    Enter Setup Menu Tianocore
+    ${out}=    Read From Terminal Until    <Enter>=Select Entry
+    ${ram_line}=    Get Lines Matching Regexp    ${out}    .*MB RAM.*
+    Should Not Be Empty    ${ram_line}    RAM size not found
+
+    ${matches}=    Get Regexp Matches    ${ram_line}    (\\d+)\\s*MB\\s*RAM    1
+    Should Not Be Equal As Numbers    ${matches}[0]    0
+
+SET004.001 Expected CPU clock speed displayed in setup menu
+    [Documentation]    This test case verifies that CPU clock speed is
+    ...    correctly indicated in setup menu.
+    Depends On Variable    \${PLATFORM_CPU_SPEED}
+
+    Power On
+    Enter Setup Menu Tianocore
+    ${out}=    Read From Terminal Until    <Enter>=Select Entry
+    ${cpu_line}=    Get Lines Matching Regexp    ${out}    .*GHz
+    Should Not Be Empty    ${cpu_line}    CPU clock speed not found
+
+    ${matches}=    Get Regexp Matches    ${cpu_line}    (\\d+\\.\\d+) GHz    1
+    Should Be Equal As Numbers    ${matches}[0]    ${PLATFORM_CPU_SPEED}
+
+SET005.001 Expected RAM speed displayed in setup menu
+    [Documentation]    This test case verifies that RAM speed is correctly
+    ...    indicated in setup menu.
+    Depends On Variable    \${PLATFORM_RAM_SPEED}
+
+    Power On
+    Enter Setup Menu Tianocore
+    ${out}=    Read From Terminal Until    <Enter>=Select Entry
+    ${ram_line}=    Get Lines Matching Regexp    ${out}    .*RAM @ \\d+ MHz.*
+    Should Not Be Empty    ${ram_line}    RAM speed not found
+
+    ${matches}=    Get Regexp Matches    ${ram_line}    (\\d+)\\s*MHz    1
+    Should Be Equal As Numbers    ${matches}[0]    ${PLATFORM_RAM_SPEED}
+
+SET006.001 Expected RAM size displayed in setup menu
+    [Documentation]    This test case verifies that RAM size is correctly
+    ...    indicated in setup menu.
+    Depends On Variable    \${PLATFORM_RAM_SIZE}
+
+    Power On
+    Enter Setup Menu Tianocore
+    ${out}=    Read From Terminal Until    <Enter>=Select Entry
+    ${ram_line}=    Get Lines Matching Regexp    ${out}    .*MB RAM.*
+    Should Not Be Empty    ${ram_line}    RAM size not found
+
+    ${matches}=    Get Regexp Matches    ${ram_line}    (\\d+)\\s*MB\\s*RAM    1
+    Should Be Equal As Numbers    ${matches}[0]    ${PLATFORM_RAM_SIZE}

--- a/keywords.robot
+++ b/keywords.robot
@@ -15,6 +15,7 @@ Resource        lib/flash.robot
 Resource        lib/self-tests.robot
 Resource        lib/sleep-lib.robot
 Resource        lib/CPU-performance-lib.robot
+Resource        lib/framework.robot
 Variables       platform-configs/fan-curve-config.yaml
 
 

--- a/keywords.robot
+++ b/keywords.robot
@@ -515,7 +515,9 @@ Prepare Test Suite
     ${url}=    Replace String    ${url}    git@github.com:    https://github.com/
     ${url}=    Remove String Using Regexp    ${url}    .git$
     # Relative path from repository base, assumes that directory has the same name as repository
-    ${path}=    Remove String Using Regexp    ${SUITE_SOURCE}    ^.*/${{$url.rsplit('/', 1)[1]}}/
+    ${dir_name_split}=    Split String    ${url}    /
+    ${dir_name}=    Get From List    ${dir_name_split}    -1
+    ${path}=    Remove String Using Regexp    ${SUITE_SOURCE}    ^.*/${dir_name}/
     Set Suite Metadata    Remote source (maybe)    ${url}/blob/${revision}/${path}
     IF    '${SNIPEIT}' == 'yes'
         Import Library    ${CURDIR}/osfv-scripts/osfv_cli/osfv_cli/snipeit_robot.py

--- a/lib/framework.robot
+++ b/lib/framework.robot
@@ -1,0 +1,17 @@
+*** Keywords ***
+Depends On Variable
+    [Documentation]    Skips the test if ``variable`` does not exist.
+    [Arguments]    ${variable}
+    ${variable_exists}=    Run Keyword And Return Status    Variable Should Exist    ${variable}
+    Depends On    ${variable_exists}    Variable: ${variable} is not defined
+
+Depends On
+    [Documentation]    Skips test if ``condition`` is not met. Test identifier
+    ...    (first word of its name) and optional ``reason`` is set
+    ...    to the test as per ```Skip`` keyword.
+    [Arguments]    ${condition}    ${reason}=${NONE}
+    ${line}=    Set Variable    ${TEST_NAME.split()}[0] not supported
+    IF    $reason is not None
+        ${line}=    Set Variable    ${line}: ${reason}
+    END
+    Skip If    not ${condition}    ${line}

--- a/lib/framework.robot
+++ b/lib/framework.robot
@@ -11,7 +11,7 @@ Depends On
     ...    to the test as per ```Skip`` keyword.
     [Arguments]    ${condition}    ${reason}=${NONE}
     ${line}=    Set Variable    ${TEST_NAME.split()}[0] not supported
-    IF    $reason is not None
+    IF    '${reason}' != ${NONE}
         ${line}=    Set Variable    ${line}: ${reason}
     END
     Skip If    not ${condition}    ${line}

--- a/platform-configs/msi-pro-z690-a-ddr5.robot
+++ b/platform-configs/msi-pro-z690-a-ddr5.robot
@@ -8,3 +8,7 @@ ${DMIDECODE_SERIAL_NUMBER}=         N/A
 ${DMIDECODE_FIRMWARE_VERSION}=      Dasharo (coreboot+UEFI) v1.1.3
 ${DMIDECODE_PRODUCT_NAME}=          MS-7D25
 ${DMIDECODE_RELEASE_DATE}=          11/27/2023
+
+${PLATFORM_CPU_SPEED}=              3.50
+${PLATFORM_RAM_SPEED}=              4000
+${PLATFORM_RAM_SIZE}=               32768

--- a/platform-configs/msi-pro-z690-a-wifi-ddr4.robot
+++ b/platform-configs/msi-pro-z690-a-wifi-ddr4.robot
@@ -14,3 +14,7 @@ ${WIFI_CARD}=                           Intel(R) Wi-Fi 6 AX201 160MHz
 ${WIRELESS_CARD_SUPPORT}=               ${TRUE}
 ${WIRELESS_CARD_WIFI_SUPPORT}=          ${TRUE}
 ${WIRELESS_CARD_BLUETOOTH_SUPPORT}=     ${TRUE}
+
+${PLATFORM_CPU_SPEED}=                  3.70
+${PLATFORM_RAM_SPEED}=                  3600
+${PLATFORM_RAM_SIZE}=                   32768

--- a/platform-configs/msi-pro-z790-p.robot
+++ b/platform-configs/msi-pro-z790-p.robot
@@ -8,3 +8,7 @@ ${DMIDECODE_SERIAL_NUMBER}=         N/A
 ${DMIDECODE_FIRMWARE_VERSION}=      Dasharo (coreboot+UEFI) v0.9.1
 ${DMIDECODE_PRODUCT_NAME}=          MS-7E06
 ${DMIDECODE_RELEASE_DATE}=          11/27/2023
+
+${PLATFORM_CPU_SPEED}=              3.50
+${PLATFORM_RAM_SPEED}=              4000
+${PLATFORM_RAM_SIZE}=               32768

--- a/platform-configs/protectli-v1210.robot
+++ b/platform-configs/protectli-v1210.robot
@@ -4,3 +4,7 @@ Resource    include/protectli-v1x10.robot
 
 *** Variables ***
 ${DMIDECODE_PRODUCT_NAME}=      V1210
+
+${PLATFORM_CPU_SPEED}=          2.00
+${PLATFORM_RAM_SPEED}=          2933
+${PLATFORM_RAM_SIZE}=           4096

--- a/platform-configs/protectli-v1410.robot
+++ b/platform-configs/protectli-v1410.robot
@@ -4,3 +4,7 @@ Resource    include/protectli-v1x10.robot
 
 *** Variables ***
 ${DMIDECODE_PRODUCT_NAME}=      V1410
+
+${PLATFORM_CPU_SPEED}=          2.00
+${PLATFORM_RAM_SPEED}=          2933
+${PLATFORM_RAM_SIZE}=           8192

--- a/platform-configs/protectli-v1610.robot
+++ b/platform-configs/protectli-v1610.robot
@@ -4,3 +4,7 @@ Resource    include/protectli-v1x10.robot
 
 *** Variables ***
 ${DMIDECODE_PRODUCT_NAME}=      V1610
+
+${PLATFORM_CPU_SPEED}=          2.00
+${PLATFORM_RAM_SPEED}=          2933
+${PLATFORM_RAM_SIZE}=           16384

--- a/platform-configs/protectli-vp2410.robot
+++ b/platform-configs/protectli-vp2410.robot
@@ -38,6 +38,10 @@ ${SMM_WRITE_PROTECTION_SUPPORT}=        ${TRUE}
 ${UEFI_PASSWORD_SUPPORT}=               ${TRUE}
 ${ME_STATICALLY_DISABLED}=              ${TRUE}
 
+${PLATFORM_CPU_SPEED}=                  2.00
+${PLATFORM_RAM_SPEED}=                  2400
+${PLATFORM_RAM_SIZE}=                   8192
+
 
 *** Keywords ***
 Power On

--- a/platform-configs/protectli-vp2420.robot
+++ b/platform-configs/protectli-vp2420.robot
@@ -25,6 +25,10 @@ ${DMIDECODE_VENDOR}=                3mdeb
 ${DMIDECODE_FAMILY}=                N/A
 ${DMIDECODE_TYPE}=                  N/A
 
+${PLATFORM_CPU_SPEED}=              2.00
+${PLATFORM_RAM_SPEED}=              2933
+${PLATFORM_RAM_SIZE}=               8192
+
 ${WATCHDOG_SUPPORT}=                ${TRUE}
 
 

--- a/platform-configs/protectli-vp4630.robot
+++ b/platform-configs/protectli-vp4630.robot
@@ -16,3 +16,7 @@ ${DEVICE_NVME_DISK}=            Non-Volatile memory controller
 ${USB_MODEL}=                   SanDisk
 
 ${DMIDECODE_PRODUCT_NAME}=      VP4630
+
+${PLATFORM_CPU_SPEED}=          2.60
+${PLATFORM_RAM_SPEED}=          2400
+${PLATFORM_RAM_SIZE}=           36864

--- a/platform-configs/protectli-vp4650.robot
+++ b/platform-configs/protectli-vp4650.robot
@@ -17,3 +17,7 @@ ${DEVICE_NVME_DISK}=            Non-Volatile memory controller
 ${USB_MODEL}=                   SanDisk
 
 ${DMIDECODE_PRODUCT_NAME}=      VP4650
+
+${PLATFORM_CPU_SPEED}=          2.10
+${PLATFORM_RAM_SPEED}=          2400
+${PLATFORM_RAM_SIZE}=           16384

--- a/platform-configs/protectli-vp4670.robot
+++ b/platform-configs/protectli-vp4670.robot
@@ -17,3 +17,7 @@ ${DEVICE_NVME_DISK}=            Non-Volatile memory controller
 ${USB_MODEL}=                   SanDisk
 
 ${DMIDECODE_PRODUCT_NAME}=      VP4670
+
+${PLATFORM_CPU_SPEED}=          1.60
+${PLATFORM_RAM_SPEED}=          2667
+${PLATFORM_RAM_SIZE}=           16384

--- a/platform-configs/protectli-vp6650.robot
+++ b/platform-configs/protectli-vp6650.robot
@@ -18,3 +18,7 @@ ${DEVICE_NVME_DISK}=            Non-Volatile memory controller
 ${USB_MODEL}=                   SanDisk
 
 ${DMIDECODE_PRODUCT_NAME}=      VP6650
+
+${PLATFORM_CPU_SPEED}=          2.50
+${PLATFORM_RAM_SPEED}=          4200
+${PLATFORM_RAM_SIZE}=           65536

--- a/platform-configs/protectli-vp6670.robot
+++ b/platform-configs/protectli-vp6670.robot
@@ -18,3 +18,7 @@ ${DEVICE_NVME_DISK}=            Non-Volatile memory controller
 ${USB_MODEL}=                   SanDisk
 
 ${DMIDECODE_PRODUCT_NAME}=      VP6670
+
+${PLATFORM_CPU_SPEED}=          2.60
+${PLATFORM_RAM_SPEED}=          4200
+${PLATFORM_RAM_SIZE}=           32678


### PR DESCRIPTION
This is somehow not present in `develop` despite reviewed here: https://github.com/Dasharo/open-source-firmware-validation/pull/243

Submitting it again, along with some Python - RF "fixes" that did not allow me to run any tests at all. Perhaps due to Python upgrade? I am not really sure...

Execution on VP4630:

```
RTE_IP=192.168.10.244 CONFIG=protectli-vp4630 SNIPEIT_NO=true ./scripts/run.sh dasharo-compatibility/setup-menu-information.robot
==============================================================================
Setup-Menu-Information                                                        
==============================================================================
SET001.001 CPU clock speed displayed in setup menu :: This test ca... | PASS |
------------------------------------------------------------------------------
SET002.001 RAM speed displayed in setup menu :: This test case ver... | PASS |
------------------------------------------------------------------------------
SET003.001 RAM size displayed in setup menu :: This test case veri... | PASS |
------------------------------------------------------------------------------
SET004.001 Expected CPU clock speed displayed in setup menu :: Thi... | PASS |
------------------------------------------------------------------------------
SET005.001 Expected RAM speed displayed in setup menu :: This test... | PASS |
------------------------------------------------------------------------------
SET006.001 Expected RAM size displayed in setup menu :: This test ... | PASS |
------------------------------------------------------------------------------
Setup-Menu-Information                                                | PASS |
6 tests, 6 passed, 0 failed
==============================================================================
```