### PR TITLE
Fix usb-detect tests

### DIFF
--- a/dasharo-compatibility/usb-boot.robot
+++ b/dasharo-compatibility/usb-boot.robot
@@ -50,10 +50,10 @@ UBT001.001 USB detect and boot after coldboot
             END
         EXCEPT
             ${failed_boot}=    Evaluate    ${failed_boot} + 1
+            IF    '${failed_boot}' > '${ALLOWED_FAILS_USB_BOOT}'
+                Fail    Boot from USB failed too many times (${failed_boot})
+            END
         END
-    END
-    IF    '${failed_boot}' > '${ALLOWED_FAILS_USB_BOOT}'
-        Fail    Boot from USB failed too many times (${failed_boot})
     END
 
 UBT002.001 USB detect and boot after warmboot
@@ -78,10 +78,10 @@ UBT002.001 USB detect and boot after warmboot
             END
         EXCEPT
             ${failed_boot}=    Evaluate    ${failed_boot} + 1
+            IF    '${failed_boot}' > '${ALLOWED_FAILS_USB_BOOT}'
+                Fail    Boot from USB failed too many times (${failed_boot})
+            END
         END
-    END
-    IF    '${failed_boot}' > '${ALLOWED_FAILS_USB_BOOT}'
-        Fail    Boot from USB failed too many times (${failed_boot})
     END
 
 UBT003.001 USB detect and boot after system reboot
@@ -97,16 +97,16 @@ UBT003.001 USB detect and boot after system reboot
             Power On
             Boot System Or From Connected Disk    ${usb}
             IF    '${PLATFORM}' != 'raptor-cs_talos2'    Reboot Via Linux On USB
-            IF    '${PLATFORM}' == 'raptor-cs_talos2'    Login To Linux
             IF    '${PLATFORM}' == 'raptor-cs_talos2'
+                Login To Linux
                 Write Into Terminal    reboot
             END
         EXCEPT
             ${failed_boot}=    Evaluate    ${failed_boot} + 1
+            IF    '${failed_boot}' > '${ALLOWED_FAILS_USB_BOOT}'
+                Fail    Boot from USB failed too many times (${failed_boot})
+            END
         END
-    END
-    IF    '${failed_boot}' > '${ALLOWED_FAILS_USB_BOOT}'
-        Fail    Boot from USB failed too many times (${failed_boot})
     END
 
 

--- a/dasharo-compatibility/usb-detect.robot
+++ b/dasharo-compatibility/usb-detect.robot
@@ -54,10 +54,10 @@ UDT001.001 USB detection after coldboot
             Should Be Equal As Integers    ${usb}    ${usb_count}
         EXCEPT
             ${failed_detection}=    Evaluate    ${FAILED_DETECTION} + 1
+            IF    '${failed_detection}' > '${ALLOWED_FAILS_USB_DETECT}'
+                Fail    Detection failed too many times (${failed_detection})
+            END
         END
-    END
-    IF    '${failed_detection}' > '${ALLOWED_FAILS_USB_DETECT}'
-        Fail    Detection failed too many times (${failed_detection})
     END
 
 UDT002.001 USB detection after warmboot
@@ -86,10 +86,10 @@ UDT002.001 USB detection after warmboot
             Should Be Equal As Integers    ${usb}    ${usb_count}
         EXCEPT
             ${failed_detection}=    Evaluate    ${FAILED_DETECTION} + 1
+            IF    '${failed_detection}' > '${ALLOWED_FAILS_USB_DETECT}'
+                Fail    Detection failed too many times (${failed_detection})
+            END
         END
-    END
-    IF    '${failed_detection}' > '${ALLOWED_FAILS_USB_DETECT}'
-        Fail    Detection failed too many times (${failed_detection})
     END
 
 UDT003.001 USB detection after system reboot
@@ -126,10 +126,10 @@ UDT003.001 USB detection after system reboot
             Should Be Equal As Integers    ${usb}    ${usb_count}
         EXCEPT
             ${failed_detection}=    Evaluate    ${failed_detection} + 1
+            IF    '${failed_detection}' > '${ALLOWED_FAILS_USB_DETECT}'
+                Fail    Detection failed too many times (${failed_detection})
+            END
         END
-    END
-    IF    '${failed_detection}' > '${ALLOWED_FAILS_USB_DETECT}'
-        Fail    Detection failed too many times (${failed_detection})
     END
 
 

--- a/dasharo-compatibility/usb-detect.robot
+++ b/dasharo-compatibility/usb-detect.robot
@@ -39,16 +39,7 @@ UDT001.001 USB detection after coldboot
         TRY
             ${usb}=    Evaluate    0
             Power Cycle On
-            IF    '${PAYLOAD}' == 'tianocore'
-                Enter Boot Menu Tianocore
-                ${menu}=    Read From Terminal Until    ESC to exit
-            ELSE IF    '${PAYLOAD}' == 'seabios'
-                ${menu}=    Enter SeaBIOS And Return Menu
-            ELSE IF    '${PAYLOAD}' == 'petitboot'
-                ${menu}=    Enter Petitboot And Return Menu
-            ELSE
-                ${menu}=    FAIL    Unknown payload: ${PAYLOAD}
-            END
+            ${menu}=    Enter Boot Menu Tianocore And Return Construction
             FOR    ${stick}    IN    @{ATTACHED_USB}
                 ${usb_tmp}=    Get Count    ${menu}    ${stick}
                 ${usb}=    Evaluate    ${usb} + ${usb_tmp}
@@ -80,15 +71,7 @@ UDT002.001 USB detection after warmboot
         TRY
             ${usb}=    Evaluate    0
             Power On
-            IF    '${PAYLOAD}' == 'tianocore'
-                ${menu}=    Enter Tianocore And Return Menu
-            ELSE IF    '${PAYLOAD}' == 'seabios'
-                ${menu}=    Enter SeaBIOS And Return Menu
-            ELSE IF    '${PAYLOAD}' == 'petitboot'
-                ${menu}=    Enter Petitboot And Return Menu
-            ELSE
-                ${menu}=    FAIL    Unknown payload: ${PAYLOAD}
-            END
+            ${menu}=    Enter Boot Menu Tianocore And Return Construction
             FOR    ${stick}    IN    @{ATTACHED_USB}
                 ${usb_tmp}=    Get Count    ${menu}    ${stick}
                 ${usb}=    Evaluate    ${usb} + ${usb_tmp}
@@ -128,15 +111,7 @@ UDT003.001 USB detection after system reboot
             ELSE
                 FAIL    Unknown payload: ${PAYLOAD}
             END
-            IF    '${PAYLOAD}' == 'tianocore'
-                ${menu}=    Enter Tianocore And Return Menu
-            ELSE IF    '${PAYLOAD}' == 'seabios'
-                ${menu}=    Enter SeaBIOS And Return Menu
-            ELSE IF    '${PAYLOAD}' == 'petitboot'
-                ${menu}=    Enter Petitboot And Return Menu
-            ELSE
-                ${menu}=    FAIL    Unknown payload: ${PAYLOAD}
-            END
+            ${menu}=    Enter Boot Menu Tianocore And Return Construction
             FOR    ${stick}    IN    @{ATTACHED_USB}
                 ${usb_tmp}=    Get Count    ${menu}    ${stick}
                 ${usb}=    Evaluate    ${usb} + ${usb_tmp}


### PR DESCRIPTION
PR removes non existing keywords and fixes `Enter Tianocore And Return Menu` keyword.
Also test to check if test should fail was moved inside try/except block to Fail test immediately when number of failed tries goes above some threshold (no need to wait for 5 fails if test would fail anyway after first one)
Related to https://github.com/Dasharo/open-source-firmware-validation/pull/312