### PR TITLE
memory-profile.robot: type errors

### DIFF
--- a/dasharo-compatibility/memory-profile.robot
+++ b/dasharo-compatibility/memory-profile.robot
@@ -49,6 +49,7 @@ MPS001.001 Switching to XMP profile
     ${dasharo_menu}=    Enter Dasharo System Features    ${setup_menu}
     ${memory_menu}=    Enter Dasharo Submenu    ${dasharo_menu}    Memory Configuration
     ${current_profile}=    Get Option State    ${memory_menu}    Memory SPD Profile
+    ${current_profile}=    Convert To String    ${current_profile}
     Should Start With    ${current_profile}    JEDEC
     Set Option State    ${memory_menu}    Memory SPD Profile    XMP#1 (predefined
     Save Changes And Reset
@@ -74,6 +75,7 @@ MPS002.001 Switching back to JEDEC profile
     ${dasharo_menu}=    Enter Dasharo System Features    ${setup_menu}
     ${memory_menu}=    Enter Dasharo Submenu    ${dasharo_menu}    Memory Configuration
     ${current_profile}=    Get Option State    ${memory_menu}    Memory SPD Profile
+    ${current_profile}=    Convert To String    ${current_profile}
     Should Start With    ${current_profile}    XMP#1
     Set Option State    ${memory_menu}    Memory SPD Profile    JEDEC (safe
     Save Changes And Reset

--- a/lib/bios/menus.robot
+++ b/lib/bios/menus.robot
@@ -284,12 +284,15 @@ Get Option State
     [Arguments]    ${menu}    ${option}
     ${index}=    Get Index Of Matching Option In Menu    ${menu}    ${option}
     ${value}=    Get Value From Brackets    ${menu}[${index}]
-    IF    '${value}[0]' == 'X'
-        ${state}=    Set Variable    ${TRUE}
-    ELSE IF    '${value}[0]' == ' '
-        ${state}=    Set Variable    ${FALSE}
-    ELSE
-        ${state}=    Set Variable    ${value}
+    ${len}=    Get Length    ${value}
+
+    ${state}=    Set Variable    ${value}
+    IF    ${len} == 1
+        IF    '${value}[0]' == 'X'
+            ${state}=    Set Variable    ${TRUE}
+        ELSE IF    '${value}[0]' == ' '
+            ${state}=    Set Variable    ${FALSE}
+        END
     END
     RETURN    ${state}
 


### PR DESCRIPTION
"Get Option State" Keyword returns True/False if the value is a boolean value you "check" or "uncheck" and String if there is some text inside. Relying on the type of returned value may be dangerous and it caused the memory-profile test suite to fail because of type errors. 
But the memory profile is a list of values, not a checkbox! Now it turns out if an option value starts with an "X" it is treated as a boolean because the letter "X" is used as a checkmark. That is the case with options like "XMP#1...". 