### PR TITLE
requirements.txt: update dependencies so they work with Python 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 bcrypt==4.1.2
 certifi==2024.2.2
-cffi==1.16.0
+cffi==1.17.1
 cfgv==3.4.0
 charset-normalizer==3.3.2
 click==8.1.7
@@ -10,7 +10,7 @@ dbbot-sqlalchemy==0.2
 distlib==0.3.8
 Faker==24.11.0
 filelock==3.13.4
-greenlet==3.0.3
+greenlet==3.1.1
 gspread==3.1.0
 httplib2==0.22.0
 identify==2.5.36
@@ -58,6 +58,7 @@ setuptools==69.5.1
 six==1.16.0
 SQLAlchemy==2.0.29
 tabulate==0.8.9
+telnetlib @ git+https://github.com/3mdeb/telnetlib@b85e3b5e6068eb3441cb21badb5a266301839e61
 toml==0.10.2
 tomli==2.0.1
 typing_extensions==4.11.0


### PR DESCRIPTION
Previous PR (couldn't reopen): https://github.com/Dasharo/open-source-firmware-validation/pull/597

Works with: 

```
telnetlib @ git+https://github.com/3mdeb/telnetlib@b85e3b5e6068eb3441cb21badb5a266301839e61
```

Should probably also work with <https://pypi.org/project/telnetlib-313-and-up/>

Quick test:

```
 robot -L TRACE -v config:qemu -v rte_ip:127.0.0.1 -v snipeit:no dasharo-compatibility/network-boot.robot
==============================================================================
Network-Boot
==============================================================================
PXE001.001 Dasharo Network Boot is available :: This test aims to ... | PASS |
------------------------------------------------------------------------------
PXE002.001 Dasharo network boot menu boot options order is correct... | PASS |
------------------------------------------------------------------------------
PXE003.001 Autoboot option is available and works correctly :: Thi... | PASS |
------------------------------------------------------------------------------
```