### PR TITLE
Add functionality for running tests on a remote machine

### DIFF
--- a/.github/workflows/qemu-self-test-seabios.yml
+++ b/.github/workflows/qemu-self-test-seabios.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Start QEMU in background
       run: |
-        ./scripts/ci/qemu-run.sh nographic seabios &
+        ./scripts/ci/qemu-run.sh nographic none seabios &
 
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/.github/workflows/qemu-self-test.yml
+++ b/.github/workflows/qemu-self-test.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Start QEMU in background
       run: |
-        ./scripts/ci/qemu-run.sh nographic uefi &
+        ./scripts/ci/qemu-run.sh nographic none uefi &
 
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/docs/qemu.md
+++ b/docs/qemu.md
@@ -72,3 +72,25 @@ robot -b command_log.txt -v snipeit:no -L TRACE -v config:qemu -v rte_ip:127.0.0
 > Note: You do not have to reserve QEMU via `snipeit` therefore `-v snipeit:no`
 > is being used. Use QEMU config `-v config:qemu`, and, as a RTE IP, use
 > `127.0.0.1`. Test suite `dts/dts-tests.robot` is shown here as an example.
+
+## Running tests on a remote machine
+
+This method is useful when you don't want to run QEMU on your local machine due
+to security reasons or lack of memory. The assumption here is that you are
+primarily using this method while developing tests.
+
+The first step is to continuously sync a local folder, which is this
+repository, to a remote machine at `/tmp/osfv` and run QEMU according to the
+parameters there.
+
+For example:
+
+```sh
+./scripts/ci/remote-runner.sh user@42.42.42.42 . nographic seabios
+```
+
+Then, you can run tests in the following way:
+
+```sh
+ssh -t user@42.42.42.42 'cd /tmp/osfv && source venv/bin/activate && ./scripts/ci/qemu-self-test-seabios.sh'
+```

--- a/lib/bios/common.robot
+++ b/lib/bios/common.robot
@@ -36,7 +36,7 @@ Enter Setup Menu
         Write Bare Into Terminal    ${SETUP_MENU_KEY}
         IF    '${BIOS_LIB}' == 'seabios'
             ${menu}=    Get Boot Menu Construction
-            Enter Menu From Snapshot    ${menu}    \[setup\]
+            Enter Submenu From Snapshot    ${menu}    \[setup\]
         END
     END
 

--- a/lib/bios/common.robot
+++ b/lib/bios/common.robot
@@ -36,7 +36,7 @@ Enter Setup Menu
         Write Bare Into Terminal    ${SETUP_MENU_KEY}
         IF    '${BIOS_LIB}' == 'seabios'
             ${menu}=    Get Boot Menu Construction
-            Enter Submenu From Snapshot    ${menu}    \[setup\]
+            Enter Submenu From Snapshot    ${menu}    setup
         END
     END
 

--- a/lib/bios/common.robot
+++ b/lib/bios/common.robot
@@ -182,7 +182,7 @@ Make Sure That Network Boot Is Enabled
 
 Get IPXE Boot Menu Construction
     [Documentation]    Keyword allows to get and return iPXE menu construction.
-    [Arguments]    ${lines_top}=1    ${lines_bot}=0    ${checkpoint}=${EDK2_IPXE_CHECKPOINT}
+    [Arguments]    ${lines_top}=1    ${lines_bot}=0    ${checkpoint}=${IPXE_CHECKPOINT}
     ${menu}=    Read From Terminal Until    ${checkpoint}
     ${construction}=    Parse Menu Snapshot Into Construction    ${menu}    ${lines_top}    ${lines_bot}
     RETURN    ${construction}

--- a/lib/bios/edk2.robot
+++ b/lib/bios/edk2.robot
@@ -436,65 +436,6 @@ Save Changes And Reset
     Save Changes
     Tianocore Reset System
 
-Make Sure That Network Boot Is Enabled
-    [Documentation]    This keywords checks that "Enable network boot" in
-    ...    "Networking Options" is enabled when present, so the network
-    ...    boot tests can be executed.
-    IF    not ${DASHARO_NETWORKING_MENU_SUPPORT}    RETURN
-    Set UEFI Option    NetworkBoot    ${TRUE}
-
-Boot System Or From Connected Disk    # robocop: disable=too-long-keyword
-    [Documentation]    Tries to boot ${system_name}. If it is not possible then it tries
-    ...    to boot from connected disk set up in config
-    [Arguments]    ${system_name}
-    IF    '${DUT_CONNECTION_METHOD}' == 'SSH'    RETURN
-
-    IF    '''${SEABIOS_BOOT_DEVICE}''' != ''
-        Read From Terminal Until    Press F10 key now for boot menu
-        Write Bare Into Terminal    ${F10}
-        Read From Terminal Until    Select boot device
-        Write Bare Into Terminal    ${SEABIOS_BOOT_DEVICE}
-        RETURN
-    END
-    ${menu_construction}=    Enter Boot Menu And Return Construction
-    # With ESP scanning feature boot entries are named differently:
-    IF    ${ESP_SCANNING_SUPPORT} == ${TRUE}
-        IF    "${system_name}" == "ubuntu"
-            ${system_name}=    Set Variable    Ubuntu
-        END
-        IF    "${system_name}" == "trenchboot" and "${MANUFACTURER}" == "QEMU"
-            ${system_name}=    Set Variable    QEMU HARDDISK
-        END
-    END
-    ${is_system_present}=    Evaluate    "${system_name}" in """${menu_construction}"""
-    IF    not ${is_system_present}
-        ${ssd_list}=    Get Current CONFIG List Param    Storage_SSD    boot_name
-        ${ssd_list_length}=    Get Length    ${ssd_list}
-        IF    ${ssd_list_length} == 0
-            ${hdd_list}=    Get Current CONFIG List Param    HDD_Storage    boot_name
-            ${hdd_list_length}=    Get Length    ${hdd_list}
-            IF    ${hdd_list_length} == 0
-                ${mmc_list}=    Get Current CONFIG List Param    MMC_Storage    boot_name
-                ${mmc_list_length}=    Get Length    ${mmc_list}
-                IF    ${mmc_list_length} == 0
-                    FAIL    "System was not found and there are no disk connected"
-                END
-                ${disk_name}=    Set Variable    ${mmc_list[0]}
-            ELSE
-                ${disk_name}=    Set Variable    ${hdd_list[0]}
-            END
-        ELSE
-            ${disk_name}=    Set Variable    ${ssd_list[0]}
-        END
-        ${system_index}=    Get Index From List    ${menu_construction}    ${disk_name}
-        IF    ${system_index} == -1
-            Fail    Disk: ${disk_name} not found in Boot Menu
-        END
-    ELSE
-        ${system_index}=    Get Index Of Matching Option In Menu    ${menu_construction}    ${system_name}
-    END
-    Press Key N Times And Enter    ${system_index}    ${ARROW_DOWN}
-
 Get Firmware Version From Tianocore Setup Menu
     [Documentation]    Keyword allows to read firmware version from Tianocore
     ...    Setup menu header.

--- a/lib/bios/edk2.robot
+++ b/lib/bios/edk2.robot
@@ -436,67 +436,6 @@ Save Changes And Reset
     Save Changes
     Tianocore Reset System
 
-<<<<<<< HEAD
-Make Sure That Network Boot Is Enabled
-    [Documentation]    This keywords checks that "Enable network boot" in
-    ...    "Networking Options" is enabled when present, so the network
-    ...    boot tests can be executed.
-    IF    not ${DASHARO_NETWORKING_MENU_SUPPORT}    RETURN
-    Set UEFI Option    NetworkBoot    ${TRUE}
-
-||||||| parent of 00399ede531f (lib/bios: move some keywords to common lib)
-Boot System Or From Connected Disk    # robocop: disable=too-long-keyword
-    [Documentation]    Tries to boot ${system_name}. If it is not possible then it tries
-    ...    to boot from connected disk set up in config
-    [Arguments]    ${system_name}
-    IF    '${DUT_CONNECTION_METHOD}' == 'SSH'    RETURN
-
-    IF    '''${SEABIOS_BOOT_DEVICE}''' != ''
-        Read From Terminal Until    Press F10 key now for boot menu
-        Write Bare Into Terminal    ${F10}
-        Read From Terminal Until    Select boot device
-        Write Bare Into Terminal    ${SEABIOS_BOOT_DEVICE}
-        RETURN
-    END
-    ${menu_construction}=    Enter Boot Menu And Return Construction
-    # With ESP scanning feature boot entries are named differently:
-    IF    ${ESP_SCANNING_SUPPORT} == ${TRUE}
-        IF    "${system_name}" == "ubuntu"
-            ${system_name}=    Set Variable    Ubuntu
-        END
-        IF    "${system_name}" == "trenchboot" and "${MANUFACTURER}" == "QEMU"
-            ${system_name}=    Set Variable    QEMU HARDDISK
-        END
-    END
-    ${is_system_present}=    Evaluate    "${system_name}" in """${menu_construction}"""
-    IF    not ${is_system_present}
-        ${ssd_list}=    Get Current CONFIG List Param    Storage_SSD    boot_name
-        ${ssd_list_length}=    Get Length    ${ssd_list}
-        IF    ${ssd_list_length} == 0
-            ${hdd_list}=    Get Current CONFIG List Param    HDD_Storage    boot_name
-            ${hdd_list_length}=    Get Length    ${hdd_list}
-            IF    ${hdd_list_length} == 0
-                ${mmc_list}=    Get Current CONFIG List Param    MMC_Storage    boot_name
-                ${mmc_list_length}=    Get Length    ${mmc_list}
-                IF    ${mmc_list_length} == 0
-                    FAIL    "System was not found and there are no disk connected"
-                END
-                ${disk_name}=    Set Variable    ${mmc_list[0]}
-            ELSE
-                ${disk_name}=    Set Variable    ${hdd_list[0]}
-            END
-        ELSE
-            ${disk_name}=    Set Variable    ${ssd_list[0]}
-        END
-        ${system_index}=    Get Index From List    ${menu_construction}    ${disk_name}
-        IF    ${system_index} == -1
-            Fail    Disk: ${disk_name} not found in Boot Menu
-        END
-    ELSE
-        ${system_index}=    Get Index Of Matching Option In Menu    ${menu_construction}    ${system_name}
-    END
-    Press Key N Times And Enter    ${system_index}    ${ARROW_DOWN}
-
 Make Sure That Network Boot Is Enabled
     [Documentation]    This keywords checks that "Enable network boot" in
     ...    "Networking Options" is enabled when present, so the network

--- a/lib/bios/seabios.robot
+++ b/lib/bios/seabios.robot
@@ -57,8 +57,14 @@ Enter Boot Menu From Snapshot
 Enter Submenu From Snapshot
     [Documentation]    Enter given Menu option and return construction
     [Arguments]    ${menu}    ${option}
-    ${key}=    Extract Menu Key    ${menu}    ${option}
-    Write Bare Into Terminal    ${key}
+    IF    '${menu}[3]' == '${EDK2_IPXE_CHECKPOINT}'
+        ${index}=    Get Index Of Matching Option In Menu    ${menu}    ${option}
+        Should Not Be Equal As Integers    ${index}    -1    msg=Option ${option} not found in menu
+        Press Key N Times And Enter    ${index}    ${ARROW_DOWN}
+    ELSE
+        ${key}=    Extract Menu Key    ${menu}    ${option}
+        Write Bare Into Terminal    ${key}
+    END
 
 Extract Boot Menu Key
     [Documentation]    Extract boot menu which should be hit to enter given Menu in SeaBIOS

--- a/lib/bios/seabios.robot
+++ b/lib/bios/seabios.robot
@@ -42,7 +42,7 @@ Set Option State
     [Arguments]    ${menu}    ${option}    ${target_state}
     ${current_state}=    Get Option State    ${menu}    ${option}
     IF    '${current_state}' != '${target_state}'
-        ${menu}=    Enter Menu From Snapshot    ${menu}    ${option}
+        ${menu}=    Enter Submenu From Snapshot    ${menu}    ${option}
         RETURN    ${TRUE}
     ELSE
         RETURN    ${FALSE}
@@ -54,7 +54,7 @@ Enter Boot Menu From Snapshot
     ${key}=    Extract Boot Menu Key    ${menu}    ${option}
     Write Bare Into Terminal    ${key}
 
-Enter Menu From Snapshot
+Enter Submenu From Snapshot
     [Documentation]    Enter given Menu option and return construction
     [Arguments]    ${menu}    ${option}
     ${key}=    Extract Menu Key    ${menu}    ${option}
@@ -103,14 +103,14 @@ Enter TPM Configuration
     [Documentation]    Enter TPM Configuration with Boot Menu Construction.
     Enter Boot Menu
     ${menu}=    Get Boot Menu Construction
-    Enter Menu From Snapshot    ${menu}    TPM Configuration
+    Enter Submenu From Snapshot    ${menu}    TPM Configuration
 
 Enter IPXE
     [Documentation]    Enter iPXE with Boot Menu Construction.
     Enable Network/PXE Boot
     Enter Boot Menu
     ${menu}=    Get Boot Menu Construction
-    Enter Menu From Snapshot    ${menu}    iPXE
+    Enter Submenu From Snapshot    ${menu}    iPXE
 
 # robocop: disable=unused-argument
 

--- a/platform-configs/qemu-selftests-seabios.robot
+++ b/platform-configs/qemu-selftests-seabios.robot
@@ -45,3 +45,6 @@ ${DASHARO_PCI_PCIE_MENU_SUPPORT}=       ${TRUE}
 ${DASHARO_MEMORY_MENU_SUPPORT}=         ${TRUE}
 
 ${BIOS_LIB}=                            seabios
+${IPXE_BOOT_SUPPORT}=                   ${TRUE}
+${IPXE_BOOT_ENTRY}=                     iPXE
+${EDK2_IPXE_CHECKPOINT}=                iPXE Shell

--- a/scripts/ci/qemu-run.sh
+++ b/scripts/ci/qemu-run.sh
@@ -73,7 +73,7 @@ esc() {
 }
 
 check_disks() {
-  UBUNTU_VERSION="22.04.4"
+  UBUNTU_VERSION="24.04.1"
 
   if [ ! -f "${HDD_PATH}" ]; then
     echo "Disk at ${HDD_PATH} not found. You can create one with:"
@@ -84,7 +84,7 @@ check_disks() {
   if [[ "$1" == "os_install" && ! -f "${INSTALLER_PATH}" ]]; then
     echo "OS installer at ${INSTALLER_PATH} not found. Please provide OS installer, to continue."
     echo "Example:"
-    echo "wget -O $(esc "$INSTALLER_PATH") $(esc "http://cdn.releases.ubuntu.com/jammy/ubuntu-${UBUNTU_VERSION}-desktop-amd64.iso")"
+    echo "wget -O $(esc "$INSTALLER_PATH") $(esc "http://cdn.releases.ubuntu.com/noble/ubuntu-${UBUNTU_VERSION}-desktop-amd64.iso")"
     exit 1
   fi
 }

--- a/scripts/ci/qemu-run.sh
+++ b/scripts/ci/qemu-run.sh
@@ -41,6 +41,8 @@ This is the QEMU wrapper script for the Dasharo Open Source Firmware Validation.
     graphic      graphic output is available in QEMU process window
 
   Available ACTIONS:
+    none         a machine with lower resources assigned will be spawned and no
+                 disk will be connected;
     os           a machine with more resources assigned will be spawned and HDD from
                  $HDD_PATH will be connected; suitable for firmware and OS validation,
                  if some OS is already installed on the disk image, it can be booted
@@ -48,12 +50,11 @@ This is the QEMU wrapper script for the Dasharo Open Source Firmware Validation.
                  from: $INSTALLER_PATH will be also attached
 
   Available FIRMWARE:
-    uefi         a machine with lower resources assigned will be spawned and no
-                 disk will be connected; suitable for Dasharo (coreboot+UEFI)
-                 validation, but not for OS booting
-    seabios      a machine with lower resources assigned will be spawned and no
-                 disk will be connected; suitable for Dasharo (coreboot+SeaBIOS)
-                 validation, but not for OS booting
+
+    uefi         suitable for Dasharo (coreboot+UEFI) validation, but not for OS
+                 booting
+    seabios      suitable for Dasharo (coreboot+SeaBIOS) validation, but not for
+                 OS booting
 
   Environmental variables:
     DIR         working directory, defaults to current working directory
@@ -181,6 +182,9 @@ esac
 ACTION="$2"
 
 case "${ACTION}" in
+  none)
+    MEMORY="1G"
+    ;;
   os)
     MEMORY="4G"
     QEMU_PARAMS="${QEMU_PARAMS} ${QEMU_PARAMS_OS}"

--- a/scripts/ci/qemu-run.sh
+++ b/scripts/ci/qemu-run.sh
@@ -153,8 +153,6 @@ QEMU_PARAMS_OS="-device ich9-intel-hda \
   -audiodev pa,id=hda,server=${PULSE_SERVER},out.frequency=44100 \
   -object rng-random,id=rng0,filename=/dev/urandom \
   -device virtio-rng-pci,max-bytes=1024,period=1000 \
-  -device virtio-net,netdev=vmnic \
-  -netdev user,id=vmnic,hostfwd=tcp::5222-:22 \
   -drive file=${HDD_PATH},if=ide"
 
 QEMU_PARAMS_INSTALLER="-cdrom ${INSTALLER_PATH}"
@@ -205,7 +203,9 @@ FIRMWARE="$3"
 
 case "${FIRMWARE}" in
   uefi)
-    QEMU_UEFI_PARAMS="-global driver=cfi.pflash01,property=secure,value=on"
+    QEMU_UEFI_PARAMS="-global driver=cfi.pflash01,property=secure,value=on \
+      -device virtio-net,netdev=vmnic \
+      -netdev user,id=vmnic,hostfwd=tcp::5222-:22"
     QEMU_PARAMS="${QEMU_PARAMS} ${QEMU_UEFI_PARAMS}"
 		;;
   seabios)

--- a/scripts/ci/qemu-self-test-seabios.sh
+++ b/scripts/ci/qemu-self-test-seabios.sh
@@ -3,6 +3,7 @@
 # Define an array of commands
 commands=(
   "robot -X -L TRACE -v config:qemu-selftests-seabios -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/setup-and-boot-seabios -v snipeit:no self-tests/setup-and-boot-seabios.robot"
+  "robot -X -L TRACE -v config:qemu-selftests-seabios -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/network-boot -v snipeit:no dasharo-compatibility/network-boot.robot"
 )
 
 # Initialize a variable to track overall success

--- a/scripts/ci/remote-runner.sh
+++ b/scripts/ci/remote-runner.sh
@@ -56,8 +56,8 @@ REMOTE_SRC_DIR="/tmp/osfv"
 # Function to continuously sync local directory with remote directory
 start_sync() {
 	ssh $REMOTE_USER_HOST "rm -rf $REMOTE_SRC_DIR"
-	rsync -avz --exclude={'.git/','logs/','venv/'} $LOCAL_SRC_DIR $REMOTE_USER_HOST:$REMOTE_SRC_DIR
-	ssh $REMOTE_USER_HOST "cd $REMOTE_SRC_DIR && virtualenv venv && source venv/bin/activate && pip install -r requirements.txt && pip install --upgrade pip"
+	rsync -qavz --exclude={'.git/','logs/','venv/'} $LOCAL_SRC_DIR $REMOTE_USER_HOST:$REMOTE_SRC_DIR
+	ssh $REMOTE_USER_HOST "cd $REMOTE_SRC_DIR && virtualenv venv && source venv/bin/activate && pip install -q -r requirements.txt && pip install -q --upgrade pip"
 	inotifywait -m -r -e modify,create,delete --exclude '\.git|logs|venv' --format '%w%f' $LOCAL_SRC_DIR | while read file; do
 		# Check if the changed file is not inside .git directory
 		if [[ $file != *".git"* ]]; then

--- a/scripts/ci/remote-runner.sh
+++ b/scripts/ci/remote-runner.sh
@@ -74,12 +74,19 @@ run_qemu() {
     rsync -avz $QEMU_FW_FILE $REMOTE_USER_HOST:$REMOTE_SRC_DIR
 
     ssh $REMOTE_USER_HOST "export QEMU_FW_FILE=$REMOTE_SRC_DIR/$(basename $QEMU_FW_FILE) \
-    && HDD_PATH=~/qemu-data/hdd.qcow2 \
+    && cd ${REMOTE_SRC_DIR} && \
+    HDD_PATH=~/qemu-data/hdd.qcow2 \
+    DIR=${REMOTE_SRC_DIR} \
     INSTALLER_PATH=~/qemu-data/ubuntu-24.04.1-desktop-amd64.iso \
     ${REMOTE_SRC_DIR}/scripts/ci/qemu-run.sh $1 $2 $3"
 
   else
-    ssh $REMOTE_USER_HOST "${REMOTE_SRC_DIR}/scripts/ci/qemu-run.sh $1 $2 $3"
+    ssh $REMOTE_USER_HOST "cd ${REMOTE_SRC_DIR} && \
+    HDD_PATH=~/qemu-data/hdd.qcow2 \
+    DIR=${REMOTE_SRC_DIR} \
+    INSTALLER_PATH=~/qemu-data/ubuntu-24.04.1-desktop-amd64.iso \
+    ${REMOTE_SRC_DIR}/scripts/ci/qemu-run.sh $1 $2 $3"
+
   fi
 }
 

--- a/scripts/ci/remote-runner.sh
+++ b/scripts/ci/remote-runner.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# Function to display help
+display_help() {
+    echo "Usage: $0 <user@remote-host> <local-src-dir> <qemu-mode> <action>"
+    echo
+    echo "This script continuously syncs a local directory to a remote"
+    echo "directory and runs a QEMU instance according to parameters on"
+    echo "the remote machine."
+    echo
+    echo "Arguments:"
+    echo "  user@remote-host    The username and host of the remote machine."
+    echo "  local-src-dir       The local source directory to sync."
+    echo "  qemu-mode           The QEMU mode nigraphic/vnc/graphic/..."
+    echo "  action              The QEMU actions like uefi/firmware/seabios/..."
+    echo
+    echo "Check ./scripts/ci/qemu-run.sh help for more information."
+    echo
+    echo "Options:"
+    echo "  -h, --help          Display this help message and exit."
+    echo
+    exit 1
+}
+
+# Check for the required parameters
+if [ "$#" -ne 4 ]; then
+    display_help
+fi
+
+# Check for help option
+for arg in "$@"
+do
+    if [ "$arg" == "-h" ] || [ "$arg" == "--help" ]; then
+        display_help
+    fi
+done
+
+# Function to clean up background processes when the script exits
+cleanup() {
+	echo "Cleaning up..."
+	# Kill the inotifywait background process
+	kill $INOTIFY_PID
+}
+
+# Set trap to call cleanup function when the script exits
+trap cleanup exit
+
+REMOTE_USER_HOST="$1"
+LOCAL_SRC_DIR="$2" # Local source directory provided as the second parameter
+SELF_TEST_TYPE="$3"
+SELF_TEST_FW="$4"
+REMOTE_SRC_DIR="/tmp/osfv"
+REMOTE_HOST=$(echo $REMOTE_USER_HOST | cut -d '@' -f2)
+
+# Function to continuously sync local directory with remote directory
+start_sync() {
+	ssh $REMOTE_USER_HOST "rm -rf $REMOTE_SRC_DIR"
+	rsync -avz --exclude={'.git/','logs/','venv/'} $LOCAL_SRC_DIR $REMOTE_USER_HOST:$REMOTE_SRC_DIR
+	ssh $REMOTE_USER_HOST "cd $REMOTE_SRC_DIR && virtualenv venv && source venv/bin/activate && pip install -r requirements.txt && pip install --upgrade pip"
+	inotifywait -m -r -e modify,create,delete --exclude '\.git|logs|venv' --format '%w%f' $LOCAL_SRC_DIR | while read file; do
+		# Check if the changed file is not inside .git directory
+		if [[ $file != *".git"* ]]; then
+			rsync -avz --exclude={'.git/','logs/','venv/'} $LOCAL_SRC_DIR $REMOTE_USER_HOST:$REMOTE_SRC_DIR
+		fi
+	done &
+	INOTIFY_PID=$!
+}
+
+# Function to run HTTP server
+run_qemu() {
+  ssh $REMOTE_USER_HOST 'pkill -f "qemu-system-x86_64"'
+  if [ -n "$QEMU_FW_FILE" ]; then
+    rsync -avz $QEMU_FW_FILE $REMOTE_USER_HOST:$REMOTE_SRC_DIR
+    ssh $REMOTE_USER_HOST "export QEMU_FW_FILE=$REMOTE_SRC_DIR/$(basename $QEMU_FW_FILE) && ${REMOTE_SRC_DIR}/scripts/ci/qemu-run.sh $1 $2"
+  else
+    ssh $REMOTE_USER_HOST "${REMOTE_SRC_DIR}/scripts/ci/qemu-run.sh $1 $2"
+  fi
+}
+
+# Function to check if a command exists
+command_exists() {
+	command -v "$1" >/dev/null 2>&1
+}
+
+# Check for required commands
+if ! command_exists rsync; then
+	echo "rsync is not installed. Please install it."
+	exit 1
+fi
+
+if ! command_exists inotifywait; then
+	echo "inotify-tools is not installed. Please install it."
+	exit 1
+fi
+
+# Start continuous synchronization in the background
+start_sync
+
+# Run QEMU
+run_qemu "${SELF_TEST_TYPE}" "${SELF_TEST_FW}"
+
+# After the QEMU and self-test script exits, kill the background sync process
+kill $!

--- a/self-tests/setup-and-boot-seabios.robot
+++ b/self-tests/setup-and-boot-seabios.robot
@@ -136,5 +136,7 @@ Enter iPXE
     [Documentation]    Test Enter iPXE kwd
     Power On
     Enter IPXE
-    ${out}=    Read From Terminal Until    autoboot
-    Should Contain    ${out}    ipxe shell
+    ${ipxe_menu}=    Get IPXE Boot Menu Construction
+    Enter Submenu From Snapshot    ${ipxe_menu}    iPXE Shell
+    Set Prompt For Terminal    iPXE>
+    Read From Terminal Until Prompt

--- a/self-tests/setup-and-boot-seabios.robot
+++ b/self-tests/setup-and-boot-seabios.robot
@@ -88,12 +88,12 @@ Get Option State
     ${state}=    Get Option State    ${menu}    Network/PXE boot
     Should Contain    ${state}    Disabled
 
-Enter Menu From Snapshot
-    [Documentation]    Test Enter Menu From Snapshot and Return sortbootorder Construction kwd
+Enter Submenu From Snapshot
+    [Documentation]    Test Enter Submenu From Snapshot kwd
     Power On
     Enter Setup Menu
     ${menu}=    Get Menu Construction    Save configuration and exit    7    0
-    Enter Menu From Snapshot    ${menu}    Network/PXE boot
+    Enter Submenu From Snapshot    ${menu}    Network/PXE boot
     ${menu}=    Get Menu Construction    Save configuration and exit    7    0
     List Should Not Contain Value    ${menu}    Boot order
     List Should Contain Value    ${menu}    r Restore boot order defaults


### PR DESCRIPTION
This commit introduces a new feature that allows users to run tests on a remote machine. This is particularly useful when running QEMU on the local machine is not desirable due to security concerns or memory limitations.

The changes include updates to the documentation to explain the new feature and a new script, `remote-runner.sh`, which handles the synchronization of a local directory to a remote machine and the execution of QEMU based on parameters on the remote machine.