### PR TITLE
30B add tags to tests for minimum regression test scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@ robot -L TRACE -v snipeit:no -v rte_ip:$RTE_IP -v config:$CONFIG \
 $TEST_MODULE
 ```
 
+Any additional parameters to `robot` can be passed using the wrapper by giving
+them as the second and further arguments to the script.
+
 ### Running tests via wrapper
 
 Test can be run directly via `robot` command, but also via the `run.sh`
@@ -219,6 +222,14 @@ SONOFF_IP=$SONOFF_IP PIKVM_IP=$PIKVM_IP
 
 Mind that `SNIPEIT_NO`, only need to be set, meaning that whatever value it
 has, it will be treated as true.
+
+### Running tests with additional arguments
+
+For example: specifying the tests to perform by giving a tag name:
+
+```bash
+DEVICE_IP=$DEVICE_IP RTE_IP=$RTE_IP CONFIG=$CONFIG ./scripts/run.sh $TEST_SUITE --include "minimal-regression"
+```
 
 ### Running regression tests
 

--- a/dasharo-compatibility/auto-boot-time-out.robot
+++ b/dasharo-compatibility/auto-boot-time-out.robot
@@ -48,6 +48,7 @@ BMM001.001 Change Auto Boot Time-out and check after reboot
 BMM002.001 F9 resets Auto Boot Time-out to default value
     [Documentation]    Check whether pressing F9 resets Auto Boot Time-out to
     ...    default value
+    [Tags]    minimal-regression
     Skip If    not ${RESET_TO_DEFAULTS_SUPPORT}    BMM002.001 not supported
     Skip If    not ${TESTS_IN_FIRMWARE_SUPPORT}    BMM002.001 not supported
     Power On

--- a/dasharo-compatibility/dmidecode.robot
+++ b/dasharo-compatibility/dmidecode.robot
@@ -42,6 +42,7 @@ DMI001.001 Verify the device serial number
 DMI002.001 Verify the firmware version
     [Documentation]    Check whether the firmware version on the DUT is the
     ...    same as it is expected.
+    [Tags]    minimal-regression
     Skip If    not ${FIRMWARE_NUMBER_VERIFICATION}    DMI002.001 not supported
     Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    DMI001.002 not supported
     Power On
@@ -57,6 +58,7 @@ DMI002.001 Verify the firmware version
 DMI003.001 Verify the firmware product name
     [Documentation]    Check whether the DUT product name is the same as it is
     ...    expected.
+    [Tags]    minimal-regression
     Skip If    not ${PRODUCT_NAME_VERIFICATION}    DMI003.001 not supported
     Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    DMI003.001 not supported
     Power On

--- a/dasharo-compatibility/network-boot.robot
+++ b/dasharo-compatibility/network-boot.robot
@@ -67,6 +67,7 @@ PXE003.001 Autoboot option is available and works correctly
 PXE004.001 DTS option is available and works correctly
     [Documentation]    This test aims to verify that the Dasharo Tools Suite
     ...    option in Dasharo Network Boot Menu allows booting into DTS.
+    [Tags]    minimal-regression
     Skip If    not ${TESTS_IN_FIRMWARE_SUPPORT}    PXE004.001 not supported
     Power On
     ${boot_menu}=    Enter Boot Menu Tianocore And Return Construction

--- a/dasharo-compatibility/usb-hid-and-msc-support.robot
+++ b/dasharo-compatibility/usb-hid-and-msc-support.robot
@@ -63,6 +63,7 @@ USB002.001 USB keyboard detected in FW
     [Documentation]    Check whether the external USB keyboard is detected
     ...    correctly by the firmware and all basic keys work
     ...    according to their labels.
+    [Tags]    minimal-regression
     Power On
     Enter UEFI Shell
     ${out}=    Execute UEFI Shell Command    devices

--- a/dasharo-compatibility/wifi-bluetooth-support.robot
+++ b/dasharo-compatibility/wifi-bluetooth-support.robot
@@ -65,6 +65,7 @@ WLE002.001 Wi-Fi scanning (Ubuntu)
     [Documentation]    Check whether the Wi-Fi functionality of card is
     ...    initialized correctly and can be used from within the
     ...    operating system..
+    [Tags]    minimal-regression
     Skip If    not ${WIRELESS_CARD_WIFI_SUPPORT}    WLE002.001 not supported
     Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    WLE002.001 not supported
     Log To Console    Remember to test all variants of wireless cards.

--- a/dasharo-performance/platform-stability.robot
+++ b/dasharo-performance/platform-stability.robot
@@ -120,6 +120,7 @@ STB001.003 Verify if no reboot occurs in the OS (Windows)
 STB002.001 Verify if no unexpected boot errors appear in Linux logs
     [Documentation]    This test aims to verify that there are no unexpected
     ...    error ,essages in Linux kernel logs.
+    [Tags]    minimal-regression
     Skip If    not ${PLATFORM_STABILITY_CHECKING}    STB002.001 not supported
 
     Power On

--- a/dasharo-security/tpm-support.robot
+++ b/dasharo-security/tpm-support.robot
@@ -79,6 +79,7 @@ TPM002.001 Verify TPM version (firmware)
 TPM002.002 Verify TPM version (Ubuntu)
     [Documentation]    This test aims to verify that the TPM version is
     ...    correctly recognized by the operating system.
+    [Tags]    minimal-regression
     Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    TPM002.002 not supported
     Power On
     Boot System Or From Connected Disk    ubuntu

--- a/scripts/lib/robot.sh
+++ b/scripts/lib/robot.sh
@@ -34,6 +34,7 @@ execute_robot() {
   #   - path to directory containing a set of .robot files
   #   - path to a single .robot file
   local _test_path=$1
+  local _robot_args=${@:2}
   local _test_name=""
   _test_name="$(basename ${_test_path%.robot})"
 
@@ -80,6 +81,7 @@ execute_robot() {
   local _output_file="${_logs_dir}/${_test_name}_out.xml"
   local _debug_file="${_logs_dir}/${_test_name}_debug.log"
 
+command="
   robot -L TRACE \
         -l ${_log_file} \
         -r ${_report_file} \
@@ -91,5 +93,9 @@ execute_robot() {
         ${fw_file_option} \
         ${installed_dut_option} \
         ${extra_options} \
+        ${_robot_args} \
         ${_test_path}
+        "
+    echo $command
+    eval $command
 }

--- a/scripts/lib/robot.sh
+++ b/scripts/lib/robot.sh
@@ -34,7 +34,7 @@ execute_robot() {
   #   - path to directory containing a set of .robot files
   #   - path to a single .robot file
   local _test_path=$1
-  local _robot_args=${@:2}
+  local _robot_args=${*:2}
   local _test_name=""
   _test_name="$(basename ${_test_path%.robot})"
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -27,4 +27,4 @@ if [ "$#" -eq 0 ] || [ ! -e "$1" ]; then
   exit 1
 fi
 
-execute_robot "$1"
+execute_robot "$1" "${@:2}"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -27,4 +27,4 @@ if [ "$#" -eq 0 ] || [ ! -e "$1" ]; then
   exit 1
 fi
 
-execute_robot "$1" "${@:2}"
+execute_robot "$@"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo ${@:1}
+echo ${@:2}
+echo ${@:3}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-echo ${@:1}
-echo ${@:2}
-echo ${@:3}


### PR DESCRIPTION
Add tags for minimum regression and make it possible to use tags and any other options of robot from the `scripts/run.sh` wrapper