### PR TITLE
Increase rtcwake warmboot wait time

### DIFF
--- a/lib/sleep-lib.robot
+++ b/lib/sleep-lib.robot
@@ -134,9 +134,9 @@ Perform Warmboot Using Rtcwake
     # would hang here and fail.
     # Sometimes it may take long to shutdown all systemd services,
     # so the waiting times have to be excessive to avoid false negatives.
-    Write Into Terminal    rtcwake -m off -s 20
+    Write Into Terminal    rtcwake -m off -s 60
     Set DUT Response Timeout    300s
-    Sleep    20s
+    Sleep    60s
 
 Perform Suspend And Wake Using Rtcwake
     [Documentation]    Suspends and then wakes up the device after some time


### PR DESCRIPTION
If the device takes longer than the time given to the command it will not wake up ever.

This change will increase the time it takes to perform this time every time. Even if the shutdown took only 1s the device will power on only after the specified time.

I don't have a good idea how to solve this unreliability other than increasing the delay...