### PR TITLE
Sensors detect deprecated usage

### DIFF
--- a/keywords.robot
+++ b/keywords.robot
@@ -496,7 +496,7 @@ Get All USB
 Prepare Lm-sensors
     [Documentation]    Install lm-sensors and probe sensors.
     Detect Or Install Package    lm-sensors
-    Execute Command In Terminal    yes | sudo sensors-detect
+    Execute Command In Terminal    sudo sensors-detect --auto
     IF    '${PLATFORM}' == 'raptor-cs_talos2'
         Execute Command In Terminal    modprobe w83795
     END


### PR DESCRIPTION
Change deprecated way of using sensors-detect program in linux. calling `yes | sudo sensors-detect` produces a warning:
```
***************************************************************
Warning: the preferred way to run this script non-interactively
is with option --auto. Other methods are discouraged and may
stop working at some point in the future.
***************************************************************
```