### PR TITLE
unify approach to Power On

### DIFF
--- a/platform-configs/include/default.robot
+++ b/platform-configs/include/default.robot
@@ -263,3 +263,18 @@ ${STABILITY_DETECTION_WARMBOOT_ITERATIONS}=         2
 ${STABILITY_DETECTION_REBOOT_ITERATIONS}=           5
 ${STABILITY_DETECTION_SUSPEND_ITERATIONS}=          5
 ${DCU_SUPPORTED_BOOLEAN_SMMSTORE_VARIABLE}=         NetworkBoot
+
+
+*** Keywords ***
+Power On Default
+    [Documentation]    Keyword clears terminal buffer and sets Device Under Test
+    ...    into Power On state using RTE OC buffers. Implementation
+    ...    must be compatible with the theory of operation of a
+    ...    specific platform.
+    Restore Initial DUT Connection Method
+    IF    '${DUT_CONNECTION_METHOD}' == 'SSH'    RETURN
+    Sleep    2s
+    Rte Power Off
+    Sleep    10s
+    Read From Terminal
+    Power Cycle On

--- a/platform-configs/include/msi-z690-common.robot
+++ b/platform-configs/include/msi-z690-common.robot
@@ -118,15 +118,4 @@ ${ROMHOLE_SUPPORT}=                             ${TRUE}
 
 *** Keywords ***
 Power On
-    [Documentation]    Keyword clears telnet buffer and sets Device Under Test
-    ...    into Power On state using RTE OC buffers. Implementation
-    ...    must be compatible with the theory of operation of a
-    ...    specific platform.
-    Restore Initial DUT Connection Method
-    IF    '${DUT_CONNECTION_METHOD}' == 'SSH'    RETURN
-    Sleep    2s
-    Rte Power Off    ${6}
-    Sleep    5s
-    # read the old output
-    Telnet.Read
-    Rte Power On
+    Power On Default

--- a/platform-configs/include/optiplex-common.robot
+++ b/platform-configs/include/optiplex-common.robot
@@ -96,6 +96,4 @@ ${HIBERNATION_AND_RESUME_SUPPORT}=              ${TRUE}
 
 *** Keywords ***
 Power On
-    Sonoff Power Cycle On
-    Sleep    2s
-    Rte Power On
+    Power On Default

--- a/platform-configs/include/pcengines.robot
+++ b/platform-configs/include/pcengines.robot
@@ -102,18 +102,3 @@ ${USB_TYPE-A_DEVICES_DETECTION_SUPPORT}=    ${TRUE}
 
 # Test module: trenchboot
 ${TRENCHBOOT_SUPPORT}=                      ${TRUE}
-
-
-*** Keywords ***
-Power On
-    [Documentation]    Keyword clears telnet buffer and sets Device Under Test
-    ...    into Power On state using RTE OC buffers. Implementation
-    ...    must be compatible with the theory of operation of a
-    ...    specific platform.
-    Restore Initial DUT Connection Method
-    IF    '${DUT_CONNECTION_METHOD}' == 'SSH'    RETURN
-    Sleep    2s
-    Rte Power Off
-    Sleep    10s
-    Telnet.Read
-    Rte Power On

--- a/platform-configs/include/protectli-common.robot
+++ b/platform-configs/include/protectli-common.robot
@@ -134,6 +134,9 @@ ${STABILITY_DETECTION_SUSPEND_ITERATIONS}=      5
 
 
 *** Keywords ***
+Power On
+    Power On Default
+
 Check Coreboot Components Measurement
     [Documentation]    Check whether the hashes of the coreboot components
     ...    measurements have been stored in the TPM PCR registers.

--- a/platform-configs/include/protectli-v1x10.robot
+++ b/platform-configs/include/protectli-v1x10.robot
@@ -38,21 +38,6 @@ ${DCU_SUPPORTED_BOOLEAN_SMMSTORE_VARIABLE}=     ${EMPTY}
 
 
 *** Keywords ***
-Power On
-    [Documentation]    Keyword clears telnet buffer and sets Device Under Test
-    ...    into Power On state using RTE OC buffers. Implementation
-    ...    must be compatible with the theory of operation of a
-    ...    specific platform.
-    Restore Initial DUT Connection Method
-    IF    '${DUT_CONNECTION_METHOD}' == 'SSH'    RETURN
-    Sleep    2s
-    Rte Power Off
-    Sleep    10s
-    Telnet.Read
-    # After Rte Power Off, the platform cannot be powered back using the power button.
-    # Possibly bug in HW or FW.
-    Power Cycle On
-
 Flash Device Via External Programmer
     [Documentation]    Keyword allows to flash Device Under Test firmware by
     ...    using external programmer and check flashing procedure

--- a/platform-configs/include/protectli-vp24xx.robot
+++ b/platform-configs/include/protectli-vp24xx.robot
@@ -12,18 +12,3 @@ ${MAX_CPU_TEMP}=                95
 ${DMIDECODE_MANUFACTURER}=      Protectli
 ${DMIDECODE_VENDOR}=            3mdeb
 ${DMIDECODE_FAMILY}=            Vault Pro
-
-
-*** Keywords ***
-Power On
-    [Documentation]    Keyword clears telnet buffer and sets Device Under Test
-    ...    into Power On state using RTE OC buffers. Implementation
-    ...    must be compatible with the theory of operation of a
-    ...    specific platform.
-    Restore Initial DUT Connection Method
-    IF    '${DUT_CONNECTION_METHOD}' == 'SSH'    RETURN
-    Sleep    2s
-    Rte Power Off
-    Sleep    10s
-    Telnet.Read
-    Rte Power On

--- a/platform-configs/include/protectli-vp32xx.robot
+++ b/platform-configs/include/protectli-vp32xx.robot
@@ -7,10 +7,3 @@ Resource    protectli-common.robot
 ${FLASH_SIZE}=      ${16*1024*1024}
 
 ${MAX_CPU_TEMP}=    82
-
-
-*** Keywords ***
-Power On
-    Rte Power Off
-    Sleep    5s
-    Power Cycle On

--- a/platform-configs/include/protectli-vp46xx.robot
+++ b/platform-configs/include/protectli-vp46xx.robot
@@ -20,11 +20,3 @@ ${DMIDECODE_FIRMWARE_VERSION}=      Dasharo (coreboot+UEFI) v1.2.0
 ${DMIDECODE_RELEASE_DATE}=          03/13/2024
 
 @{ETH_PERF_PAIR_2_G}=               enp5s0    enp6s0
-
-
-*** Keywords ***
-Power On
-    Restore Initial DUT Connection Method
-    Rte Power Off
-    Sleep    5s
-    Power Cycle On

--- a/platform-configs/include/protectli-vp66xx.robot
+++ b/platform-configs/include/protectli-vp66xx.robot
@@ -22,10 +22,3 @@ ${HYPER_THREADING_SUPPORT}=         ${TRUE}
 ${INTEL_HYBRID_ARCH_SUPPORT}=       ${TRUE}
 @{ETH_PERF_PAIR_2_G}=               enp5s0    enp6s0
 @{ETH_PERF_PAIR_10_G}=              enp2s0f0    enp2s0f1
-
-
-*** Keywords ***
-Power On
-    Rte Power Off
-    Sleep    5s
-    Power Cycle On

--- a/platform-configs/minnowboard-turbot.robot
+++ b/platform-configs/minnowboard-turbot.robot
@@ -37,15 +37,4 @@ ${CUSTOM_BOOT_MENU_KEY_SUPPORT}=        ${TRUE}
 
 *** Keywords ***
 Power On
-    [Documentation]    Keyword clears telnet buffer and sets Device Under Test
-    ...    into Power On state using RTE OC buffers. Implementation
-    ...    must be compatible with the theory of operation of a
-    ...    specific platform.
-    Restore Initial DUT Connection Method
-    IF    '${DUT_CONNECTION_METHOD}' == 'SSH'    RETURN
-    Sleep    3s
-    Rte Power Off
-    Sleep    1s
-    Telnet.Read
-    Rte Power On
-    Sleep    1s
+    Power On Default

--- a/platform-configs/odroid-h4-plus.robot
+++ b/platform-configs/odroid-h4-plus.robot
@@ -62,14 +62,4 @@ ${AUTO_BOOT_TIME_OUT_DEFAULT_VALUE}=    2
 
 *** Keywords ***
 Power On
-    [Documentation]    Keyword clears telnet buffer and sets Device Under Test
-    ...    into Power On state using RTE OC buffers. Implementation
-    ...    must be compatible with the theory of operation of a
-    ...    specific platform.
-    Restore Initial DUT Connection Method
-    Sleep    2s
-    Rte Relay Power Cycle Off
-    Sleep    5s
-    # read the old output
-    Telnet.Read
-    Rte Relay Power Cycle On
+    Power On Default

--- a/platform-configs/protectli-vp2410.robot
+++ b/platform-configs/protectli-vp2410.robot
@@ -42,20 +42,3 @@ ${PLATFORM_RAM_SPEED}=                  2400
 ${PLATFORM_RAM_SIZE}=                   8192
 
 @{ETH_PERF_PAIR_1_G}=                   enp2s0    enp3s0
-
-
-*** Keywords ***
-Power On
-    [Documentation]    Keyword clears telnet buffer and sets Device Under Test
-    ...    into Power On state using RTE OC buffers. Implementation
-    ...    must be compatible with the theory of operation of a
-    ...    specific platform.
-    Restore Initial DUT Connection Method
-    IF    '${DUT_CONNECTION_METHOD}' == 'SSH'    RETURN
-    Sleep    2s
-    Rte Power Off
-    Sleep    10s
-    Telnet.Read
-    # After Rte Power Off, the platform cannot be powered back using the power button.
-    # Possibly bug in HW or FW.
-    Power Cycle On

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ MarkupSafe==2.1.5
 mdurl==0.1.2
 nodeenv==1.8.0
 oauth2client==4.1.3
-osfv @ git+https://github.com/Dasharo/osfv-scripts.git@6f7eb96d2f586e00f0f69d52ac0ed9dfc1208eec#subdirectory=osfv_cli
+osfv @ git+https://github.com/Dasharo/osfv-scripts.git@36a030eb006391c3761c25d6972036a5a34fb73b#subdirectory=osfv_cli
 paramiko==3.4.0
 pathspec==0.9.0
 pexpect==4.9.0


### PR DESCRIPTION
* Use Power Supply keywords from osfv_cli libs
* Unify Power On keywords in include/default.robot in a for of "Power On Default" keyword, as most of them looked more or less identical
* Platfom configs can choose to use this keyword as Powe On, or define platform-specific one as before

Tested following platforms via the
BPS001.001 from util/basic-platform-setup.robot:
- protectli-vp2410
- protectli-vp2420
- protectli-vp4630
- protectli-vp4670
- protectli-vp6670
- pcengines-apu2
- msi-pro-z690-a-ddr5
- odroid-h4-plus
- minnowboard-turbot
- optiplex-7010