### PR TITLE
Use DCU for UEFI settings on platforms w/o serial console

### DIFF
--- a/dasharo-security/me-neuter.robot
+++ b/dasharo-security/me-neuter.robot
@@ -24,7 +24,7 @@ Suite Setup         Run Keywords
 ...                     AND
 ...                     Skip If    not ${DASHARO_INTEL_ME_MENU_SUPPORT}    Dasharo Intel ME menu not supported
 ...                     AND
-...                     Set Intel ME Mode    Enabled
+...                     Set UEFI Option    MeMode    Enabled
 Suite Teardown      Run Keyword
 ...                     Log Out And Close Connection
 
@@ -45,12 +45,7 @@ MNE002.001 Intel ME mode option Enabled works correctly (Ubuntu 22.04)
     [Documentation]    Check whether the Intel ME mode option in state Enabled
     ...    works correctly.
     Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    MNE002.001 not supported
-    Power On
-    ${setup_menu}=    Enter Setup Menu Tianocore And Return Construction
-    ${dasharo_menu}=    Enter Dasharo System Features    ${setup_menu}
-    ${me_menu}=    Enter Dasharo Submenu    ${dasharo_menu}    Intel Management Engine Options
-    Set Option State    ${me_menu}    Intel ME mode    Enabled
-    Save Changes And Reset
+    Set UEFI Option    MeMode    Enabled
     Boot System Or From Connected Disk    ubuntu
     Login To Linux
     Switch To Root User
@@ -61,12 +56,7 @@ MNE003.001 Intel ME mode option Disabled (Soft) works correctly (Ubuntu 22.04)
     [Documentation]    Check whether the Intel ME mode option in state
     ...    Disabled (Soft) works correctly
     Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    MNE003.001 not supported
-    Power On
-    ${setup_menu}=    Enter Setup Menu Tianocore And Return Construction
-    ${dasharo_menu}=    Enter Dasharo System Features    ${setup_menu}
-    ${me_menu}=    Enter Dasharo Submenu    ${dasharo_menu}    Intel Management Engine Options
-    Set Option State    ${me_menu}    Intel ME mode    Disabled (Soft)
-    Save Changes And Reset
+    Set UEFI Option    MeMode    Disabled (Soft)
     Boot System Or From Connected Disk    ubuntu
     Login To Linux
     Switch To Root User
@@ -77,12 +67,7 @@ MNE004.001 Intel ME mode option Disabled (HAP) works correctly (Ubuntu 22.04)
     [Documentation]    Check whether the Intel ME mode option in state
     ...    Disabled (HAP) works correctly.
     Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    MNE004.001 not supported
-    Power On
-    ${setup_menu}=    Enter Setup Menu Tianocore And Return Construction
-    ${dasharo_menu}=    Enter Dasharo System Features    ${setup_menu}
-    ${me_menu}=    Enter Dasharo Submenu    ${dasharo_menu}    Intel Management Engine Options
-    Set Option State    ${me_menu}    Intel ME mode    Disabled (HAP)
-    Save Changes And Reset
+    Set UEFI Option    MeMode    Disabled (HAP)
     Boot System Or From Connected Disk    ubuntu
     Login To Linux
     Switch To Root User
@@ -94,26 +79,10 @@ MNE006.001 Check Intel ME version (Ubuntu 22.04)
     ...    be read on the Operating System level. The read version should be
     ...    the same as in the release notes.
     Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    MNE006.001 not supported
-    Power On
-    ${setup_menu}=    Enter Setup Menu Tianocore And Return Construction
-    ${dasharo_menu}=    Enter Dasharo System Features    ${setup_menu}
-    ${me_menu}=    Enter Dasharo Submenu    ${dasharo_menu}    Intel Management Engine Options
-    Set Option State    ${me_menu}    Intel ME mode    Enabled
-    Save Changes And Reset
+    Set UEFI Option    MeMode    Enabled
     Power On
     Boot System Or From Connected Disk    ubuntu
     Login To Linux
     Switch To Root User
     ${out}=    Execute Command In Terminal    cat /sys/class/mei/mei0/fw_ver
     Should Not Be Empty    ${out}
-
-
-*** Keywords ***
-Set Intel ME Mode
-    [Arguments]    ${mode}
-    Power On
-    ${setup_menu}=    Enter Setup Menu Tianocore And Return Construction
-    ${dasharo_menu}=    Enter Dasharo System Features    ${setup_menu}
-    ${me_menu}=    Enter Dasharo Submenu    ${dasharo_menu}    Intel Management Engine Options
-    Set Option State    ${me_menu}    Intel ME mode    ${mode}
-    Save Changes And Reset

--- a/keywords.robot
+++ b/keywords.robot
@@ -506,6 +506,8 @@ Prepare Test Suite
     ...    preparing connection with the DUT based on used
     ...    transmission protocol. Keyword used in all [Suite Setup]
     ...    sections.
+    Log    Library configuration:
+    Log    - options: ${OPTIONS_LIB}
     # Add some metadata to track test version
     ${revision}=    Run    git describe --dirty --always --tags
     Set Suite Metadata    OSFV revision    ${revision}

--- a/keywords.robot
+++ b/keywords.robot
@@ -506,8 +506,6 @@ Prepare Test Suite
     ...    preparing connection with the DUT based on used
     ...    transmission protocol. Keyword used in all [Suite Setup]
     ...    sections.
-    Log    Library configuration:
-    Log    - options: ${OPTIONS_LIB}
     # Add some metadata to track test version
     ${revision}=    Run    git describe --dirty --always --tags
     Set Suite Metadata    OSFV revision    ${revision}
@@ -561,7 +559,7 @@ Prepare To SSH Connection
     # tu leci zmiana, musimy brać platformy zgodnie z tym co zostało pobrane w dasharo
     Set Global Variable    ${PLATFORM}    ${CONFIG}
     SSHLibrary.Set Default Configuration    timeout=60 seconds
-    # Sonoff API Setup    ${sonoff_ip}
+    Open Connection And Log In
     IF    '${SNIPEIT}'=='no'    RETURN
     SnipeIt Checkout    ${RTE_IP}
 
@@ -730,7 +728,11 @@ Sonoff Power Cycle On
     ...    Sonoff
     Sonoff Power Off
     Sleep    10
-    Telnet.Read
+    TRY
+        Telnet.Read
+    EXCEPT
+        Log    Could not clear Telnet buffer
+    END
     Sonoff Power On
 
 Power Cycle Off

--- a/keywords.robot
+++ b/keywords.robot
@@ -142,7 +142,7 @@ Login To Linux Via SSH
     ...    height=100
     ...    escape_ansi=True
     ...    newline=LF
-    Wait Until Keyword Succeeds    12x    10s
+    Wait Until Keyword Succeeds    120x    1s
     ...    SSHLibrary.Login    ${username}    ${password}
 
 Login To Windows Via SSH

--- a/keywords.robot
+++ b/keywords.robot
@@ -559,7 +559,6 @@ Prepare To SSH Connection
     # tu leci zmiana, musimy brać platformy zgodnie z tym co zostało pobrane w dasharo
     Set Global Variable    ${PLATFORM}    ${CONFIG}
     SSHLibrary.Set Default Configuration    timeout=60 seconds
-    Open Connection And Log In
     IF    '${SNIPEIT}'=='no'    RETURN
     SnipeIt Checkout    ${RTE_IP}
 

--- a/lib/bios/menus.py
+++ b/lib/bios/menus.py
@@ -128,3 +128,66 @@ def merge_lists(list1, list2):
             final_list.add(i2)
 
     return final_list
+
+
+getoptionpath = {
+    "LockBios": [
+        "Dasharo System Features",
+        "Dasharo Security Features",
+        "Lock the BIOS boot medium",
+    ],
+    "NetworkBoot": [
+        "Dasharo System Features",
+        "Networking Options",
+        "Enable network boot",
+    ],
+    "UsbDriverStack": [
+        "Dasharo System Features",
+        "USB Configuration",
+        "Enable USB stack",
+    ],
+    "UsbMassStorage": [
+        "Dasharo System Features",
+        "USB Configuration",
+        "Enable USB Mass Storage driver",
+    ],
+    "SmmBwp": [
+        "Dasharo System Features",
+        "Dasharo Security Features",
+        "Enable SMM BIOS write protection",
+    ],
+    "MeMode": [
+        "Dasharo System Features",
+        "Intel Management Engine Options",
+        "Intel ME mode",
+    ],
+    "FanCurveOption": [
+        "Dasharo System Features",
+        "Power Management Options",
+        "Fan profile",
+    ],
+    "EnableCamera": [
+        "Dasharo System Features",
+        "Dasharo Security Features",
+        "Enable Camera",
+    ],
+    "EnableWifiBt": [
+        "Dasharo System Features",
+        "Dasharo Security Features",
+        "Enable Wi-Fi + BT radios",
+    ],
+    "SerialRedirection": [
+        "Dasharo System Features",
+        "Serial Port Configuration",
+        "Enable Serial Port Console Redirection",
+    ],
+}
+
+
+@keyword("Option Name To UEFI Path")
+def option_name_to_uefi_path(name):
+    """
+    This keyword converts an option name to a UEFI menu path. This path can be
+    used to navigate to the option in the UEFI Setup Menu app.
+    """
+    return getoptionpath[name]

--- a/lib/options/dcu.robot
+++ b/lib/options/dcu.robot
@@ -23,9 +23,7 @@ Set UEFI Option
     Execute Linux Command    flashrom -p internal -r coreboot.rom --fmap -i FMAP -i SMMSTORE &> /dev/null
     SSHLibrary.Get File    coreboot.rom    dcu/coreboot.rom
     # TODO error handling
-    Run    cd dcu
-    Run    ./dcu v coreboot.rom --set "${option_name}" --value "${value}"
-    Run    cd ..
+    Run    cd dcu && ./dcu v coreboot.rom --set "${option_name}" --value "${value}"
     SSHLibrary.Put File    dcu/coreboot.rom    coreboot.rom
     Execute Linux Command    flashrom -p internal -w coreboot.rom --fmap -i SMMSTORE --noverify-all &> /dev/null
     Power On

--- a/lib/options/dcu.robot
+++ b/lib/options/dcu.robot
@@ -15,7 +15,6 @@ Set UEFI Option
     Run    git clone https://github.com/Dasharo/dcu
     # TODO: Remove once smmstore support is merged
     Run    cd dcu && git checkout smmstore > /dev/null 2>&1 && cd ..
-    Power On
     Boot System Or From Connected Disk    ubuntu
     Login To Linux
     Switch To Root User
@@ -26,4 +25,8 @@ Set UEFI Option
     Run    cd dcu && ./dcu v coreboot.rom --set "${option_name}" --value "${value}"
     SSHLibrary.Put File    dcu/coreboot.rom    coreboot.rom
     Execute Linux Command    flashrom -p internal -w coreboot.rom --fmap -i SMMSTORE --noverify-all &> /dev/null
-    Power On
+    Execute Reboot Command
+    # Assume we don't have serial to tell us that we've rebooted, so just wait
+    # 20s for shutdown to finish, to prevent subsequent kwds from running before
+    # reboot.
+    Sleep    20s

--- a/lib/options/dcu.robot
+++ b/lib/options/dcu.robot
@@ -4,6 +4,7 @@ Documentation       Library for UEFI configuration using Dasharo Configuration
 ...                 available.
 
 Library             Collections
+Library             OperatingSystem
 Library             String
 
 
@@ -11,4 +12,20 @@ Library             String
 Set UEFI Option
     [Documentation]    Set an UEFI option to a value.
     [Arguments]    ${option_name}    ${value}
-    Skip    I am a dummy! ${option_name} ${value}
+    Run    git clone https://github.com/Dasharo/dcu
+    # TODO: Remove once smmstore support is merged
+    Run    cd dcu && git checkout smmstore > /dev/null 2>&1 && cd ..
+    Power On
+    Boot System Or From Connected Disk    ubuntu
+    Login To Linux
+    Switch To Root User
+    Get Flashrom From Cloud
+    Execute Linux Command    flashrom -p internal -r coreboot.rom --fmap -i FMAP -i SMMSTORE &> /dev/null
+    SSHLibrary.Get File    coreboot.rom    dcu/coreboot.rom
+    # TODO error handling
+    Run    cd dcu
+    Run    ./dcu v coreboot.rom --set "${option_name}" --value "${value}"
+    Run    cd ..
+    SSHLibrary.Put File    dcu/coreboot.rom    coreboot.rom
+    Execute Linux Command    flashrom -p internal -w coreboot.rom --fmap -i SMMSTORE --noverify-all &> /dev/null
+    Power On

--- a/lib/options/dcu.robot
+++ b/lib/options/dcu.robot
@@ -14,8 +14,6 @@ Set UEFI Option
     [Documentation]    Set an UEFI option to a value.
     [Arguments]    ${option_name}    ${value}
     Run    git clone https://github.com/Dasharo/dcu
-    # TODO: Remove once smmstore support is merged
-    Run    cd dcu && git checkout smmstore > /dev/null 2>&1 && cd ..
     Boot System Or From Connected Disk    ubuntu
     Login To Linux
     Switch To Root User

--- a/lib/options/dcu.robot
+++ b/lib/options/dcu.robot
@@ -6,6 +6,7 @@ Documentation       Library for UEFI configuration using Dasharo Configuration
 Library             Collections
 Library             OperatingSystem
 Library             String
+Resource            ../terminal.robot
 
 
 *** Keywords ***
@@ -19,12 +20,12 @@ Set UEFI Option
     Login To Linux
     Switch To Root User
     Get Flashrom From Cloud
-    Execute Linux Command    flashrom -p internal -r coreboot.rom --fmap -i FMAP -i SMMSTORE &> /dev/null
+    Execute Command In Terminal    flashrom -p internal -r coreboot.rom --fmap -i FMAP -i SMMSTORE &> /dev/null
     SSHLibrary.Get File    coreboot.rom    dcu/coreboot.rom
     # TODO error handling
     Run    cd dcu && ./dcu v coreboot.rom --set "${option_name}" --value "${value}"
     SSHLibrary.Put File    dcu/coreboot.rom    coreboot.rom
-    Execute Linux Command    flashrom -p internal -w coreboot.rom --fmap -i SMMSTORE --noverify-all &> /dev/null
+    Execute Command In Terminal    flashrom -p internal -w coreboot.rom --fmap -i SMMSTORE --noverify-all &> /dev/null
     Execute Reboot Command
     # Assume we don't have serial to tell us that we've rebooted, so just wait
     # 20s for shutdown to finish, to prevent subsequent kwds from running before

--- a/lib/options/dcu.robot
+++ b/lib/options/dcu.robot
@@ -1,0 +1,14 @@
+*** Settings ***
+Documentation       Library for UEFI configuration using Dasharo Configuration
+...                 Utility tool. Commonly used when serial port is not
+...                 available.
+
+Library             Collections
+Library             String
+
+
+*** Keywords ***
+Set UEFI Option
+    [Documentation]    Set an UEFI option to a value.
+    [Arguments]    ${option_name}    ${value}
+    Skip    I am a dummy! ${option_name} ${value}

--- a/lib/options/uefi-setup-menu.robot
+++ b/lib/options/uefi-setup-menu.robot
@@ -1,0 +1,34 @@
+*** Settings ***
+Documentation       Library for UEFI configuration using the UEFI setup menu
+...                 app (e.g. over serial port)
+
+Library             Collections
+Library             String
+Resource            ../bios/menus.robot
+
+
+*** Keywords ***
+Set UEFI Option
+    [Documentation]    Set an UEFI option to a value.
+    ...    TODO: Only works with options following the submenu/submenu/option
+    ...    pattern (e.g. all Dasharo System Features options).
+    [Arguments]    ${option_name}    ${value}
+    Skip If    not ${TESTS_IN_FIRMWARE_SUPPORT}    Can not configure UEFI settings on this platform.
+
+    TRY
+        @{option_path}=    Option Name To UEFI Path    ${option_name}
+    EXCEPT
+        Skip    Setting option ${option_name} is currently unimplemented.
+    END
+
+    Power On
+    ${setup_menu}=    Enter Setup Menu Tianocore And Return Construction
+    ${submenu_l1}=    Enter Submenu From Snapshot And Return Construction
+    ...    ${setup_menu}
+    ...    ${option_path[0]}
+    ${submenu_l2}=    Enter Submenu From Snapshot And Return Construction
+    ...    ${submenu_l1}
+    ...    ${option_path[1]}
+    ...    opt_only=${TRUE}
+    Set Option State    ${submenu_l2}    ${option_path[2]}    ${value}
+    Save Changes And Reset

--- a/lib/options/uefi-setup-menu.robot
+++ b/lib/options/uefi-setup-menu.robot
@@ -22,13 +22,14 @@ Set UEFI Option
     END
 
     Power On
-    ${setup_menu}=    Enter Setup Menu Tianocore And Return Construction
-    ${submenu_l1}=    Enter Submenu From Snapshot And Return Construction
-    ...    ${setup_menu}
-    ...    ${option_path[0]}
-    ${submenu_l2}=    Enter Submenu From Snapshot And Return Construction
-    ...    ${submenu_l1}
-    ...    ${option_path[1]}
-    ...    opt_only=${TRUE}
-    Set Option State    ${submenu_l2}    ${option_path[2]}    ${value}
+    ${menu}=    Enter Setup Menu Tianocore And Return Construction
+
+    ${path_len}=    Get Length    ${option_path}
+    FOR    ${i}    IN RANGE    ${path_len} - 1
+        ${menu}=    Enter Submenu From Snapshot And Return Construction
+        ...    ${menu}
+        ...    ${option_path[${i}]}
+    END
+
+    Set Option State    ${menu}    ${option_path[${path_len}-1]}    ${value}
     Save Changes And Reset

--- a/platform-configs/include/default.robot
+++ b/platform-configs/include/default.robot
@@ -1,5 +1,6 @@
 *** Settings ***
 Resource    ../../os-config/ubuntu-credentials.robot
+Resource    ../../lib/options/${OPTIONS_LIB}.robot
 
 
 *** Variables ***
@@ -26,6 +27,12 @@ ${INTERNAL_PROGRAMMER_CHIPNAME}=                    Opaque flash chip
 
 # See: https://github.com/Dasharo/dasharo-issues/issues/614
 ${LAPTOP_EC_SERIAL_WORKAROUND}=                     ${FALSE}
+
+# Library config
+# Option library: UEFI configuration variable backend.
+# - uefi-setup-menu: Will set options via the UEFI Setup menu (serial)
+# - dcu: Will use Dasharo Configuration Utility to configure options.
+${OPTIONS_LIB}=                                     uefi-setup-menu
 
 # OS config
 ${DEVICE_WINDOWS_USERNAME}=                         user

--- a/platform-configs/include/novacustom-common.robot
+++ b/platform-configs/include/novacustom-common.robot
@@ -6,10 +6,9 @@ Resource    default.robot
 # For the pikvm connection, we switch between pikvm/SSH when in firmware/OS.
 # We need to go back to the initial method (pikvm) when switching back from
 # OS to firmware (e.g. when rebooting inside a single test case).
-${INITIAL_DUT_CONNECTION_METHOD}=                   pikvm
+${INITIAL_DUT_CONNECTION_METHOD}=                   SSH
 ${DUT_CONNECTION_METHOD}=                           ${INITIAL_DUT_CONNECTION_METHOD}
 ${PAYLOAD}=                                         tianocore
-${RTE_S2_N_PORT}=                                   13541
 ${TIANOCORE_STRING}=                                to boot directly
 ${BOOT_MENU_KEY}=                                   F7
 ${SETUP_MENU_KEY}=                                  F2
@@ -30,11 +29,13 @@ ${DMIDECODE_VENDOR}=                                3mdeb
 ${DMIDECODE_FAMILY}=                                Not Applicable
 ${DMIDECODE_TYPE}=                                  Notebook
 
+${OPTIONS_LIB}=                                     dcu
+
 ${DEVICE_USB_KEYBOARD}=                             Logitech, Inc. Keyboard K120
 ${CLEVO_USB_C_HUB}=                                 4-port
 ${3_MDEB_WIFI_NETWORK}=                             3mdeb_abr
 # Supported test environments
-${TESTS_IN_FIRMWARE_SUPPORT}=                       ${TRUE}
+${TESTS_IN_FIRMWARE_SUPPORT}=                       ${FALSE}
 ${TESTS_IN_UBUNTU_SUPPORT}=                         ${TRUE}
 ${TESTS_IN_WINDOWS_SUPPORT}=                        ${FALSE}
 
@@ -133,7 +134,6 @@ Power On
     ...    into Power On state from Mechanical Off. (coldboot) For example:
     ...    sonoff, RTE relays.
     Restore Initial DUT Connection Method
-    IF    '${DUT_CONNECTION_METHOD}' == 'SSH'    RETURN
     Power Cycle On
     Sleep    2s
     RteCtrl Set OC GPIO    12    low

--- a/scripts/check-unused-variables.sh
+++ b/scripts/check-unused-variables.sh
@@ -33,7 +33,7 @@ fi
 # Loop through each provided robot variable file
 for robot_variable_file in "$@"; do
     # Specify the file paths to search for variable usage
-    file_paths=("dasharo-compatibility" "dasharo-security" "dasharo-performance" "dasharo-stability" "lib" "keywords.robot")
+    file_paths=("dasharo-compatibility" "dasharo-security" "dasharo-performance" "dasharo-stability" "lib" "keywords.robot" "platform-configs")
 
     # Read variables from the specified robot variable file (only consider the leftmost variable on each line)
     mapfile -t variables < <(awk -F'=' '/^\$\{[^}]+\}=/{gsub(/[[:space:]]/, "", $1); print $1}' "$robot_variable_file" | sort -u)


### PR DESCRIPTION
Introduce libraries for setting options. Tests will use one of these to configure options, and the actual mechanism (serial, DCU...) will be opaque.