### PR TITLE
dasharo-compatibility/network-boot*: Add suite docs

### DIFF
--- a/dasharo-compatibility/network-boot-utilities.robot
+++ b/dasharo-compatibility/network-boot-utilities.robot
@@ -1,4 +1,9 @@
 *** Settings ***
+Documentation       This test suite is supported on Protectli releases with a
+...                 custom network boot menu. It is incompatible with the PXE
+...                 test suite. For most other releases the PXE test suite
+...                 should be used instead.
+
 Library             Collections
 Library             OperatingSystem
 Library             Process


### PR DESCRIPTION
The NBT test suite is only used on Protectli devices which use a custom network boot menu. Other Dasharo releases should be tested with the PXE test suite. The suites are incompatible and will never both work on one release. This fact is not documented in the tests and may cause confusion and/or errors during release tests.