### PR TITLE
lib/robot.sh: Fix faulty condition

### DIFF
--- a/scripts/lib/robot.sh
+++ b/scripts/lib/robot.sh
@@ -37,7 +37,7 @@ execute_robot() {
   _test_path=${_test_path%%--*}
   local _robot_args=${*}
   _robot_args=${_robot_args#*--}
-  if [[ "$_test_path" != *"--"* ]]; then
+  if ! echo "${*}" | grep " -- "; then
     _robot_args=""
   fi
   local _test_name


### PR DESCRIPTION
In theory using [[]] and * matching should work as expected, that is clear the _robot_args variable if `--` substring was not found in the args. When there is no `--` seperating test suite names from additonal args fails.
In practice it turned out that the condition was always true.  Using grep is using a cannon to kill a fly, but it works.

Bug was merged with this PR:
https://github.com/Dasharo/open-source-firmware-validation/pull/420/files