### PR TITLE
Add trenchboot tests

### DIFF
--- a/.codespellx
+++ b/.codespellx
@@ -1,2 +1,2 @@
   -device hda-duplex,audiodev=hda \
-  -audiodev pa,id=hda,server=unix:/run/user/1000/pulse/native,out.frequency=44100 \
+  -audiodev pa,id=hda,server=${PULSE_SERVER},out.frequency=44100 \

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ FW_FILE=$FW_FILE DEVICE_IP=$DEVICE_IP RTE_IP=$RTE_IP CONFIG=$CONFIG ./scripts/re
 
 ## Run sample test
 
-Start quemu:
+Start qemu:
 
 '''
 ./scripts/ci/qemu-run.sh graphic firmware
@@ -212,7 +212,7 @@ robot  -L TRACE -v config:qemu -v rte_ip:127.0.0.1 -v snipeit:no \
 -t "PXE007.001*" dasharo-compatibility/network-boot.robot
 '''
 
-If everything is setup correctly, you should see tests progress in quemu.
+If everything is setup correctly, you should see tests progress in qemu.
 After the test ends log files 'output.xml' 'log.html' and 'report.html' can be
 found in 'open-source-firmware-validation' folder.
 

--- a/dasharo-security/measured-boot.robot
+++ b/dasharo-security/measured-boot.robot
@@ -13,6 +13,7 @@ Resource            ../rtectrl-rest-api/rtectrl.robot
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot
+Resource            ../lib/tpm.robot
 
 # TODO:
 # - document which setup/teardown keywords to use and what are they doing
@@ -42,18 +43,7 @@ MBO001.001 Measured Boot support
 MBO002.001 Check if event log PCRs match actual values
     [Documentation]    Check whether PCRs values calculated from event log match
     ...    actual PCRs values
-    ${tpm2_eventlog}=    Execute Command In Terminal
-    ...    tpm2_eventlog /sys/kernel/security/tpm0/binary_bios_measurements
-    Should Not Contain    ${tpm2_eventlog}    ERROR: Unable to run tpm2_eventlog
-    FOR    ${algo}    IN    sha1    sha256
-        ${eventlog_pcrs}=    Get PCRs From Eventlog    ${tpm2_eventlog}    ${algo}
-        FOR    ${pcr_element}    IN    @{eventlog_pcrs}
-            ${pcr}    ${hash}=    Split String    ${pcr_element}    separator=:
-            ${sha_hash}=    Execute Command In Terminal
-            ...    cat /sys/class/tpm/tpm0/pcr-${algo}/${pcr}
-            Should Contain    ${hash}    ${sha_hash}    ignore_case=${TRUE}
-        END
-    END
+    Validate PCRs Against Event Log    /sys/kernel/security/tpm0/binary_bios_measurements
 
 MBO003.001 Changing Secure Boot certificate changes only PCR-7
     [Documentation]    Check if changes to Secure Boot certificates influence
@@ -66,7 +56,7 @@ MBO003.001 Changing Secure Boot certificate changes only PCR-7
     Save Changes And Reset
 
     Boot Ubuntu And Login To Root
-    ${default_hashes}=    Get PCRs State From Linux
+    ${default_hashes}=    Get PCRs State From Linux    ${PCRS_TO_CHECK}
 
     Power On
     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
@@ -97,7 +87,7 @@ MBO004.001 Changing Dasharo network boot settings changes only PCR-1
     Skip If    not ${DASHARO_NETWORKING_MENU_SUPPORT}    Tests in Dasharo Networking Menu are not supported
     Power On
     Boot Ubuntu And Login To Root
-    @{hashes_before_changes}=    Get PCRs State From Linux
+    @{hashes_before_changes}=    Get PCRs State From Linux    ${PCRS_TO_CHECK}
 
     Power On
     ${menu}=    Enter Setup Menu Tianocore And Return Construction
@@ -126,7 +116,7 @@ MBO004.002 Changing Dasharo USB settings changes only PCR-1
     Skip If    not ${USB_MASS_STORAGE_SUPPORT}    Tests in Dasharo USB Menu are not supported
     Power On
     Boot Ubuntu And Login To Root
-    @{hashes_before_changes}=    Get PCRs State From Linux
+    @{hashes_before_changes}=    Get PCRs State From Linux    ${PCRS_TO_CHECK}
 
     Power On
     ${menu}=    Enter Setup Menu Tianocore And Return Construction
@@ -155,7 +145,7 @@ MBO004.003 Changing Dasharo APU settings changes only PCR-1
     Skip If    not ${APU_CONFIGURATION_MENU_SUPPORT}    Tests in Dasharo APU Menu are not supported
     Power On
     Boot Ubuntu And Login To Root
-    @{hashes_before_changes}=    Get PCRs State From Linux
+    @{hashes_before_changes}=    Get PCRs State From Linux    ${PCRS_TO_CHECK}
 
     Power On
     ${menu}=    Enter Setup Menu Tianocore And Return Construction
@@ -187,12 +177,12 @@ MBO005.001 Flashing firmware and reset to defaults results in same measurement
 
     Power Cycle On
     Boot Ubuntu And Login To Root
-    ${default_pcr_state}=    Get PCRs State From Linux
+    ${default_pcr_state}=    Get PCRs State From Linux    ${PCRS_TO_CHECK}
 
     Restore SB And Tianocore Defaults And Reset
 
     Boot Ubuntu And Login To Root
-    ${reset_pcr_state}=    Get PCRs State From Linux
+    ${reset_pcr_state}=    Get PCRs State From Linux    ${PCRS_TO_CHECK}
     Lists Should Be Equal    ${default_pcr_state}    ${reset_pcr_state}
 
 MBO005.002 Multiple reset to defaults results in identical measurements
@@ -282,39 +272,6 @@ MBO006.002 Identical configuration after reset results in identical measurements
 
 
 *** Keywords ***
-Get PCRs From Eventlog
-    [Documentation]    Returns PCRs from Eventlog as a list of strings:
-    ...    ["<pcr>:<hash>"] with spaces removed
-    [Arguments]    ${eventlog}    ${sha}
-    @{eventlog}=    Split To Lines    ${eventlog}
-    ${sha_index_start}=    Get Index From List Regexp
-    ...    ${eventlog}    ${sha}:
-    Run Keyword And Return If    ${sha_index_start} == -1    Create List
-    ${sha_index_start}=    Evaluate    ${sha_index_start} + 1
-    ${sha_index_end}=    Get Index From List Regexp
-    ...    ${eventlog}    sha[0-9]+:    start=${sha_index_start}
-    IF    ${sha_index_end} == -1
-        ${sha_index_end}=    Set Variable    ${NONE}
-    END
-    ${pcrs}=    Get Slice From List
-    ...    ${eventlog}    ${sha_index_start}    ${sha_index_end}
-    FOR    ${index}    ${element}    IN ENUMERATE    @{pcrs}
-        ${stripped_element}=    Remove String    ${element}    ${SPACE}
-        Set List Value    ${pcrs}    ${index}    ${stripped_element}
-    END
-    RETURN    ${pcrs}
-
-Get Index From List Regexp
-    [Documentation]    Same as "Get Index From List" but with regexp
-    [Arguments]    ${list}    ${regexp}    ${start}=0    ${end}=None
-    ${list}=    Get Slice From List    ${list}    ${start}    ${end}
-    FOR    ${index}    ${element}    IN ENUMERATE    @{list}    start=${start}
-        ${found}=    Run Keyword And Return Status
-        ...    Should Match Regexp    ${element}    ${regexp}
-        IF    ${found} == ${TRUE}    RETURN    ${index}
-    END
-    RETURN    -1
-
 Get Default PCRs State
     [Documentation]    First time this keyword is called it resets platform
     ...    configuration to default and then returns PCRs values. Next call
@@ -324,24 +281,10 @@ Get Default PCRs State
     IF    ${default_pcr_state} is ${NONE}
         Restore SB And Tianocore Defaults And Reset
         Boot Ubuntu And Login To Root
-        ${default_pcr_state}=    Get PCRs State From Linux
+        ${default_pcr_state}=    Get PCRs State From Linux    ${PCRS_TO_CHECK}
         Set Suite Variable    $DEFAULT_PCR_STATE_SUITE    ${default_pcr_state}
     END
     RETURN    ${default_pcr_state}
-
-Get PCRs State From Linux
-    [Documentation]    Returns list of strings containing
-    ...    ["<path_to_pcr>:<hash>"]. Should be called when logged in Linux
-    [Arguments]    ${pcr_glob}=${PCRS_TO_CHECK}
-    Execute Command In Terminal    shopt -s extglob
-    # grep returns file path and it's content i.e.
-    # "/sys/class/tpm/tpm0/pcr-sha1/0:", each in
-    # new line
-    ${hashes}=    Execute Command In Terminal
-    ...    grep -H . /sys/class/tpm/tpm0/pcr-sha*/@(${pcr_glob})
-    Should Not Contain    ${hashes}    No such file or directory
-    ${pcr_state}=    Split To Lines    ${hashes}
-    RETURN    ${pcr_state}
 
 Boot Ubuntu And Login To Root
     [Documentation]    Boots Ubuntu and logins as root

--- a/lib/bios/menus.robot
+++ b/lib/bios/menus.robot
@@ -575,6 +575,9 @@ Boot System Or From Connected Disk
         IF    "${system_name}" == "ubuntu"
             ${system_name}=    Set Variable    Ubuntu
         END
+        IF    "${system_name}" == "trenchboot" and "${MANUFACTURER}" == "QEMU"
+            ${system_name}=    Set Variable    QEMU HARDDISK
+        END
     END
     ${is_system_present}=    Evaluate    "${system_name}" in """${menu_construction}"""
     IF    not ${is_system_present}

--- a/lib/tpm.robot
+++ b/lib/tpm.robot
@@ -1,0 +1,69 @@
+*** Settings ***
+Library     OperatingSystem
+Library     String
+
+
+*** Keywords ***
+Get PCRs State From Linux
+    [Documentation]    Returns list of strings containing
+    ...    ["<path_to_pcr>:<hash>"]. Should be called when logged in Linux
+    [Arguments]    ${pcr_glob}
+    Execute Command In Terminal    shopt -s extglob
+    # grep returns file path and it's content i.e.
+    # "/sys/class/tpm/tpm0/pcr-sha1/0:", each in
+    # new line
+    ${hashes}=    Execute Command In Terminal
+    ...    grep -H . /sys/class/tpm/tpm0/pcr-sha*/@(${pcr_glob})
+    Should Not Contain    ${hashes}    No such file or directory
+    ${pcr_state}=    Split To Lines    ${hashes}
+    RETURN    ${pcr_state}
+
+Get PCRs From Eventlog
+    [Documentation]    Returns PCRs from Eventlog as a list of strings:
+    ...    ["<pcr>:<hash>"] with spaces removed
+    [Arguments]    ${eventlog}    ${sha}
+    @{eventlog}=    Split To Lines    ${eventlog}
+    ${sha_index_start}=    Get Index From List Regexp
+    ...    ${eventlog}    ${sha}:
+    Run Keyword And Return If    ${sha_index_start} == -1    Create List
+    ${sha_index_start}=    Evaluate    ${sha_index_start} + 1
+    ${sha_index_end}=    Get Index From List Regexp
+    ...    ${eventlog}    sha[0-9]+:    start=${sha_index_start}
+    IF    ${sha_index_end} == -1
+        ${sha_index_end}=    Set Variable    ${NONE}
+    END
+    ${pcrs}=    Get Slice From List
+    ...    ${eventlog}    ${sha_index_start}    ${sha_index_end}
+    FOR    ${index}    ${element}    IN ENUMERATE    @{pcrs}
+        ${stripped_element}=    Remove String    ${element}    ${SPACE}
+        Set List Value    ${pcrs}    ${index}    ${stripped_element}
+    END
+    RETURN    ${pcrs}
+
+Get Index From List Regexp
+    [Documentation]    Same as "Get Index From List" but with regexp
+    [Arguments]    ${list}    ${regexp}    ${start}=0    ${end}=None
+    ${list}=    Get Slice From List    ${list}    ${start}    ${end}
+    FOR    ${index}    ${element}    IN ENUMERATE    @{list}    start=${start}
+        ${found}=    Run Keyword And Return Status
+        ...    Should Match Regexp    ${element}    ${regexp}
+        IF    ${found} == ${TRUE}    RETURN    ${index}
+    END
+    RETURN    -1
+
+Validate PCRs Against Event Log
+    [Documentation]    Check that current PCRs values match result of replaying
+    ...    some binary event log
+    [Arguments]    ${binary_log_file}
+    ${tpm2_eventlog}=    Execute Command In Terminal
+    ...    tpm2_eventlog ${binary_log_file}
+    Should Not Contain    ${tpm2_eventlog}    ERROR: Unable to run tpm2_eventlog
+    FOR    ${algo}    IN    sha1    sha256
+        ${eventlog_pcrs}=    Get PCRs From Eventlog    ${tpm2_eventlog}    ${algo}
+        FOR    ${pcr_element}    IN    @{eventlog_pcrs}
+            ${pcr}    ${hash}=    Split String    ${pcr_element}    separator=:
+            ${sha_hash}=    Execute Command In Terminal
+            ...    cat /sys/class/tpm/tpm0/pcr-${algo}/${pcr}
+            Should Contain    ${hash}    ${sha_hash}    ignore_case=${TRUE}
+        END
+    END

--- a/lib/trenchboot.robot
+++ b/lib/trenchboot.robot
@@ -1,0 +1,15 @@
+*** Settings ***
+Library     Telnet    timeout=20 seconds    connection_timeout=120 seconds
+Resource    terminal.robot
+
+
+*** Keywords ***
+TrenchBoot Telnet Root Login
+    [Documentation]    Telnet login for Trenchboot
+    # The login is password-less which makes use of Telnet.Login very
+    # inconvenient.
+    Telnet.Read Until    login:
+    Telnet.Write    root
+    Telnet.Set Prompt    root@tb:~#
+    Telnet.Write Bare    \n
+    Telnet.Read Until Prompt

--- a/platform-configs/include/default.robot
+++ b/platform-configs/include/default.robot
@@ -71,6 +71,7 @@ ${TESTS_IN_FIRMWARE_SUPPORT}=                       ${FALSE}
 ${TESTS_IN_UBUNTU_SUPPORT}=                         ${FALSE}
 ${TESTS_IN_DEBIAN_SUPPORT}=                         ${FALSE}
 ${TESTS_IN_WINDOWS_SUPPORT}=                        ${FALSE}
+${TESTS_IN_METATB_SUPPORT}=                         ${FALSE}
 
 # Regression test flags
 ${DASHARO_SECURITY_MENU_SUPPORT}=                   ${FALSE}
@@ -191,6 +192,9 @@ ${TPM_DETECT_SUPPORT}=                              ${FALSE}
 ${NVME_DETECTION_SUPPORT}=                          ${FALSE}
 ${USB_TYPE-A_DEVICES_DETECTION_SUPPORT}=            ${FALSE}
 ${NETWORK_INTERFACE_AFTER_SUSPEND_SUPPORT}=         ${FALSE}
+
+# Test module: trenchboot
+${TRENCHBOOT_SUPPORT}=                              ${FALSE}
 
 # Test cases iterations number
 # Booting OS from USB stick test cases

--- a/platform-configs/include/pcengines.robot
+++ b/platform-configs/include/pcengines.robot
@@ -42,6 +42,7 @@ ${DMIDECODE_TYPE}=                          Desktop
 # Supported test environments
 ${TESTS_IN_FIRMWARE_SUPPORT}=               ${TRUE}
 ${TESTS_IN_UBUNTU_SUPPORT}=                 ${TRUE}
+${TESTS_IN_METATB_SUPPORT}=                 ${TRUE}
 
 # Regression test flags
 ${DASHARO_SECURITY_MENU_SUPPORT}=           ${TRUE}
@@ -98,6 +99,9 @@ ${PLATFORM_STABILITY_CHECKING}=             ${TRUE}
 # Test module: dasharo-stab
 ${TPM_DETECT_SUPPORT}=                      ${TRUE}
 ${USB_TYPE-A_DEVICES_DETECTION_SUPPORT}=    ${TRUE}
+
+# Test module: trenchboot
+${TRENCHBOOT_SUPPORT}=                      ${TRUE}
 
 
 *** Keywords ***

--- a/platform-configs/qemu.robot
+++ b/platform-configs/qemu.robot
@@ -24,6 +24,7 @@ ${DMIDECODE_TYPE}=                          Desktop
 # Supported test environments
 ${TESTS_IN_FIRMWARE_SUPPORT}=               ${TRUE}
 ${TESTS_IN_UBUNTU_SUPPORT}=                 ${TRUE}
+${TESTS_IN_METATB_SUPPORT}=                 ${TRUE}
 
 # Regression test flags
 ${DASHARO_SECURITY_MENU_SUPPORT}=           ${TRUE}
@@ -72,6 +73,9 @@ ${SERIAL_BOOT_MEASURE}=                     ${TRUE}
 ${CPU_FREQUENCY_MEASURE}=                   ${TRUE}
 ${CPU_TEMPERATURE_MEASURE}=                 ${TRUE}
 ${PLATFORM_STABILITY_CHECKING}=             ${TRUE}
+
+# Test module: trenchboot
+${TRENCHBOOT_SUPPORT}=                      ${TRUE}
 
 ${AUTO_BOOT_TIME_OUT_DEFAULT_VALUE}=        0
 

--- a/scripts/check-unused-variables.sh
+++ b/scripts/check-unused-variables.sh
@@ -33,7 +33,13 @@ fi
 # Loop through each provided robot variable file
 for robot_variable_file in "$@"; do
     # Specify the file paths to search for variable usage
-    file_paths=("dasharo-compatibility" "dasharo-security" "dasharo-performance" "dasharo-stability" "lib" "keywords.robot" "platform-configs")
+    file_paths=(
+        "dasharo-compatibility" "dasharo-security" "dasharo-performance" "dasharo-stability"
+        "lib"
+        "keywords.robot"
+        "platform-configs"
+        "trenchboot"
+    )
 
     # Read variables from the specified robot variable file (only consider the leftmost variable on each line)
     mapfile -t variables < <(awk -F'=' '/^\$\{[^}]+\}=/{gsub(/[[:space:]]/, "", $1); print $1}' "$robot_variable_file" | sort -u)

--- a/scripts/ci/qemu-run.sh
+++ b/scripts/ci/qemu-run.sh
@@ -19,6 +19,7 @@ then
 fi
 
 HDD_PATH=${HDD_PATH:-qemu-data/hdd.qcow2}
+PULSE_SERVER=${PULSE_SERVER:-unix:/run/user/$(id -u)/pulse/native}
 INSTALLER_PATH="qemu-data/ubuntu.iso"
 
 TPM_DIR="/tmp/osfv/tpm"
@@ -138,7 +139,7 @@ QEMU_PARAMS_BASE="-machine q35,smm=on \
 
 QEMU_PARAMS_OS="-device ich9-intel-hda \
   -device hda-duplex,audiodev=hda \
-  -audiodev pa,id=hda,server=unix:/run/user/1000/pulse/native,out.frequency=44100 \
+  -audiodev pa,id=hda,server=${PULSE_SERVER},out.frequency=44100 \
   -object rng-random,id=rng0,filename=/dev/urandom \
   -device virtio-rng-pci,max-bytes=1024,period=1000 \
   -device virtio-net,netdev=vmnic \

--- a/scripts/ci/qemu-run.sh
+++ b/scripts/ci/qemu-run.sh
@@ -18,7 +18,7 @@ then
     exit 1
 fi
 
-HDD_PATH="qemu-data/hdd.qcow2"
+HDD_PATH=${HDD_PATH:-qemu-data/hdd.qcow2}
 INSTALLER_PATH="qemu-data/ubuntu.iso"
 
 TPM_DIR="/tmp/osfv/tpm"
@@ -69,7 +69,7 @@ check_disks() {
 
   if [ ! -f "${HDD_PATH}" ]; then
     echo "Disk at ${HDD_PATH} not found. You can create one with:"
-    echo "qemu-img create -f qcow2 qemu-data/hdd.qcow 20G"
+    echo "qemu-img create -f qcow2 '${HDD_PATH}' 20G"
     exit 1
   fi
 

--- a/trenchboot/01-without-drtm.robot
+++ b/trenchboot/01-without-drtm.robot
@@ -1,0 +1,71 @@
+*** Settings ***
+Library             OperatingSystem
+Library             Telnet    timeout=20 seconds    connection_timeout=120 seconds
+Library             SSHLibrary    timeout=90 seconds
+Library             RequestsLibrary
+Resource            ../sonoff-rest-api/sonoff-api.robot
+Resource            ../rtectrl-rest-api/rtectrl.robot
+Resource            ../variables.robot
+Resource            ../keywords.robot
+Resource            ../keys.robot
+Resource            ../lib/trenchboot.robot
+Resource            ../lib/tpm.robot
+
+Suite Setup         TrenchBoot Suite Setup
+Suite Teardown      Run Keyword
+...                     Log Out And Close Connection
+# WOD -- WithOut Drtm
+#
+# These tests verify sanity of the platform when DRTM is not employed and should
+# precede tests with DRTM on.
+#
+# Supported TPM: 1.2 or 2.0 (SHA1 and/or SHA256 PCR banks)
+
+
+*** Test Cases ***
+WOD001.001 All cores are up
+    [Documentation]    Verifies that all CPUs are online without DRTM because
+    ...    it's easy to do and this could potentially catch an issue.
+    ${offline}=    Execute Command In Terminal
+    ...    cat /sys/devices/system/cpu/offline
+    Should Be Equal As Strings    ${offline}    ${EMPTY}
+    ...    Not all cores are up
+
+WOD002.001 SRTM event log exists
+    [Documentation]    SRTM event log should be present even without DRTM.
+    ${present}=    Execute Command In Terminal
+    ...    test -f /sys/kernel/security/tpm0/binary_bios_measurements && echo y
+    Should Be Equal As Strings    ${present}    y    msg=SRTM log is missing
+
+WOD003.001 DRTM PCRs are not updated without TB
+    [Documentation]    Checks that PCRs 17-22 have values of FF* when DRTM
+    ...    isn't active.
+
+    ${pcr_hashes}=    Get PCRs State From Linux    1[7-9]|2[0-2]
+    FOR    ${pcr_hash}    IN    @{pcr_hashes}
+        ${pcr}    ${hash}=    Split String    ${pcr_hash}    separator=:
+        ${unique_values_str}=    Evaluate    ''.join(set("${hash}"))
+        Should Be Equal    ${unique_values_str}    F    msg=${pcr}
+    END
+
+WOD004.001 DRTM event log doesn't exist
+    [Documentation]    Verifies that DRTM event log is missing without DRTM.
+    ${present}=    Execute Command In Terminal
+    ...    test -f /sys/kernel/security/slaunch/eventlog && echo y
+    Should Be Equal As Strings    ${present}    ${EMPTY}    msg=DRTM log is missing
+
+
+*** Keywords ***
+TrenchBoot Suite Setup
+    Prepare Test Suite
+
+    Skip If    not ${TPM_SUPPORT}    TPM tests not supported
+    Skip If    not ${TRENCHBOOT_SUPPORT}    TrenchBoot tests aren't supported
+    Skip If    not ${TESTS_IN_METATB_SUPPORT}    Tests in meta-trenchboot aren't supported
+
+    Power On
+    Boot System Or From Connected Disk    trenchboot
+    Read From Terminal Until    Press enter to boot the selected OS
+    Write Bare Into Terminal    ${ENTER}
+
+    TrenchBoot Telnet Root Login

--- a/trenchboot/02-with-drtm.robot
+++ b/trenchboot/02-with-drtm.robot
@@ -1,0 +1,133 @@
+*** Settings ***
+Library             OperatingSystem
+Library             Telnet    timeout=20 seconds    connection_timeout=120 seconds
+Library             SSHLibrary    timeout=90 seconds
+Library             RequestsLibrary
+Resource            ../sonoff-rest-api/sonoff-api.robot
+Resource            ../rtectrl-rest-api/rtectrl.robot
+Resource            ../variables.robot
+Resource            ../keywords.robot
+Resource            ../keys.robot
+Resource            ../lib/trenchboot.robot
+Resource            ../lib/tpm.robot
+
+Suite Setup         TrenchBoot Suite Setup
+Suite Teardown      Run Keyword
+...                     Log Out And Close Connection
+# WTD -- WiTh Drtm
+#
+# These tests verify sanity of the platform when DRTM is enabled.
+#
+# Supported TPM: 1.2 or 2.0 (SHA1 and/or SHA256 PCR banks)
+
+
+*** Test Cases ***
+WTD001.001 All cores are up
+    [Documentation]    Verifies that all CPUs are online with DRTM.
+    ${offline}=    Execute Command In Terminal
+    ...    cat /sys/devices/system/cpu/offline
+    Should Be Equal As Strings    ${offline}    ${EMPTY}
+    ...    Not all cores are up
+
+WTD002.001 DRTM PCRs are updated with TB
+    [Documentation]    Checks that DRTM changes 17-22 PCRs as it should.
+
+    ${pcr_hashes}=    Get PCRs State From Linux    1[7-8]
+    FOR    ${pcr_hash}    IN    @{pcr_hashes}
+        ${pcr}    ${hash}=    Split String    ${pcr_hash}    separator=:
+        ${unique_values_str}=    Evaluate    ''.join(set("${hash}"))
+        Should Not Be Equal    ${unique_values_str}    F    msg=${pcr}
+        Should Not Be Equal    ${unique_values_str}    0    msg=${pcr}
+    END
+
+    ${pcr_hashes}=    Get PCRs State From Linux    19|2[0-2]
+    FOR    ${pcr_hash}    IN    @{pcr_hashes}
+        ${pcr}    ${hash}=    Split String    ${pcr_hash}    separator=:
+        ${unique_values_str}=    Evaluate    ''.join(set("${hash}"))
+        Should Be Equal    ${unique_values_str}    0    msg=${pcr}
+    END
+
+WTD003.001 SRTM event log exists
+    [Documentation]    Verifies that SRTM event log is present with DRTM.
+    ${present}=    Execute Command In Terminal
+    ...    test -f /sys/kernel/security/tpm0/binary_bios_measurements && echo y
+    Should Be Equal As Strings    ${present}    y    msg=SRTM log is missing
+
+WTD004.001 DRTM event log exists
+    [Documentation]    Verifies that DRTM event log is present with DRTM.
+    ${present}=    Execute Command In Terminal
+    ...    test -f /sys/kernel/security/slaunch/eventlog && echo y
+    Should Be Equal As Strings    ${present}    y    msg=DRTM log is missing
+
+WTD005.001 DRTM event log has DRTM entries (AMD)
+    [Documentation]    Verifies that event log includes DRTM entries
+
+    ${cpuinfo}=    Execute Command In Terminal    cat /proc/cpuinfo
+    Skip If    "AuthenticAMD" not in """${cpuinfo}"""    Not an AMD CPU
+
+    ${present}=    Execute Command In Terminal
+    ...    test -f /sys/kernel/security/slaunch/eventlog && echo y
+    Skip If    "${present}" != "y"    DRTM log is missing
+
+    Execute Command In Terminal
+    ...    tpm2_eventlog /sys/kernel/security/slaunch/eventlog > /tmp/event-log
+    Execute Command In Terminal
+    ...    function to_hex() { echo -n "$1" | hexdump -ve '1/1 "%02x"'; }
+    Execute Command In Terminal
+    ...    function find_event() { sed -n "/\\s*PCRIndex: $1/,/Event: \\"/s/\\s*Event: \\"$(to_hex "$2")\\"/MATCH/p" /tmp/event-log; }
+
+    ${match}=    Execute Command In Terminal
+    ...    find_event 17 "SKINIT"
+    Should Be Equal As Strings    ${match}    MATCH    No "SKINIT" entry
+
+    ${match}=    Execute Command In Terminal
+    ...    find_event 17 "DLME entry offset"
+    Should Be Equal As Strings    ${match}    MATCH    No "DLME entry offset" entry
+
+    ${match}=    Execute Command In Terminal
+    ...    find_event 17 "DLME"
+    Should Be Equal As Strings    ${match}    MATCH    No "DLME" entry
+
+    # Early TPM code doesn't identify SLRT measurement event in any way.
+    ${match}=    Execute Command In Terminal
+    ...    find_event 18 ""
+    Should Be Equal As Strings    ${match}    MATCH    No SLRT entry
+
+    ${match}=    Execute Command In Terminal
+    ...    find_event 17 "Measured MB2 module"
+    Should Be Equal As Strings    ${match}    MATCH\nMATCH    No "Measured MB2 module" entries
+
+WTD006.001 DRTM log aligns with PCR values
+    [Documentation]    Verify that all DRTM measurements are correctly reflected
+    ...    in DRTM event log
+    Validate PCRs Against Event Log    /sys/kernel/security/slaunch/eventlog
+
+WTD007.001 SRTM log aligns with PCR values
+    [Documentation]    Verify that all SRTM measurements are correctly reflected
+    ...    in SRTM event log
+    Validate PCRs Against Event Log    /sys/kernel/security/tpm0/binary_bios_measurements
+
+
+*** Keywords ***
+TrenchBoot Suite Setup
+    Prepare Test Suite
+
+    Skip If    not ${TPM_SUPPORT}    TPM tests not supported
+    Skip If    not ${TRENCHBOOT_SUPPORT}    TrenchBoot tests aren't supported
+    Skip If    not ${TESTS_IN_METATB_SUPPORT}    Tests in meta-trenchboot aren't supported
+
+    Power On
+    Boot System Or From Connected Disk    trenchboot
+    Read From Terminal Until    Press enter to boot the selected OS
+    # Slaunch is the second boot option, pick it.
+    Write Bare Into Terminal    ${ARROW_DOWN}
+    Write Bare Into Terminal    ${ENTER}
+
+    # Permit trying running the tests in QEMU even though DRTM sequence won't
+    # work
+    IF    "${MANUFACTURER}" != "QEMU"
+        ${grub_out}=    Read From Terminal Until    Press any key to continue...
+        Should Not Contain    ${grub_out}    error: secure launch not enabled.
+    END
+
+    TrenchBoot Telnet Root Login


### PR DESCRIPTION
So far run it in Qemu which doesn't allow testing of DRTM, but most of test cases do pass.

Start Qemu:

    HDD_PATH=tb-minimal-image-genericx86-64.rootfs.wic scripts/ci/qemu-run.sh graphic os

Run tests:


    CONFIG=qemu RTE_IP=127.0.0.1 SNIPEIT_NO=1 scripts/run.sh trenchboot

***

Questionable things:
 - update `scripts/stats.py`?
 - add module to `README.md`? it's not strictly a Dasharo module

***

Currently the new tests won't completely pass anywhere, so maybe this shouldn't be merged until this changes.