### PR TITLE
README.md: improve docs gen tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,11 +292,27 @@ FW_FILE=$FW_FILE DEVICE_IP=$DEVICE_IP RTE_IP=$RTE_IP CONFIG=$CONFIG ./scripts/re
 Keywords documentation (Develop) deploy status: ![Build Status](https://github.com/Dasharo/open-source-firmware-validation/actions/workflows/pages/pages-build-deployment/badge.svg)
 
 Documentation in the form of auto-generated html documents can be created using
-`libdoc` and `testdoc`. In order to generate a document for a resource file
+`libdoc` and `testdoc`.
+
+Note: you should be in your python virtual environment. If you haven't
+created any, please refer to [Getting Started](#getting-started)
+
+To generate a document for a resource file
 containing keywords, use these commands:
 
 ```bash
-$ python3 robot-venv/bin/libdoc keywords.robot keywords.html
+$(venv) libdoc keywords.robot keywords.html
+```
+
+Or in more general form:
+
+```bash
+$(venv) libdoc <file-with-keywords> <output filename>
+```
+
+The output file can be opened in any web-browser like so:
+
+```bash
 $ firefox keywords.html
 ```
 
@@ -307,24 +323,29 @@ within this repo:
 
 ```bash
 $ ./scripts/create-docs.sh
-Documentation generated and saved as all-keywords.html
-$ firefox all-keywords.html
+Documentation generated and saved as docs/index.html
 ```
 
-In order to generate documentation regarding a specific test, `testdoc` has to
+The resulting file can be opened in any web-browser:
+
+```bash
+$ firefox docs/index.html
+```
+
+To generate documentation regarding a specific test, `testdoc` has to
 be used, for example if we want documentation regarding the
 `dasharo-compatibility/dasharo-tools-suite.robot` test, these commands would
 need to be executed:
 
 ```bash
-$ python3 ./robot-venv/lib/python3.11/site-packages/robot/testdoc.py dasharo-compatibility/dasharo-tools-suite.robot test.html
+$ python3 robot.testdoc dasharo-compatibility/dasharo-tools-suite.robot test.html
 $ firefox test.html
 ```
 
 [This website](https://dasharo.github.io/open-source-firmware-validation/) shows
 the current state of all keywords from all libraries as they appear right now on
 the `develop` branch. It works by utilizing a workflow, so remember that local
-changes that are made won't show up there, until they are pushed to `develop`
+changes that are made won't show up there, until they are pushed to the `develop`
 branch.
 
 ## Additional documents


### PR DESCRIPTION
Improve the tutorial for walkingh through generating the .html documentation for keywords.

Main changes:
- Add a reminder about virtual environment.
- Simplify commands for generating the documentation.