### PR TITLE
scripts/lib/robot.sh: Print the path of debug log

### DIFF
--- a/scripts/lib/robot.sh
+++ b/scripts/lib/robot.sh
@@ -128,6 +128,9 @@ execute_robot() {
     local _output_file="${_logs_dir}/${_test_name}_out.xml"
     local _debug_file="${_logs_dir}/${_test_name}_debug.log"
 
+    echo "Logs will be saved at ${_logs_dir}"
+    echo "Watch \"${_debug_file}\" to monitor the progress of the test"
+
     command="
           robot -L TRACE \
                 -l ${_log_file} \


### PR DESCRIPTION
Will make it much easier to follow the tests as looking for the file before the tests end and the path is printed is a bit troublesome.