### PR TITLE
v560tne-v0.9.1-rc3-testing-fixes

### DIFF
--- a/dasharo-compatibility/usb-hid-and-msc-support.robot
+++ b/dasharo-compatibility/usb-hid-and-msc-support.robot
@@ -28,6 +28,7 @@ USB001.001 USB devices detected in FW
     [Documentation]    Check whether USB devices are detected in Tianocore
     ...    (edk2).
     Skip If    not ${USB_DISKS_DETECTION_SUPPORT}    USB001.001 not supported
+    Skip If    not ${TESTS_IN_FIRMWARE_SUPPORT}
     Upload And Mount DTS Flash Iso
     Power On
     ${boot_menu}=    Enter Boot Menu Tianocore And Return Construction
@@ -64,6 +65,7 @@ USB002.001 USB keyboard detected in FW
     ...    correctly by the firmware and all basic keys work
     ...    according to their labels.
     [Tags]    minimal-regression
+    Skip If    not ${TESTS_IN_FIRMWARE_SUPPORT}
     Power On
     Enter UEFI Shell
     ${out}=    Execute UEFI Shell Command    devices

--- a/keywords.robot
+++ b/keywords.robot
@@ -986,7 +986,7 @@ Check Internal LCD Windows
 Check External HDMI In Linux
     [Documentation]    Keyword checks if an external HDMI device is visible
     ...    in Linux OS.
-    ${out}=    Execute Linux Command    cat /sys/devices/pci0000:00/0000:00:02.0/drm/card*/*HDMI*/status
+    ${out}=    Execute Linux Command    cat /sys/class/drm/card*/*
 
     Should Contain    ${out}    connected
 

--- a/lib/flash.robot
+++ b/lib/flash.robot
@@ -17,7 +17,7 @@ Flash Via Internal Programmer With Args
     ...    Should Contain    ${out_flash}    VERIFIED
     IF    not ${success}
         Log    Retry flashing once again in case of failure
-        ${out_flash}=    Execute Command In Terminal    flashrom -p internal -w ${fw_file_path} ${args}
+        ${out_flash}=    Execute Command In Terminal    flashrom -p internal -w ${fw_file_path} ${args}    300s
         IF    "Warning: Chip content is identical to the requested image." in """${out_flash}"""
             RETURN
         END

--- a/lib/options/dcu.robot
+++ b/lib/options/dcu.robot
@@ -23,7 +23,8 @@ Set UEFI Option
     Login To Linux
     Switch To Root User
     Get Flashrom From Cloud
-    Execute Command In Terminal    flashrom -p internal -r coreboot.rom --fmap -i FMAP -i SMMSTORE &> /dev/null
+    ${result}=    Execute Command In Terminal    flashrom -p internal -r coreboot.rom --fmap -i FMAP -i SMMSTORE
+    Should Not Contain    ${result}    read-only
     Execute Command In Terminal    chmod 666 coreboot.rom
     SSHLibrary.Get File    coreboot.rom    dcu/coreboot.rom
     ${result}=    Run Process
@@ -32,7 +33,7 @@ Set UEFI Option
     Should Contain    ${result.stdout}    Success
     SSHLibrary.Put File    dcu/coreboot.rom    coreboot.rom
     ${result}=    Execute Command In Terminal
-    ...    flashrom -p internal -w coreboot.rom --fmap -i SMMSTORE --noverify-all &> /dev/null
+    ...    flashrom -p internal -w coreboot.rom --fmap -i SMMSTORE    300s
     Should Contain    ${result}    VERIFIED
     Execute Reboot Command
     # Assume we don't have serial to tell us that we've rebooted, so just wait

--- a/lib/options/dcu.robot
+++ b/lib/options/dcu.robot
@@ -31,7 +31,9 @@ Set UEFI Option
     ...    shell=True
     Should Contain    ${result.stdout}    Success
     SSHLibrary.Put File    dcu/coreboot.rom    coreboot.rom
-    Execute Command In Terminal    flashrom -p internal -w coreboot.rom --fmap -i SMMSTORE --noverify-all &> /dev/null
+    ${result}=    Execute Command In Terminal
+    ...    flashrom -p internal -w coreboot.rom --fmap -i SMMSTORE --noverify-all &> /dev/null
+    Should Contain    ${result}    VERIFIED
     Execute Reboot Command
     # Assume we don't have serial to tell us that we've rebooted, so just wait
     # 20s for shutdown to finish, to prevent subsequent kwds from running before

--- a/platform-configs/novacustom-v560tnd.robot
+++ b/platform-configs/novacustom-v560tnd.robot
@@ -23,4 +23,3 @@ ${SNIPEIT}=                         no
 ${TESTS_IN_WINDOWS_SUPPORT}=        ${FALSE}    # change windows/ubuntu support depending
 ${TESTS_IN_UBUNTU_SUPPORT}=         ${TRUE}    # on which OS is first in the boot order
 ${USB_STACK_SUPPORT}=               ${TRUE}
-${DEVICE_AUDIO1}=                   ALC245

--- a/platform-configs/novacustom-v560tnd.robot
+++ b/platform-configs/novacustom-v560tnd.robot
@@ -7,13 +7,13 @@ Resource    include/novacustom-mtl.robot
 # CPU
 ${CPU}=                                 Intel(R) Core(TM) Ultra 7 155H
 
-${3_MDEB_WIFI_NETWORK}=             3mdeb_abr
-${DEVICE_NVME_DISK}=                Non-Volatile memory controller
-${DEVICE_USB_KEYBOARD}=             Logitech, Inc. Keyboard K120
-${DMIDECODE_PRODUCT_NAME}=          V5xTNC_TND_TNE
-${EXTERNAL_HEADSET}=                USB PnP Audio Device
-${CPU_MAX_FREQUENCY}=               4800
-${CPU_MIN_FREQUENCY}=               200
+${3_MDEB_WIFI_NETWORK}=                 3mdeb_abr
+${DEVICE_NVME_DISK}=                    Non-Volatile memory controller
+${DEVICE_USB_KEYBOARD}=                 Logitech, Inc. Keyboard K120
+${DMIDECODE_PRODUCT_NAME}=              V5xTNC_TND_TNE
+${EXTERNAL_HEADSET}=                    USB PnP Audio Device
+${CPU_MAX_FREQUENCY}=                   4800
+${CPU_MIN_FREQUENCY}=                   200
 
 ${NVIDIA_GRAPHICS_CARD_SUPPORT}=        ${TRUE}
 

--- a/platform-configs/novacustom-v560tnd.robot
+++ b/platform-configs/novacustom-v560tnd.robot
@@ -21,6 +21,6 @@ ${POWER_CTRL}=                      none
 ${FLASH_SIZE}=                      ${32*1024*1024}
 ${SNIPEIT}=                         no
 ${TESTS_IN_WINDOWS_SUPPORT}=        ${FALSE}    # change windows/ubuntu support depending
-${TESTS_IN_UBUNTU_SUPPORT}=         ${TRUE} # on which OS is first in the boot order
+${TESTS_IN_UBUNTU_SUPPORT}=         ${TRUE}    # on which OS is first in the boot order
 ${USB_STACK_SUPPORT}=               ${TRUE}
 ${DEVICE_AUDIO1}=                   ALC245

--- a/platform-configs/novacustom-v560tnd.robot
+++ b/platform-configs/novacustom-v560tnd.robot
@@ -5,7 +5,7 @@ Resource    include/novacustom-mtl.robot
 
 *** Variables ***
 # CPU
-${CPU}=                             Intel(R) Core(TM) Ultra 7 155H
+${CPU}=                                 Intel(R) Core(TM) Ultra 7 155H
 
 ${3_MDEB_WIFI_NETWORK}=             3mdeb_abr
 ${DEVICE_NVME_DISK}=                Non-Volatile memory controller
@@ -15,11 +15,16 @@ ${EXTERNAL_HEADSET}=                USB PnP Audio Device
 ${CPU_MAX_FREQUENCY}=               4800
 ${CPU_MIN_FREQUENCY}=               200
 
-${NVIDIA_GRAPHICS_CARD_SUPPORT}=    ${TRUE}
+${NVIDIA_GRAPHICS_CARD_SUPPORT}=        ${TRUE}
 
-${POWER_CTRL}=                      none
-${FLASH_SIZE}=                      ${32*1024*1024}
-${SNIPEIT}=                         no
-${TESTS_IN_WINDOWS_SUPPORT}=        ${FALSE}    # change windows/ubuntu support depending
-${TESTS_IN_UBUNTU_SUPPORT}=         ${TRUE}    # on which OS is first in the boot order
-${USB_STACK_SUPPORT}=               ${TRUE}
+${POWER_CTRL}=                          none
+${FLASH_SIZE}=                          ${32*1024*1024}
+${SNIPEIT}=                             no
+${TESTS_IN_WINDOWS_SUPPORT}=            ${FALSE} # change windows/ubuntu support depending
+${TESTS_IN_UBUNTU_SUPPORT}=             ${TRUE} # on which OS is first in the boot order
+${USB_STACK_SUPPORT}=                   ${TRUE}
+${DASHARO_POWER_MGMT_MENU_SUPPORT}=     ${FALSE}
+
+${USB_DETECTION_ITERATIONS_NUMBER}=     1
+${BOOT_FROM_USB_ITERATIONS_NUMBER}=     1
+${WIFI_CARD}=                           Intel(R) Wi-Fi 6E AX211 160MHz

--- a/platform-configs/novacustom-v560tne.robot
+++ b/platform-configs/novacustom-v560tne.robot
@@ -25,3 +25,5 @@ ${TESTS_IN_UBUNTU_SUPPORT}=             ${TRUE} # on which OS is first in the bo
 ${USB_STACK_SUPPORT}=                   ${TRUE}
 
 ${USB_DETECTION_ITERATIONS_NUMBER}=     1
+${BOOT_FROM_USB_ITERATIONS_NUMBER}=     1
+${WIFI_CARD}=                           Intel(R) Wi-Fi 6E AX211 160MHz

--- a/platform-configs/novacustom-v560tne.robot
+++ b/platform-configs/novacustom-v560tne.robot
@@ -23,3 +23,5 @@ ${SNIPEIT}=                             no
 ${TESTS_IN_WINDOWS_SUPPORT}=            ${FALSE} # change windows/ubuntu support depending
 ${TESTS_IN_UBUNTU_SUPPORT}=             ${TRUE} # on which OS is first in the boot order
 ${USB_STACK_SUPPORT}=                   ${TRUE}
+
+${USB_DETECTION_ITERATIONS_NUMBER}=     1

--- a/platform-configs/novacustom-v560tne.robot
+++ b/platform-configs/novacustom-v560tne.robot
@@ -24,6 +24,5 @@ ${TESTS_IN_WINDOWS_SUPPORT}=            ${FALSE} # change windows/ubuntu support
 ${TESTS_IN_UBUNTU_SUPPORT}=             ${TRUE} # on which OS is first in the boot order
 ${USB_STACK_SUPPORT}=                   ${TRUE}
 
-${USB_DETECTION_ITERATIONS_NUMBER}=     1
-${BOOT_FROM_USB_ITERATIONS_NUMBER}=     1
+${BOOT_FROM_USB_ITERATIONS_NUMBER}=     3
 ${WIFI_CARD}=                           Intel(R) Wi-Fi 6E AX211 160MHz

--- a/platform-configs/novacustom-v560tne.robot
+++ b/platform-configs/novacustom-v560tne.robot
@@ -5,22 +5,21 @@ Resource    include/novacustom-mtl.robot
 
 *** Variables ***
 # CPU
-${CPU}=                             Intel(R) Core(TM) Ultra 7 155H
+${CPU}=                                 Intel(R) Core(TM) Ultra 7 155H
 
-${3_MDEB_WIFI_NETWORK}=             3mdeb_abr
-${DEVICE_NVME_DISK}=                Non-Volatile memory controller
-${DEVICE_USB_KEYBOARD}=             Logitech, Inc. Keyboard K120
-${DMIDECODE_PRODUCT_NAME}=          V5xTNC_TND_TNE
-${EXTERNAL_HEADSET}=                USB PnP Audio Device
-${CPU_MAX_FREQUENCY}=               4800
-${CPU_MIN_FREQUENCY}=               200
+${3_MDEB_WIFI_NETWORK}=                 3mdeb_abr
+${DEVICE_NVME_DISK}=                    Non-Volatile memory controller
+${DEVICE_USB_KEYBOARD}=                 Logitech, Inc. Keyboard K120
+${DMIDECODE_PRODUCT_NAME}=              V5xTNC_TND_TNE
+${EXTERNAL_HEADSET}=                    USB PnP Audio Device
+${CPU_MAX_FREQUENCY}=                   4800
+${CPU_MIN_FREQUENCY}=                   300
+${USB_DETECTION_ITERATIONS_NUMBER}=     3
+${NVIDIA_GRAPHICS_CARD_SUPPORT}=        ${TRUE}
 
-${NVIDIA_GRAPHICS_CARD_SUPPORT}=    ${TRUE}
-
-${POWER_CTRL}=                      none
-${FLASH_SIZE}=                      ${32*1024*1024}
-${SNIPEIT}=                         no
-${TESTS_IN_WINDOWS_SUPPORT}=        ${FALSE} # change windows/ubuntu support depending
-${TESTS_IN_UBUNTU_SUPPORT}=         ${TRUE} # on which OS is first in the boot order
-${USB_STACK_SUPPORT}=               ${TRUE}
-${DEVICE_AUDIO1}=                   ALC245
+${POWER_CTRL}=                          none
+${FLASH_SIZE}=                          ${32*1024*1024}
+${SNIPEIT}=                             no
+${TESTS_IN_WINDOWS_SUPPORT}=            ${FALSE} # change windows/ubuntu support depending
+${TESTS_IN_UBUNTU_SUPPORT}=             ${TRUE} # on which OS is first in the boot order
+${USB_STACK_SUPPORT}=                   ${TRUE}


### PR DESCRIPTION
fix usb-hid-and-msc-support tests missing skip
if tests in firmware not supported