### PR TITLE
Compatibility nvidia accept vga controller as gpu

### DIFF
--- a/dasharo-compatibility/nvidia.robot
+++ b/dasharo-compatibility/nvidia.robot
@@ -34,7 +34,7 @@ NVI001.001 NVIDIA Graphics detect (Ubuntu)
     Switch To Root User
     Detect Or Install Package    pciutils
     ${out}=    Execute Linux Command    lspci | grep -i nvidia | cat
-    Should Contain    ${out}    3D controller: NVIDIA Corporation
+    Should Contain Any    ${out}    3D controller: NVIDIA Corporation    VGA compatible controller: NVIDIA Corporation
     Exit From Root User
 
 NVI001.002 NVIDIA Graphics detect (Windows)


### PR DESCRIPTION
This change makes the automatic test pass when vga controller is detected
Moved from https://github.com/Dasharo/open-source-firmware-validation/pull/466 because of typo in branch name pushed by me because I forgot to install pre-commit