### PR TITLE
Another approach to write netboot-lib

### DIFF
--- a/keywords.robot
+++ b/keywords.robot
@@ -3,6 +3,7 @@ Library         Collections
 Library         OperatingSystem
 Resource        pikvm-rest-api/pikvm_comm.robot
 Resource        lib/secure-boot-lib.robot
+Resource        lib/netbootxyz-lib.robot
 Resource        lib/usb-hid-msc-lib.robot
 Resource        lib/dts-lib.robot
 Resource        lib/terminal.robot

--- a/lib/bios/common.robot
+++ b/lib/bios/common.robot
@@ -166,7 +166,7 @@ Boot System Or From Connected Disk    # robocop: disable=too-long-keyword
     ELSE
         ${system_index}=    Get Index Of Matching Option In Menu    ${menu_construction}    ${system_name}
     END
-    Select Boot Menu Option    ${system_index}    ${ARROW_DOWN}
+    Select Option    ${system_index}    ${ARROW_DOWN}
 
 Make Sure That Network Boot Is Enabled
     [Documentation]    This keywords checks that "Enable network boot" in
@@ -224,3 +224,8 @@ Press Enter
     ELSE
         Press Key N Times    1    ${ENTER}
     END
+
+Select Option
+    [Documentation]    Select the option by hitting index-times given key.
+    [Arguments]    ${index}    ${key}
+    Press Key N Times    ${index}    ${key}

--- a/lib/bios/edk2.robot
+++ b/lib/bios/edk2.robot
@@ -444,8 +444,3 @@ Get Firmware Version From Tianocore Setup Menu
     ${firmware_line}=    Get Lines Containing String    ${output}    Dasharo (coreboot+UEFI)
     ${firmware_version}=    Get Regexp Matches    ${firmware_line}    v\\d{1,}\.\\d{1,}\.\\d{1,}
     RETURN    ${firmware_version}
-
-Select Boot Menu Option
-    [Documentation]    Select the boot menu option using the given index.
-    [Arguments]    ${index}    ${key}
-    Press Key N Times    ${index}    ${key}

--- a/lib/bios/seabios.robot
+++ b/lib/bios/seabios.robot
@@ -42,7 +42,10 @@ Set Option State
     [Arguments]    ${menu}    ${option}    ${target_state}
     ${current_state}=    Get Option State    ${menu}    ${option}
     IF    '${current_state}' != '${target_state}'
-        ${menu}=    Enter Submenu From Snapshot    ${menu}    ${option}
+        Enter Submenu From Snapshot    ${menu}    ${option}
+        ${menu}=    Get Menu Construction    Save configuration and exit    7    0
+        ${current_state}=    Get Option State    ${menu}    ${option}
+        Should Match    ${current_state}    Enabled
         RETURN    ${TRUE}
     ELSE
         RETURN    ${FALSE}

--- a/lib/bios/seabios.robot
+++ b/lib/bios/seabios.robot
@@ -118,14 +118,3 @@ Enter IPXE
     ${menu}=    Get Boot Menu Construction
     Enter Submenu From Snapshot    ${menu}    iPXE
 
-# robocop: disable=unused-argument
-
-Select Boot Menu Option
-    [Documentation]    Select the boot menu option using the given index.
-    ...    Accounts for indices counting from zero, and SeaBIOS options counting
-    ...    from '1.'. Has to take a dummy parameter for compatibility with the
-    ...    EDK2 version of this keyword.
-    [Arguments]    ${index}    ${dummy}
-    ${option}=    Evaluate    ${index} + 1
-    Write Bare Into Terminal    '${option}'
-# robocop: disable=unused-argument

--- a/lib/netbootxyz-lib.robot
+++ b/lib/netbootxyz-lib.robot
@@ -66,3 +66,48 @@ Enter Netboot.Xyz Menu And Return Construction
     Enter Netboot.Xyz Menu
     ${nb_menu}=    Get Netboot.Xyz Menu Construction
     RETURN    ${nb_menu}
+
+Enter Netboot.Xyz Linux Install Menu And Return Construction
+    [Documentation]    Return only selectable entries of netboot.xyz Linux
+    ...    Install submenu. If some menu option is not selectable it will not
+    ...    be in the menu construction list.
+    Enter Netboot.Xyz Menu
+    ${nb_menu}=    Get Netboot.Xyz Menu Construction
+    ${index}=    Get Index Of Matching Option In Menu    ${nb_menu}    Linux Network Installs (64-bit)
+    Select Option    ${index}    ${ARROW_DOWN}
+    Press Enter
+    Select Option    1    ${ARROW_DOWN}
+    ${out}=    Read From Terminal
+    ${menu}=    Parse Netboot.Xyz Linux Install Menu Snapshot Into Construction    ${out}
+    RETURN    ${menu}
+
+Parse Netboot.Xyz Linux Install Menu Snapshot Into Construction
+    [Documentation]    Breaks grabbed netboot.xyz Linux install menu data into
+    ...    selectable lines.
+    [Arguments]    ${menu}
+    ${menu}=    Remove String    ${menu}    \r
+    @{menu_lines}=    Split To Lines    ${menu}
+    @{construction}=    Create List
+    ${nextpage}=    Set Variable    ${FALSE}
+    FOR    ${line}    IN    @{menu_lines}
+        ${match}=    Run Keyword And Return Status    Should Match Regexp    ${line}    \\w+( \\w+)*$
+        IF    ${match}
+            ${line}=    Strip String    ${line}
+            # If the resulting line is not empty, add it as a menu entry
+            ${length}=    Get Length    ${line}
+            IF    ${length} > 0    Append To List    ${construction}    ${line}
+        END
+    END
+    Remove Values From List
+    ...    ${construction}
+    ...    Linux Installers - Current Arch [ x86_64 ]
+    ...    Linux Distros:
+    ${nextpage}=    Strip String    ${menu_lines[-1]}
+    IF    "${nextpage}" == "..."
+        ${keypress}=    Get Length    ${construction}
+        Press Key N Times    ${keypress}    ${ARROW_DOWN}
+        ${out}=    Read From Terminal
+        ${menu}=    Parse Netboot.Xyz Linux Install Menu Snapshot Into Construction    ${out}
+        ${construction}=    Combine Lists   ${construction}    ${menu}
+    END
+    RETURN    ${construction}

--- a/lib/netbootxyz-lib.robot
+++ b/lib/netbootxyz-lib.robot
@@ -4,6 +4,13 @@ Documentation       Collection of keywords related to netboot.xyz
 Library             Collections
 Library             String
 
+# Nomenclature:
+# - Netboot.Xyz Menu - netboot.xyz main menu
+# - Netboot.Xyz Linux Install Menu - submenu of Netboot.Xyz Menu behind Linux
+# Network Installs (64-bit) (aka Linux Installers - Current Arch [ x86_64 ])
+# - Netboot.Xyz Linux Distro Install Menu - submenu of Netboot.Xyz Linux Install
+# Menu of each distribtuion, those may vary depending on distro contain various
+# releases and submenus
 
 *** Keywords ***
 Get Netboot.Xyz Menu Construction
@@ -76,10 +83,56 @@ Enter Netboot.Xyz Linux Install Menu And Return Construction
     ${index}=    Get Index Of Matching Option In Menu    ${nb_menu}    Linux Network Installs (64-bit)
     Select Option    ${index}    ${ARROW_DOWN}
     Press Enter
-    Select Option    1    ${ARROW_DOWN}
     ${out}=    Read From Terminal
     ${menu}=    Parse Netboot.Xyz Linux Install Menu Snapshot Into Construction    ${out}
     RETURN    ${menu}
+
+Enter Netboot.Xyz Linux Distro Install Menu And Return Construction
+    [Documentation]    Return only selectable entries of netboot.xyz Linux
+    ...    Install submenu for provided Linux distribution. If some menu option
+    ...    is not selectable it will not be in the menu construction list.
+    [Arguments]    ${distro}
+    Enter Netboot.Xyz Menu
+    ${nb_menu}=    Get Netboot.Xyz Menu Construction
+    ${index}=    Get Index Of Matching Option In Menu    ${nb_menu}    Linux Network Installs (64-bit)
+    Select Option    ${index}    ${ARROW_DOWN}
+    Press Enter
+    Select Option    1    ${ARROW_DOWN}
+    ${out}=    Read From Terminal
+    ${menu}=    Parse Netboot.Xyz Linux Install Menu Snapshot Into Construction    ${out}
+
+    ${index}=    Get Index Of Matching Option In Menu    ${menu}    ${distro}    ${TRUE}
+    Should Not Be Equal    '${index}'    -1    The option was not found in menu
+    ${index}=    Evaluate    ${index}-1
+    Press Key N Times And Enter    ${index}    ${ARROW_DOWN}
+    ${out}=    Read From Terminal
+    ${menu}=    Parse Netboot.Xyz Linux Distro Install Menu Snapshot Into Construction    ${out}
+    RETURN    ${menu}
+
+Parse Netboot.Xyz Linux Distro Install Menu Snapshot Into Construction
+    [Documentation]    Breaks grabbed netboot.xyz Linux distro install menu data
+    ...    into selectable lines.
+    [Arguments]    ${menu}
+    ${menu}=    Remove String    ${menu}    \r
+    @{menu_lines}=    Split To Lines    ${menu}
+    @{construction}=    Create List
+    ${nextpage}=    Set Variable    ${FALSE}
+    FOR    ${line}    IN    @{menu_lines}
+        ${match}=    Run Keyword And Return Status    Should Match Regexp    ${line}    ^ {6}\\S+(?: \\S+)*$
+        IF    ${match}
+            ${line}=    Strip String    ${line}
+            # If the resulting line is not empty, add it as a menu entry
+            ${length}=    Get Length    ${line}
+            IF    ${length} > 0    Append To List    ${construction}    ${line}
+        END
+    END
+    Remove Values From List
+    ...    ${construction}
+    ...    Latest Release
+    ...    Older Releases
+    ...    Testing Releases
+    ...    .* - amd64
+    RETURN    ${construction}
 
 Parse Netboot.Xyz Linux Install Menu Snapshot Into Construction
     [Documentation]    Breaks grabbed netboot.xyz Linux install menu data into
@@ -107,7 +160,11 @@ Parse Netboot.Xyz Linux Install Menu Snapshot Into Construction
         ${keypress}=    Get Length    ${construction}
         Press Key N Times    ${keypress}    ${ARROW_DOWN}
         ${out}=    Read From Terminal
+        ${out}=    Fetch From Right    ${out}    ...
         ${menu}=    Parse Netboot.Xyz Linux Install Menu Snapshot Into Construction    ${out}
         ${construction}=    Combine Lists   ${construction}    ${menu}
+        # We have to get back to top of the list to no confuse user
+        Press Key N Times    ${keypress}    ${ARROW_UP}
     END
     RETURN    ${construction}
+

--- a/lib/netbootxyz-lib.robot
+++ b/lib/netbootxyz-lib.robot
@@ -87,6 +87,19 @@ Enter Netboot.Xyz Linux Install Menu And Return Construction
     ${menu}=    Parse Netboot.Xyz Linux Install Menu Snapshot Into Construction    ${out}
     RETURN    ${menu}
 
+Enter Netboot.Xyz Utilities Menu And Return Construction
+    [Documentation]    Return only selectable entries of netboot.xyz Utilities
+    ...    submenu. If some menu option is not selectable it will not
+    ...    be in the menu construction list.
+    Enter Netboot.Xyz Menu
+    ${nb_menu}=    Get Netboot.Xyz Menu Construction
+    ${index}=    Get Index Of Matching Option In Menu    ${nb_menu}    Utilities (64-bit)
+    Select Option    ${index}    ${ARROW_DOWN}
+    Press Enter
+    ${out}=    Read From Terminal
+    ${menu}=    Parse Netboot.Xyz Linux Distro Install Menu Snapshot Into Construction    ${out}
+    RETURN    ${menu}
+
 Enter Netboot.Xyz Linux Distro Install Menu And Return Construction
     [Documentation]    Return only selectable entries of netboot.xyz Linux
     ...    Install submenu for provided Linux distribution. If some menu option
@@ -132,6 +145,19 @@ Parse Netboot.Xyz Linux Distro Install Menu Snapshot Into Construction
     ...    Older Releases
     ...    Testing Releases
     ...    .* - amd64
+    ...    netboot.xyz tools:
+    ...    Utilities:
+    ${nextpage}=    Strip String    ${menu_lines[-1]}
+    IF    "${nextpage}" == "..."
+        ${keypress}=    Get Length    ${construction}
+        Press Key N Times    ${keypress}    ${ARROW_DOWN}
+        ${out}=    Read From Terminal
+        ${out}=    Fetch From Right    ${out}    ...
+        ${menu}=    Parse Netboot.Xyz Linux Distro Install Menu Snapshot Into Construction    ${out}
+        ${construction}=    Combine Lists   ${construction}    ${menu}
+        # We have to get back to top of the list to no confuse user
+        Press Key N Times    ${keypress}    ${ARROW_UP}
+    END
     RETURN    ${construction}
 
 Parse Netboot.Xyz Linux Install Menu Snapshot Into Construction
@@ -168,3 +194,14 @@ Parse Netboot.Xyz Linux Install Menu Snapshot Into Construction
     END
     RETURN    ${construction}
 
+Enter Netboot.Xyz And Set Kernel Cmdline Params
+    [Documentation]    Enter Netboot.Xyz Utilities and set kernel cmdline params
+    [Arguments]    ${params}
+    ${menu}=    Enter Netboot.Xyz Utilities Menu And Return Construction
+    ${index}=    Get Index Of Matching Option In Menu    ${menu}    Kernel cmdline params: []    ${TRUE}
+    Should Not Be Equal    '${index}'    -1    The option was not found in menu
+    Press Key N Times And Enter    ${index}    ${ARROW_DOWN}
+    ${out}=    Read From Terminal
+    Write Bare Into Terminal    ${params}\n    0.1
+    ${out}=    Read From Terminal
+    Press Key N Times    2    ${ESC}

--- a/lib/netbootxyz-lib.robot
+++ b/lib/netbootxyz-lib.robot
@@ -6,29 +6,6 @@ Library             String
 
 
 *** Keywords ***
-Boot To Netboot.Xyz
-    [Documentation]    This keyword enters netboot.xyz menu after the platform was
-    ...    powered on.
-    Power On
-    ${boot_menu}=    Enter Boot Menu And Return Construction
-    Enter Submenu From Snapshot    ${boot_menu}    ${IPXE_BOOT_ENTRY}
-    ${ipxe_menu}=    Get IPXE Boot Menu Construction
-    IF    '${BIOS_LIB}' == 'seabios'
-        Enter Submenu From Snapshot    ${ipxe_menu}    iPXE Shell
-        Set Prompt For Terminal    iPXE>
-        Read From Terminal Until Prompt
-        Write Into Terminal    dhcp
-        ${out}=    Read From Terminal Until Prompt
-        Should Contain    ${out}    ok
-        Set DUT Response Timeout    60s
-        Write Bare Into Terminal    chain --autofree http://boot.netboot.xyz/ipxe/netboot.xyz.lkrn\n    0.1
-        Read From Terminal Until    http://boot.netboot.xyz/ipxe/netboot.xyz.lkrn...
-        Read From Terminal Until    ok
-    ELSE
-        Enter Submenu From Snapshot    ${ipxe_menu}    OS installation
-    END
-    Read From Terminal Until    netboot.xyz [ enabled: true ]
-
 Get Netboot.Xyz Menu Construction
     [Documentation]    Return only selectable entries of netboot.xyz menu.
     ...    If some menu option is not selectable it will not be in the menu 
@@ -65,10 +42,23 @@ Parse Netboot.Xyz Menu Snapshot Into Construction
 Enter Netboot.Xyz Menu
     [Documentation]    This keyword enters netboot.xyz menu after the platform was
     ...    powered on.
-    ${boot_menu}=    Enter Boot Menu Tianocore And Return Construction
+    ${boot_menu}=    Enter Boot Menu And Return Construction
     Enter Submenu From Snapshot    ${boot_menu}    ${IPXE_BOOT_ENTRY}
     ${ipxe_menu}=    Get IPXE Boot Menu Construction
-    Enter Submenu From Snapshot    ${ipxe_menu}    OS installation
+    IF    '${BIOS_LIB}' == 'seabios'
+        Enter Submenu From Snapshot    ${ipxe_menu}    iPXE Shell
+        Set Prompt For Terminal    iPXE>
+        Read From Terminal Until Prompt
+        Write Into Terminal    dhcp
+        ${out}=    Read From Terminal Until Prompt
+        Should Contain    ${out}    ok
+        Set DUT Response Timeout    60s
+        Write Bare Into Terminal    chain --autofree http://boot.netboot.xyz/ipxe/netboot.xyz.lkrn\n    0.1
+        Read From Terminal Until    http://boot.netboot.xyz/ipxe/netboot.xyz.lkrn...
+        Read From Terminal Until    ok
+    ELSE
+        Enter Submenu From Snapshot    ${ipxe_menu}    OS installation
+    END
 
 Enter Netboot.Xyz Menu And Return Construction
     [Documentation]    This keyword enters netboot.xyz menu after the platform

--- a/lib/netbootxyz-lib.robot
+++ b/lib/netbootxyz-lib.robot
@@ -28,3 +28,54 @@ Boot To Netboot.Xyz
         Enter Submenu From Snapshot    ${ipxe_menu}    OS installation
     END
     Read From Terminal Until    netboot.xyz [ enabled: true ]
+
+Parse netboot.xyz Menu Snapshot Into Construction
+    [Documentation]    Breaks grabbed netboot.xyz data into selectable lines.
+    [Arguments]    ${menu}    ${lines_top}    ${lines_bot}
+    ${slice_start}=    Set Variable    ${lines_top}
+    IF    ${lines_bot} == 0
+        ${slice_end}=    Set Variable    None
+    ELSE
+        ${slice_end}=    Evaluate    ${lines_bot} * -1
+    END
+    ${menu}=    Remove String    ${menu}    \r
+    @{menu_lines}=    Split To Lines    ${menu}
+    @{construction}=    Create List
+    FOR    ${line}    IN    @{menu_lines}
+        # Replace multiple spaces with a single one
+        ${line}=    Replace String Using Regexp    ${line}    ${SPACE}+    ${SPACE}
+        # Remove leading and trailing spaces
+        ${line}=    Strip String    ${line}
+        # Drop leading and trailing pipes (e.g. in One Time Boot Menu)
+        ${line}=    Strip String    ${line}    characters=|
+        # Remove leading and trailing spaces
+        ${line}=    Strip String    ${line}
+        # Drop all remaining borders
+        ${line}=    Remove String Using Regexp    ${line}    ^[\\|\\s/\\\\-]+$
+        # If the resulting line is not empty, add it as a menu entry
+        ${length}=    Get Length    ${line}
+        IF    ${length} > 0    Append To List    ${construction}    ${line}
+    END
+    Log    ${construction}
+    ${construction}=    Get Slice From List    ${construction}    ${slice_start}    ${slice_end}
+    # TODO: Improve parsing of the menu into construction. It can probably be
+    # simplified, but at least we have this only in one kewyrod not in multiple
+    # ones.
+    # Make sure to remove control help text appearing in the screen if somehow
+    # they are still there.
+    Remove Values From List
+    ...    ${construction}
+    ...    Default:
+    ...    Distributions:
+    ...    Tools:
+    ...    Signature Checks
+    RETURN    ${construction}
+
+Enter Netboot.xyz Menu
+    [Documentation]    This keyword enters netboot.xyz menu after the platform was
+    ...    powered on.
+    ${boot_menu}=    Enter Boot Menu Tianocore And Return Construction
+    Enter Submenu From Snapshot    ${boot_menu}    ${IPXE_BOOT_ENTRY}
+    ${ipxe_menu}=    Get IPXE Boot Menu Construction
+    Enter Submenu From Snapshot    ${ipxe_menu}    OS installation
+

--- a/lib/netbootxyz-lib.robot
+++ b/lib/netbootxyz-lib.robot
@@ -5,6 +5,7 @@ Library             Collections
 Library             String
 
 
+
 *** Keywords ***
 Boot To Netboot.Xyz
     [Documentation]    This keyword enters netboot.xyz menu after the platform was
@@ -29,53 +30,27 @@ Boot To Netboot.Xyz
     END
     Read From Terminal Until    netboot.xyz [ enabled: true ]
 
-Parse netboot.xyz Menu Snapshot Into Construction
+Parse Netboot.Xyz Menu Snapshot Into Construction
     [Documentation]    Breaks grabbed netboot.xyz data into selectable lines.
-    [Arguments]    ${menu}    ${lines_top}    ${lines_bot}
-    ${slice_start}=    Set Variable    ${lines_top}
-    IF    ${lines_bot} == 0
-        ${slice_end}=    Set Variable    None
-    ELSE
-        ${slice_end}=    Evaluate    ${lines_bot} * -1
-    END
+    [Arguments]    ${menu}
     ${menu}=    Remove String    ${menu}    \r
     @{menu_lines}=    Split To Lines    ${menu}
     @{construction}=    Create List
     FOR    ${line}    IN    @{menu_lines}
-        # Replace multiple spaces with a single one
-        ${line}=    Replace String Using Regexp    ${line}    ${SPACE}+    ${SPACE}
-        # Remove leading and trailing spaces
-        ${line}=    Strip String    ${line}
-        # Drop leading and trailing pipes (e.g. in One Time Boot Menu)
-        ${line}=    Strip String    ${line}    characters=|
-        # Remove leading and trailing spaces
-        ${line}=    Strip String    ${line}
-        # Drop all remaining borders
-        ${line}=    Remove String Using Regexp    ${line}    ^[\\|\\s/\\\\-]+$
-        # If the resulting line is not empty, add it as a menu entry
-        ${length}=    Get Length    ${line}
-        IF    ${length} > 0    Append To List    ${construction}    ${line}
+        # It seems that selectable entries start with 6 spaces, followed by
+        # non-whitespace character
+        ${match}=    Run Keyword And Return Status    Should Match Regexp    ${line}    ^ {6}\\S+.*$
+        IF    ${match}
+            ${line}=    Strip String    ${line}
+            Append To List    ${construction}    ${line}
+        END
     END
-    Log    ${construction}
-    ${construction}=    Get Slice From List    ${construction}    ${slice_start}    ${slice_end}
-    # TODO: Improve parsing of the menu into construction. It can probably be
-    # simplified, but at least we have this only in one kewyrod not in multiple
-    # ones.
-    # Make sure to remove control help text appearing in the screen if somehow
-    # they are still there.
-    Remove Values From List
-    ...    ${construction}
-    ...    Default:
-    ...    Distributions:
-    ...    Tools:
-    ...    Signature Checks
     RETURN    ${construction}
 
-Enter Netboot.xyz Menu
+Enter Netboot.Xyz Menu
     [Documentation]    This keyword enters netboot.xyz menu after the platform was
     ...    powered on.
     ${boot_menu}=    Enter Boot Menu Tianocore And Return Construction
     Enter Submenu From Snapshot    ${boot_menu}    ${IPXE_BOOT_ENTRY}
     ${ipxe_menu}=    Get IPXE Boot Menu Construction
     Enter Submenu From Snapshot    ${ipxe_menu}    OS installation
-

--- a/lib/netbootxyz-lib.robot
+++ b/lib/netbootxyz-lib.robot
@@ -5,7 +5,6 @@ Library             Collections
 Library             String
 
 
-
 *** Keywords ***
 Boot To Netboot.Xyz
     [Documentation]    This keyword enters netboot.xyz menu after the platform was
@@ -29,6 +28,22 @@ Boot To Netboot.Xyz
         Enter Submenu From Snapshot    ${ipxe_menu}    OS installation
     END
     Read From Terminal Until    netboot.xyz [ enabled: true ]
+
+Get Netboot.Xyz Menu Construction
+    [Documentation]    Return only selectable entries of netboot.xyz menu.
+    ...    If some menu option is not selectable it will not be in the menu 
+    ...    construction list.
+    [Arguments]    ${checkpoint}=[ enabled: true ]    ${lines_top}=1    ${lines_bot}=0
+    ${out}=    Read From Terminal Until    ${checkpoint}
+    # At first, parse the menu as usual
+    ${menu}=    Parse Netboot.Xyz Menu Snapshot Into Construction    ${out}
+    # Remove Values From List
+    #   ...    ${menu}
+    #   ...    To enable Secure Boot, set Secure Boot Mode to
+    #   ...    Custom and enroll the keys/PK first.
+    #   ...    Enable Secure Boot [ ]
+    #   ...    Enable Secure Boot [X]
+    RETURN    ${menu}
 
 Parse Netboot.Xyz Menu Snapshot Into Construction
     [Documentation]    Breaks grabbed netboot.xyz data into selectable lines.
@@ -54,3 +69,10 @@ Enter Netboot.Xyz Menu
     Enter Submenu From Snapshot    ${boot_menu}    ${IPXE_BOOT_ENTRY}
     ${ipxe_menu}=    Get IPXE Boot Menu Construction
     Enter Submenu From Snapshot    ${ipxe_menu}    OS installation
+
+Enter Netboot.Xyz Menu And Return Construction
+    [Documentation]    This keyword enters netboot.xyz menu after the platform
+    ...    was powered on. Returns netboot.xyz menu construction.
+    Enter Netboot.Xyz Menu
+    ${nb_menu}=    Get Netboot.Xyz Menu Construction
+    RETURN    ${nb_menu}

--- a/self-tests/netbootxyz.robot
+++ b/self-tests/netbootxyz.robot
@@ -85,6 +85,48 @@ Enter Netboot.Xyz Linux Install Menu And Return Construction
     Should Contain    ${nb_menu}    Zen Installer Arch
     Should Not Contain    ${nb_menu}    ...
 
+Enter Netboot.Xyz Linux Distro Install Menu And Return Construction (Debian)
+    [Documentation]    Test Enter Netboot.Xyz Linux Install Menu And Return
+    ...    Construction kwd
+    Power On
+    ${nb_menu}=    Enter Netboot.Xyz Linux Distro Install Menu And Return Construction    Debian
+    Should Contain    ${nb_menu}    Debian 12.0 (bookworm)
+    Should Contain    ${nb_menu}    Debian 11.0 (bullseye)
+    Should Contain    ${nb_menu}    Debian 10.0 (buster)
+    Should Contain    ${nb_menu}    Debian trixie (testing)
+    Should Contain    ${nb_menu}    Debian sid (unstable)
+    Should Contain    ${nb_menu}    Set release codename...
+    Should Not Contain    ${nb_menu}    Latest Releases
+    Should Not Contain    ${nb_menu}    Older Releases
+    Should Not Contain    ${nb_menu}    Testing Releases
+
+Enter Netboot.Xyz Linux Distro Install Menu And Return Construction (Ubuntu)
+    [Documentation]    Test Enter Netboot.Xyz Linux Install Menu And Return
+    ...    Construction kwd
+    Power On
+    ${nb_menu}=    Enter Netboot.Xyz Linux Distro Install Menu And Return Construction    Ubuntu
+    Should Contain    ${nb_menu}    Ubuntu 24.10 Oracular Oriole
+    Should Contain    ${nb_menu}    Ubuntu 24.04 LTS Noble Numbat
+    Should Contain    ${nb_menu}    Ubuntu 22.04 LTS Jammy Jellyfish
+    Should Contain    ${nb_menu}    Ubuntu 20.04 LTS Focal Fossa (Subiquity)
+    Should Contain    ${nb_menu}    Ubuntu 20.04 LTS Focal Fossa (Legacy)
+    Should Contain    ${nb_menu}    Ubuntu 18.04 LTS Bionic Beaver
+    Should Contain    ${nb_menu}    Ubuntu 16.04 LTS Xenial Xerus
+    Should Contain    ${nb_menu}    Set release codename...
+    Should Not Contain    ${nb_menu}    Latest Releases
+    Should Not Contain    ${nb_menu}    Older Releases
+    Should Not Contain    ${nb_menu}    Testing Releases
+
+Enter Netboot.Xyz Linux Distro Install Menu And Return Construction (Fedora)
+    [Documentation]    Test Enter Netboot.Xyz Linux Install Menu And Return
+    ...    Construction kwd
+    Power On
+    ${nb_menu}=    Enter Netboot.Xyz Linux Distro Install Menu And Return Construction    Fedora
+    Should Contain    ${nb_menu}    Fedora 41
+    Should Contain    ${nb_menu}    Fedora 40
+    Should Contain    ${nb_menu}    Fedora rawhide
+    Should Not Contain    ${nb_menu}    Latest Releases
+
 # Enter Advanced Secure Boot Keys Management
 #     [Documentation]    Test Enter Advanced Secure Boot Keys Management kwd
 #     Power On

--- a/self-tests/netbootxyz.robot
+++ b/self-tests/netbootxyz.robot
@@ -39,16 +39,16 @@ Enter Netboot.Xyz Menu
     Should Contain    ${out}    Linux Network Installs (64-bit)
     Should Contain    ${out}    netboot.xyz [ enabled: true ]
 
-# Enter Secure Boot Menu And Return Construction
-#     [Documentation]    Test Enter Secure Boot Menu And Return Construction kwd
-#     Power On
-#     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
-#     Should Not Contain    ${sb_menu}    Secure Boot Configuration
-#     Should Match Regexp    ${sb_menu}[0]    ^Current Secure Boot State.*$
-#     Should Match Regexp    ${sb_menu}[-1]    ^Secure Boot Mode \\<.*\\>.*$
-#     Should Not Contain    ${sb_menu}    To enable Secure Boot, set Secure Boot Mode to
-#     Should Not Contain    ${sb_menu}    Custom and enroll the keys/PK first.
-# 
+Enter Netboot.Xyz Menu And Return Construction
+    [Documentation]    Test Enter Netboot.Xyz Menu And Return Construction kwd
+    Power On
+    ${nb_menu}=    Enter Netboot.Xyz Menu And Return Construction
+    Should Not Contain    ${nb_menu}    Default
+    Should Not Contain    ${nb_menu}    Distributions
+    Should Not Contain    ${nb_menu}    Tools
+    Should Not Contain    ${nb_menu}    Signature Checks
+    Should Match Regexp    ${nb_menu}[-1]    ^netboot\.xyz \[ enable: (true|false) \]$
+
 # Enter Advanced Secure Boot Keys Management
 #     [Documentation]    Test Enter Advanced Secure Boot Keys Management kwd
 #     Power On

--- a/self-tests/netbootxyz.robot
+++ b/self-tests/netbootxyz.robot
@@ -127,6 +127,50 @@ Enter Netboot.Xyz Linux Distro Install Menu And Return Construction (Fedora)
     Should Contain    ${nb_menu}    Fedora rawhide
     Should Not Contain    ${nb_menu}    Latest Releases
 
+Enter Netboot.Xyz Utilities Menu And Return Construction
+    [Documentation]    Test Enter Netboot.Xyz Utilities Menu And Return
+    ...    Construction kwd
+    Power On
+    ${nb_menu}=    Enter Netboot.Xyz Utilities Menu And Return Construction
+    Should Contain    ${nb_menu}    4MLinux
+    Should Contain    ${nb_menu}    Boot Repair CD
+    Should Contain    ${nb_menu}    Breakin
+    Should Contain    ${nb_menu}    CAINE
+    Should Contain    ${nb_menu}    Clonezilla
+    Should Contain    ${nb_menu}    Dasharo Tools Suite
+    Should Contain    ${nb_menu}    DBAN
+    Should Contain    ${nb_menu}    GParted
+    Should Contain    ${nb_menu}    Grml
+    Should Contain    ${nb_menu}    Kaspersky Rescue Disk
+    Should Contain    ${nb_menu}    Memtest86+ 5.01.0
+    Should Contain    ${nb_menu}    Memtest86+ 7.20
+    Should Contain    ${nb_menu}    RedoRescue
+    Should Contain    ${nb_menu}    Rescatux
+    Should Contain    ${nb_menu}    Rescuezilla
+    Should Contain    ${nb_menu}    ShredOS
+    Should Contain    ${nb_menu}    Super GRUB2 Disk
+    Should Contain    ${nb_menu}    System Rescue CD
+    Should Contain    ${nb_menu}    Ultimate Boot CD (UBCD)
+    Should Contain    ${nb_menu}    Kernel cmdline params: []
+    Should Contain    ${nb_menu}    Set custom menu [url: ]
+    Should Contain    ${nb_menu}    Set Github username [user: ]
+    Should Contain    ${nb_menu}    Test Distribution ISO
+    Should Contain    ${nb_menu}    netboot.xyz endpoints
+    Should Not Contain    ${nb_menu}    netboot.xyz tools:
+    Should Not Contain    ${nb_menu}    Utilities:
+
+Enter Netboot.Xyz And Set Kernel Cmdline Params
+    [Documentation]    Test Enter Netboot.Xyz And Set Kernel Cmdline Params kwd
+    Power On
+    Enter Netboot.Xyz And Set Kernel Cmdline Params    console=ttyS0,115200n8
+    ${nb_menu}=    Get Netboot.Xyz Menu Construction
+    ${index}=    Get Index Of Matching Option In Menu    ${nb_menu}    Utilities (64-bit)
+    Select Option    ${index}    ${ARROW_DOWN}
+    Press Enter
+    ${out}=    Read From Terminal
+    ${menu}=    Parse Netboot.Xyz Linux Distro Install Menu Snapshot Into Construction    ${out}
+    Should Contain    ${menu}    Kernel cmdline params: [console=ttyS0,115200n8]
+
 # Enter Advanced Secure Boot Keys Management
 #     [Documentation]    Test Enter Advanced Secure Boot Keys Management kwd
 #     Power On

--- a/self-tests/netbootxyz.robot
+++ b/self-tests/netbootxyz.robot
@@ -10,8 +10,6 @@ Library             SSHLibrary    timeout=90 seconds
 Library             RequestsLibrary
 # TODO: maybe have a single file to include if we need to include the same
 # stuff in all test cases
-Resource            ../sonoff-rest-api/sonoff-api.robot
-Resource            ../rtectrl-rest-api/rtectrl.robot
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot

--- a/self-tests/netbootxyz.robot
+++ b/self-tests/netbootxyz.robot
@@ -1,0 +1,192 @@
+*** Settings ***
+Documentation       This suite verifies the correct operation of keywords parsing Secure Boot menus from the lib/secure-boot-lib.robot.
+
+Library             Collections
+Library             OperatingSystem
+Library             Process
+Library             String
+Library             Telnet    timeout=30 seconds    connection_timeout=120 seconds
+Library             SSHLibrary    timeout=90 seconds
+Library             RequestsLibrary
+# TODO: maybe have a single file to include if we need to include the same
+# stuff in all test cases
+Resource            ../sonoff-rest-api/sonoff-api.robot
+Resource            ../rtectrl-rest-api/rtectrl.robot
+Resource            ../variables.robot
+Resource            ../keywords.robot
+Resource            ../keys.robot
+Resource            ../pikvm-rest-api/pikvm_comm.robot
+
+# TODO:
+# - document which setup/teardown keywords to use and what are they doing
+# - go threough them and make sure they are doing what the name suggest (not
+# exactly the case right now)
+Suite Setup         Run Keywords
+...                     Prepare Test Suite
+Suite Teardown      Run Keyword
+...                     Log Out And Close Connection
+Test Setup          Run Keyword
+...                     Make Sure That Network Boot Is Enabled
+
+
+*** Test Cases ***
+Enter Netboot.Xyz Menu
+    [Documentation]    Test Enter Netboot.Xyz Menu kwd
+    Power On
+    Enter Netboot.Xyz Menu
+    ${out}=    Read From Terminal Until    netboot.xyz [ enabled: true ]
+    Should Contain    ${out}    netboot.xyz v2.x
+    Should Contain    ${out}    Linux Network Installs (64-bit)
+    Should Contain    ${out}    netboot.xyz [ enabled: true ]
+
+# Enter Secure Boot Menu And Return Construction
+#     [Documentation]    Test Enter Secure Boot Menu And Return Construction kwd
+#     Power On
+#     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+#     Should Not Contain    ${sb_menu}    Secure Boot Configuration
+#     Should Match Regexp    ${sb_menu}[0]    ^Current Secure Boot State.*$
+#     Should Match Regexp    ${sb_menu}[-1]    ^Secure Boot Mode \\<.*\\>.*$
+#     Should Not Contain    ${sb_menu}    To enable Secure Boot, set Secure Boot Mode to
+#     Should Not Contain    ${sb_menu}    Custom and enroll the keys/PK first.
+# 
+# Enter Advanced Secure Boot Keys Management
+#     [Documentation]    Test Enter Advanced Secure Boot Keys Management kwd
+#     Power On
+#     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+#     Enter Advanced Secure Boot Keys Management    ${sb_menu}
+#     ${out}=    Read From Terminal Until    Esc=Exit
+#     Should Contain    ${out}    Advanced Secure Boot Keys Management
+#     Should Contain    ${out}    Reset to default Secure Boot Keys
+#     Should Contain    ${out}    Erase all Secure Boot Keys
+# 
+# Reset To Default Secure Boot Keys
+#     [Documentation]    Test Reset To Default Secure Boot Keys kwd
+#     Power On
+#     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+#     Enter Advanced Secure Boot Keys Management    ${sb_menu}
+#     Reset To Default Secure Boot Keys
+#     Save Changes And Reset    3
+# 
+#     Enter Secure Boot Menu
+#     ${out}=    Read From Terminal Until    Esc=Exit
+#     Should Not Contain    ${out}    To enable Secure Boot, set Secure Boot Mode to
+#     Should Not Contain    ${out}    Custom and enroll the keys/PK first.
+# 
+# Erase All Secure Boot Keys
+#     [Documentation]    Test Erase All Secure Boot Keys kwd
+#     Power On
+#     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+#     Enter Advanced Secure Boot Keys Management    ${sb_menu}
+#     Erase All Secure Boot Keys
+#     Save Changes And Reset    3
+# 
+#     Enter Secure Boot Menu
+#     ${out}=    Read From Terminal Until    Esc=Exit
+#     Should Contain    ${out}    To enable Secure Boot, set Secure Boot Mode to
+#     Should Contain    ${out}    Custom and enroll the keys/PK first.
+# 
+# Secure Boot Menu Parsing With Default Keys
+#     Power On
+#     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+#     Enter Advanced Secure Boot Keys Management    ${sb_menu}
+#     Reset To Default Secure Boot Keys
+#     Save Changes And Reset    3
+# 
+#     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+#     Should Not Contain    ${sb_menu}    Secure Boot Configuration
+#     Should Match Regexp    ${sb_menu}[0]    ^Current Secure Boot State.*$
+#     Should Match Regexp    ${sb_menu}[1]    ^Enable Secure Boot \\[.\\].*$
+#     Should Match Regexp    ${sb_menu}[2]    ^Secure Boot Mode \\<.*\\>.*$
+#     Should Not Contain    ${sb_menu}    To enable Secure Boot, set Secure Boot Mode to
+#     Should Not Contain    ${sb_menu}    Custom and enroll the keys/PK first.
+# 
+# Secure Boot Menu Parsing With Erased Keys
+#     [Documentation]    Test Enter Secure Boot Menu And Return Construction kwd
+#     Power On
+#     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+#     Enter Advanced Secure Boot Keys Management    ${sb_menu}
+#     Erase All Secure Boot Keys
+#     Reset To Default Secure Boot Keys
+#     Save Changes And Reset    3
+# 
+#     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+#     Should Not Contain    ${sb_menu}    Secure Boot Configuration
+#     Should Match Regexp    ${sb_menu}[0]    ^Current Secure Boot State.*$
+#     Should Match Regexp    ${sb_menu}[1]    ^Secure Boot Mode \\<.*\\>.*$
+#     Should Not Contain    ${sb_menu}    To enable Secure Boot, set Secure Boot Mode to
+#     Should Not Contain    ${sb_menu}    Custom and enroll the keys/PK first.
+# 
+# Return Secure Boot State
+#     [Documentation]    Test Return Secure Boot State kwd
+#     Power On
+#     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+#     ${sb_state}=    Return Secure Boot State    ${sb_menu}
+#     Should Contain Any    ${sb_state}    Enabled    Disabled
+# 
+# Make Sure That Keys Are Provisioned
+#     [Documentation]    Test Make Sure That Keys Are Provisioned kwd
+#     # 1. Erase All SB keys
+#     Power On
+#     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+#     Enter Advanced Secure Boot Keys Management    ${sb_menu}
+#     Erase All Secure Boot Keys
+#     Exit From Current Menu
+#     ${sb_menu}=    Get Secure Boot Menu Construction
+#     Should Not Contain Any    ${sb_menu}    Enable Secure Boot [ ]    Enable Secure Boot [X]
+# 
+#     # 2. Call tke kwd and make sure that the keys are provisioned
+#     ${sb_menu}=    Make Sure That Keys Are Provisioned    ${sb_menu}
+#     Should Contain Any    ${sb_menu}    Enable Secure Boot [ ]    Enable Secure Boot [X]
+# 
+#     # 3. Restore default SB keys
+#     Enter Advanced Secure Boot Keys Management    ${sb_menu}
+#     Reset To Default Secure Boot Keys
+#     Exit From Current Menu
+#     ${sb_menu}=    Get Secure Boot Menu Construction
+#     Should Contain Any    ${sb_menu}    Enable Secure Boot [ ]    Enable Secure Boot [X]
+# 
+#     # 4. Call tke kwd and make sure that the keys are still provisioned
+#     ${sb_menu}=    Make Sure That Keys Are Provisioned    ${sb_menu}
+#     Should Contain Any    ${sb_menu}    Enable Secure Boot [ ]    Enable Secure Boot [X]
+# 
+# Enable Secure Boot
+#     [Documentation]    Test Enable Secure Boot kwd
+#     Power On
+#     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+#     Enable Secure Boot    ${sb_menu}
+#     Save Changes And Reset    2
+# 
+#     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+#     ${sb_state}=    Return Secure Boot State    ${sb_menu}
+#     Should Contain    ${sb_state}    Enabled
+# 
+# Disable Secure Boot
+#     [Documentation]    Test Disable Secure Boot kwd
+#     Power On
+#     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+#     Disable Secure Boot    ${sb_menu}
+#     Save Changes And Reset    2
+# 
+#     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+#     ${sb_state}=    Return Secure Boot State    ${sb_menu}
+#     Should Contain    ${sb_state}    Disabled
+# 
+# Enable and Disable Secure Boot Multiple Times
+#     [Documentation]    Test Enabling and Disabling Secure Boot 5 times
+#     Power On
+#     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+#     FOR    ${index}    IN RANGE    5
+#         Set Option State    ${sb_menu}    Enable Secure Boot    ${TRUE}
+#         Save Changes And Reset    2
+# 
+#         ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+#         ${sb_state}=    Return Secure Boot State    ${sb_menu}
+#         Should Contain    ${sb_state}    Enabled
+# 
+#         Set Option State    ${sb_menu}    Enable Secure Boot    ${FALSE}
+#         Save Changes And Reset    2
+# 
+#         ${sb_menu}=    Enter Secure Boot Menu And Return Construction
+#         ${sb_state}=    Return Secure Boot State    ${sb_menu}
+#         Should Contain    ${sb_state}    Disabled
+#     END

--- a/self-tests/netbootxyz.robot
+++ b/self-tests/netbootxyz.robot
@@ -47,7 +47,7 @@ Enter Netboot.Xyz Menu And Return Construction
     Should Not Contain    ${nb_menu}    Distributions
     Should Not Contain    ${nb_menu}    Tools
     Should Not Contain    ${nb_menu}    Signature Checks
-    Should Match Regexp    ${nb_menu}[-1]    ^netboot\.xyz \[ enable: (true|false) \]$
+    Should Contain    ${nb_menu}[-1]    netboot.xyz [ enabled: true ]
 
 # Enter Advanced Secure Boot Keys Management
 #     [Documentation]    Test Enter Advanced Secure Boot Keys Management kwd

--- a/self-tests/netbootxyz.robot
+++ b/self-tests/netbootxyz.robot
@@ -47,6 +47,44 @@ Enter Netboot.Xyz Menu And Return Construction
     Should Not Contain    ${nb_menu}    Signature Checks
     Should Contain    ${nb_menu}[-1]    netboot.xyz [ enabled: true ]
 
+Enter Netboot.Xyz Linux Install Menu And Return Construction
+    [Documentation]    Test Enter Netboot.Xyz Linux Install Menu And Return
+    ...    Construction kwd
+    Power On
+    ${nb_menu}=    Enter Netboot.Xyz Linux Install Menu And Return Construction
+    Should Contain    ${nb_menu}    AlmaLinux
+    Should Contain    ${nb_menu}    Alpine Linux
+    Should Contain    ${nb_menu}    Arch Linux
+    Should Contain    ${nb_menu}    BlackArch
+    Should Contain    ${nb_menu}    CentOS
+    Should Contain    ${nb_menu}    Debian
+    Should Contain    ${nb_menu}    Devuan
+    Should Contain    ${nb_menu}    Fedora
+    Should Contain    ${nb_menu}    Fedora CoreOS
+    Should Contain    ${nb_menu}    Flatcar Container Linux
+    Should Contain    ${nb_menu}    Gentoo
+    Should Contain    ${nb_menu}    Harvester
+    Should Contain    ${nb_menu}    IPFire
+    Should Contain    ${nb_menu}    k3OS
+    Should Contain    ${nb_menu}    Kali Linux
+    Should Contain    ${nb_menu}    Mageia
+    Should Contain    ${nb_menu}    NixOS
+    Should Contain    ${nb_menu}    openEuler
+    Should Contain    ${nb_menu}    openSUSE
+    Should Contain    ${nb_menu}    Oracle Linux
+    Should Contain    ${nb_menu}    Proxmox
+    Should Contain    ${nb_menu}    Red Hat Enterprise Linux
+    Should Contain    ${nb_menu}    Rocky Linux
+    Should Contain    ${nb_menu}    Slackware
+    Should Contain    ${nb_menu}    Talos
+    Should Contain    ${nb_menu}    Tiny Core Linux
+    Should Contain    ${nb_menu}    Ubuntu
+    Should Contain    ${nb_menu}    VMware ESXi
+    Should Contain    ${nb_menu}    VMware Photon
+    Should Contain    ${nb_menu}    VyOS
+    Should Contain    ${nb_menu}    Zen Installer Arch
+    Should Not Contain    ${nb_menu}    ...
+
 # Enter Advanced Secure Boot Keys Management
 #     [Documentation]    Test Enter Advanced Secure Boot Keys Management kwd
 #     Power On

--- a/self-tests/os-boot.robot
+++ b/self-tests/os-boot.robot
@@ -11,8 +11,6 @@ Library             SSHLibrary    timeout=90 seconds
 Library             RequestsLibrary
 # TODO: maybe have a single file to include if we need to include the same
 # stuff in all test cases
-Resource            ../sonoff-rest-api/sonoff-api.robot
-Resource            ../rtectrl-rest-api/rtectrl.robot
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot


### PR DESCRIPTION
Current state:

### Dasharo (coreboot+UEFI)

Test env preparation:

```sh
./scripts/ci/remote-runner.sh user@host . nographic os_install uefi
ssh -t user@host 'cd /tmp/osfv && source venv/bin/activate && ./scripts/ci/qemu-self-test.sh
```

self-test was moded to execute only `self-test/netbootxyz.robot`

```sh
==============================================================================
Netbootxyz :: This suite verifies the correct operation of keywords parsing...
==============================================================================
Enter Netboot.Xyz Menu :: Test Enter Netboot.Xyz Menu kwd             | PASS |
------------------------------------------------------------------------------
Enter Netboot.Xyz Menu And Return Construction :: Test Enter Netbo... | PASS |
------------------------------------------------------------------------------
Netbootxyz :: This suite verifies the correct operation of keyword... | PASS |
2 tests, 2 passed, 0 failed
==============================================================================
Output:  /tmp/osfv/logs/2024.12.17_23.53.40/nextboot/output.xml
Log:     /tmp/osfv/logs/2024.12.17_23.53.40/nextboot/log.html
Report:  /tmp/osfv/logs/2024.12.17_23.53.40/nextboot/report.html
```

### Dasharo (coreboot+SeaBIOS)


Test env preparation:

```sh
./scripts/ci/remote-runner.sh user@host . nographic os_install seabios
ssh -t user@host 'cd /tmp/osfv && source venv/bin/activate && ./scripts/ci/qemu-self-test-seabios.sh
```

self-test was moded to execute only `self-test/netbootxyz.robot`

```sh
==============================================================================
Netbootxyz :: This suite verifies the correct operation of keywords parsing...
==============================================================================
Enter Netboot.Xyz Menu :: Test Enter Netboot.Xyz Menu kwd             | PASS |
------------------------------------------------------------------------------
Enter Netboot.Xyz Menu And Return Construction :: Test Enter Netbo... | PASS |
------------------------------------------------------------------------------
Netbootxyz :: This suite verifies the correct operation of keyword... | PASS |
2 tests, 2 passed, 0 failed
==============================================================================
Output:  /tmp/osfv/logs/2024.12.17_23.59.28/nextboot/output.xml
Log:     /tmp/osfv/logs/2024.12.17_23.59.28/nextboot/log.html
Report:  /tmp/osfv/logs/2024.12.17_23.59.28/nextboot/report.html
```

With this PR we should be able to remove two branches:
- https://github.com/Dasharo/open-source-firmware-validation/tree/netboot-lib-wip
- https://github.com/Dasharo/open-source-firmware-validation/tree/netbootxyz-lib

Obviously there is redundancy here and we should clean this PR first.