### PR TITLE
TrenchBoot updates

### DIFF
--- a/lib/bios/menus.robot
+++ b/lib/bios/menus.robot
@@ -572,6 +572,15 @@ Boot System Or From Connected Disk
     ...    to boot from connected disk set up in config
     [Arguments]    ${system_name}
     IF    '${DUT_CONNECTION_METHOD}' == 'SSH'    RETURN
+
+    IF    '''${SEABIOS_BOOT_DEVICE}''' != ''
+        Read From Terminal Until    Press F10 key now for boot menu
+        Write Bare Into Terminal    ${F10}
+        Read From Terminal Until    Select boot device
+        Write Bare Into Terminal    ${SEABIOS_BOOT_DEVICE}
+        RETURN
+    END
+
     ${menu_construction}=    Enter Boot Menu Tianocore And Return Construction
     # When ESP scanning feature is there, boot entries are named differently than
     # they used to

--- a/lib/trenchboot.robot
+++ b/lib/trenchboot.robot
@@ -8,8 +8,13 @@ TrenchBoot Telnet Root Login
     [Documentation]    Telnet login for Trenchboot
     # The login is password-less which makes use of Telnet.Login very
     # inconvenient.
+    Telnet.Set Prompt    root@tb:~#
     Telnet.Read Until    login:
     Telnet.Write    root
-    Telnet.Set Prompt    root@tb:~#
-    Telnet.Write Bare    \n
+    # Try to work around prompt detection issues by first matching on a single
+    # character.
+    Telnet.Set Prompt    \#
     Telnet.Read Until Prompt
+    # Now set the real prompt and tell dmesg to shut up.
+    Telnet.Set Prompt    root@tb:~#
+    Execute Command In Terminal    dmesg -n1

--- a/platform-configs/include/default.robot
+++ b/platform-configs/include/default.robot
@@ -29,6 +29,7 @@ ${MAX_CPU_TEMP}=                                    ${TBD}
 ${INTERNAL_PROGRAMMER_CHIPNAME}=                    "Opaque flash chip"
 ${FLASHING_METHOD}=                                 external
 ${SNIPEIT}=                                         yes
+${SEABIOS_BOOT_DEVICE}=
 
 # See: https://github.com/Dasharo/dasharo-issues/issues/614
 ${LAPTOP_EC_SERIAL_WORKAROUND}=                     ${FALSE}

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -4,7 +4,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib/robot.sh"
 
 print_help() {
-  echo "Usage: $0 [test_file | directory_path]"
+  echo "Usage: $0 (test_file | directory_path)... [-- arbitrary robot args...]"
   echo
   echo "This script is used to execute OSFV Robot Framework tests."
   echo "You can specify either a single test or a whole directory of tests."

--- a/trenchboot/02-with-drtm.robot
+++ b/trenchboot/02-with-drtm.robot
@@ -86,14 +86,16 @@ WTD005.001 DRTM event log has DRTM entries (AMD)
     ...    find_event 17 "DLME"
     Should Be Equal As Strings    ${match}    MATCH    No "DLME" entry
 
+    # XXX: No part of SLRT is measured on AMD platforms.
     # Early TPM code doesn't identify SLRT measurement event in any way.
-    ${match}=    Execute Command In Terminal
-    ...    find_event 18 ""
-    Should Be Equal As Strings    ${match}    MATCH    No SLRT entry
+    # ${match}=    Execute Command In Terminal
+    # ...    find_event 18 ""
+    # Should Be Equal As Strings    ${match}    MATCH    No SLRT entry
 
-    ${match}=    Execute Command In Terminal
-    ...    find_event 17 "Measured MB2 module"
-    Should Be Equal As Strings    ${match}    MATCH\nMATCH    No "Measured MB2 module" entries
+    # XXX: This is only for Multiboot2 protocol.
+    # ${match}=    Execute Command In Terminal
+    # ...    find_event 17 "Measured MB2 module"
+    # Should Be Equal As Strings    ${match}    MATCH\nMATCH    No "Measured MB2 module" entries
 
 WTD006.001 DRTM log aligns with PCR values
     [Documentation]    Verify that all DRTM measurements are correctly reflected

--- a/trenchboot/README.md
+++ b/trenchboot/README.md
@@ -1,0 +1,28 @@
+# TrenchBoot tests
+
+These are the tests of [TrenchBoot] functionality meant to be used with
+[meta-trenchboot] distribution.
+
+The tests check sanitity of the environment with and without the DRTM.
+
+[TrenchBoot]: https://trenchboot.org/
+[meta-trenchboot]: https://github.com/3mdeb/meta-trenchboot
+
+## Example usage
+
+From the root of the repository.
+
+### With UEFI firmware on APU2
+
+```bash
+CONFIG=pcengines-apu2 RTE_IP=192.168.10.172 SNIPEIT_NO=1 scripts/run.sh trenchboot
+```
+
+### With SeaBIOS firmware on APU2
+
+```bash
+CONFIG=pcengines-apu2 RTE_IP=192.168.10.172 SNIPEIT_NO=1 scripts/run.sh trenchboot -- -v SEABIOS_BOOT_DEVICE:2
+```
+
+Here `SEABIOS_BOOT_DEVICE` specifies a device to boot from via SeaBIOS boot
+menu.  It should correspond to the drive with the [meta-trenchboot] image.


### PR DESCRIPTION
Previously only non-DRTM case was tested, now DRTM one works as well.  It requires SeaBIOS which is harder to automate, see README file for how to use it.

See commit messages for more info.