### PR TITLE
Added test to verify if network boot uses https:// and not http://

### DIFF
--- a/dasharo-compatibility/network-boot.robot
+++ b/dasharo-compatibility/network-boot.robot
@@ -114,3 +114,18 @@ PXE006.001 iPXE shell option is available and works correctly
     ${ipxe_menu}=    Get IPXE Boot Menu Construction
     Enter Submenu From Snapshot    ${ipxe_menu}    iPXE Shell
     Read From Terminal Until    iPXE>
+
+PXE007.001 Dasharo Network Boot over https not http
+    [Documentation]    This test aims to verify, if the boot takes place via
+    ...    https:// and not via http://.
+    Skip If    not ${IPXE_BOOT_SUPPORT}    PXE007.001 not supported
+    Skip If    not ${TESTS_IN_FIRMWARE_SUPPORT}    PXE007.001 not supported
+    Power On
+    ${boot_menu}=    Enter Boot Menu Tianocore And Return Construction
+    Enter Submenu From Snapshot    ${boot_menu}    ${IPXE_BOOT_ENTRY}
+    ${ipxe_menu}=    Get IPXE Boot Menu Construction
+    Enter Submenu From Snapshot    ${ipxe_menu}    Dasharo Tools Suite
+    ${out}=    Read From Terminal Until    Enter an option
+    Log    ${out}
+    Should Contain    ${out}    https://
+    Should Not Contain    ${out}    http://


### PR DESCRIPTION
Added test to verify if network boot uses https:// and not http://
Fixes: [https://github.com/Dasharo/open-source-firmware-validation/issues/200](https://github.com/Dasharo/open-source-firmware-validation/issues/200)