### PR TITLE
platform-configs: protectli-v1x10: USB stack/menu not supported

### DIFF
--- a/platform-configs/include/protectli-v1x10.robot
+++ b/platform-configs/include/protectli-v1x10.robot
@@ -27,6 +27,10 @@ ${DMIDECODE_TYPE}=                  Desktop
 ${NVME_DISK_SUPPORT}=               ${TRUE}
 ${MEASURED_BOOT_SUPPORT}=           ${TRUE}
 
+${DASHARO_USB_MENU_SUPPORT}=        ${FALSE}
+${USB_STACK_SUPPORT}=               ${FALSE}
+${USB_MASS_STORAGE_SUPPORT}=        ${FALSE}
+
 
 *** Keywords ***
 Power On


### PR DESCRIPTION
No USB settings in `Dasharo System Features` on Protectli  v1x10