### PR TITLE
Some MSI fixes

### DIFF
--- a/dasharo-compatibility/apu-configuration-menu.robot
+++ b/dasharo-compatibility/apu-configuration-menu.robot
@@ -18,9 +18,9 @@ Suite Setup         Run Keywords
 ...                     Prepare Test Suite    AND
 ...                     Skip If    not ${APU_CONFIGURATION_MENU_SUPPORT}    APU configuration tests not supported.
 Suite Teardown      Run Keywords
-...                     Flash Firmware    ${FW_FILE}
+...                     Skip If    '${SUITE_STATUS}' == 'SKIP'    Skipping Teardown since Suite was skipped as well
 ...                     AND
-...                     Turn On Power Supply
+...                     Flash Firmware    ${FW_FILE}
 ...                     AND
 ...                     Log Out And Close Connection
 

--- a/dasharo-compatibility/apu-configuration-menu.robot
+++ b/dasharo-compatibility/apu-configuration-menu.robot
@@ -20,6 +20,8 @@ Suite Setup         Run Keywords
 Suite Teardown      Run Keywords
 ...                     Flash Firmware    ${FW_FILE}
 ...                     AND
+...                     Turn On Power Supply
+...                     AND
 ...                     Log Out And Close Connection
 
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,7 +7,7 @@ output is enabled in the firmware and this setting is turned on by default.
 This issue is not related to PiKVM itself. It will occur on any DUT that uses
 serial connection. However PiKVM may make it look like everything is working
 correctly (video output etc). On some platforms like example on the MSI
-laptops, the default setting for the Serial Redirection is off. This is why
+boards, the default setting for the Serial Redirection is off. This is why
 tests that flash firmware need to have the fw file modified to have the serial
 enabled. Otherwise every time firmware is flashed by the test the DUT setup
 will be broken. To prepare a modified fw file use:

--- a/lib/flash.robot
+++ b/lib/flash.robot
@@ -73,7 +73,7 @@ Flash Firmware
     ...    chip size.
     [Arguments]    ${fw_file}
     ${file_size}=    Run    ls -l ${fw_file} | awk '{print $5}'
-    IF    '${file_size}'!='${FLASH_SIZE}'
+    IF    '''${file_size}''' != '''${FLASH_SIZE}'''
         FAIL    Image size doesn't match the flash chip's size!
     END
 

--- a/platform-configs/msi-pro-z690-a-ddr5.robot
+++ b/platform-configs/msi-pro-z690-a-ddr5.robot
@@ -9,5 +9,7 @@ ${DMIDECODE_FIRMWARE_VERSION}=      Dasharo (coreboot+UEFI) v1.1.3
 ${DMIDECODE_PRODUCT_NAME}=          MS-7D25
 ${DMIDECODE_RELEASE_DATE}=          11/27/2023
 
+${DEVICE_AUDIO2}=                   Raptorlake HDMI
+
 ${CPU_MAX_FREQUENCY}=               5200
 ${CPU_MIN_FREQUENCY}=               300

--- a/platform-configs/msi-pro-z690-a-ddr5.robot
+++ b/platform-configs/msi-pro-z690-a-ddr5.robot
@@ -3,11 +3,11 @@ Resource    include/msi-z690-common.robot
 
 
 *** Variables ***
-${FW_VERSION}=                      v1.1.2
+${FW_VERSION}=                      v1.1.4-rc1
 ${DMIDECODE_SERIAL_NUMBER}=         N/A
-${DMIDECODE_FIRMWARE_VERSION}=      Dasharo (coreboot+UEFI) v1.1.3
+${DMIDECODE_FIRMWARE_VERSION}=      Dasharo (coreboot+UEFI) ${FW_VERSION}
 ${DMIDECODE_PRODUCT_NAME}=          MS-7D25
-${DMIDECODE_RELEASE_DATE}=          11/27/2023
+${DMIDECODE_RELEASE_DATE}=          09/27/2024
 
 ${DEVICE_AUDIO2}=                   Raptorlake HDMI
 

--- a/scripts/regression.sh
+++ b/scripts/regression.sh
@@ -7,6 +7,11 @@ source "${SCRIPT_DIR}/lib/robot.sh"
 check_env_variable "FW_FILE"
 check_env_variable "DEVICE_IP"
 
+if [ ! -f "$FW_FILE" ]; then
+    echo "Error: Environment variable FW_FILE doesn't point to a file."
+    exit 1
+fi
+
 check_test_station_variables
 
 execute_robot "dasharo-compatibility" "${@}"


### PR DESCRIPTION
Some commits here should be useful, but they don't even remotely let regression tests pass, although part of it is probably setup (like missing Windows on the platform I used).  Actual release binary can't be tested because serial output is reset to its default (off) state in multiple places.

I've probably never tried to run so many tests and can say they are extremely slow even when skipped.  When suite setup skips all tests, teardown still does things like flashing or starting the machine and changing EDK settings.

See commit messages.