### PR TITLE
Run DTS-E2E tests faster

### DIFF
--- a/dts/dts-e2e.robot
+++ b/dts/dts-e2e.robot
@@ -12,9 +12,13 @@ Resource            ../variables.robot
 
 Suite Setup         Run Keywords
 ...                     Prepare Test Suite    AND
-...                     Skip If    not ${DTS_SUPPORT}
+...                     Skip If    not ${DTS_SUPPORT}    AND
+...                     Power On And Enter DTS Shell    AND
+...                     Execute Linux Command    systemctl start sshd
 Suite Teardown      Run Keyword
 ...                     Log Out And Close Connection
+Test Setup          Prepare DTS Test
+Test Teardown       Teardown DTS Test
 
 
 *** Variables ***
@@ -55,9 +59,6 @@ E2E001.001 HCL Report test
     [Documentation]    Verify that HCL Report is being executed with all
     ...    expected messages. The report should not fail even if it failed to
     ...    collect some data, because it is responsible only for collecting.
-    # 1) Get into DTS:
-    Power On And Enter DTS Shell
-
     # 2) Prepare DTS for testing:
     Execute Command In Terminal    export DTS_TESTING="true"
     Write Into Terminal    dts-boot
@@ -85,9 +86,6 @@ E2E002.001 NCM NV4XMB,ME,MZ initial deployment (legacy -> Coreboot + UEFI) - com
     ...    of Dahsaro Firmware for NovaCustom NV4XMB,ME,MZ. This deployment
     ...    should pass without credentials.
     [Tags]    novacustom_comm
-    # 1) Get into DTS:
-    Power On And Enter DTS Shell
-
     # 2) Emulate needed env.:
     Execute Command In Terminal
     ...    export DTS_TESTING="true" TEST_SYSTEM_MODEL="NV4XMB,ME,MZ" TEST_BOARD_MODEL="NV4XMB,ME,MZ"
@@ -106,9 +104,6 @@ E2E002.002 NCM NS50_70MU initial deployment (legacy -> Coreboot + UEFI) - commun
     ...    of Dahsaro Firmware for NovaCustom NS50_70MU. This deployment
     ...    should pass without credentials.
     [Tags]    novacustom_comm
-    # 1) Get into DTS:
-    Power On And Enter DTS Shell
-
     # 2) Emulate needed env.:
     Execute Command In Terminal
     ...    export DTS_TESTING="true" TEST_SYSTEM_MODEL="NS50_70MU" TEST_BOARD_MODEL="NS50_70MU"
@@ -127,9 +122,6 @@ E2E002.003 NCM NS5x_NS7xPU initial deployment (legacy -> Coreboot + UEFI) - comm
     ...    of Dahsaro Firmware for NovaCustom NS5x_NS7xPU. This deployment
     ...    should pass without credentials.
     [Tags]    novacustom_comm
-    # 1) Get into DTS:
-    Power On And Enter DTS Shell
-
     # 2) Emulate needed env.:
     Execute Command In Terminal
     ...    export DTS_TESTING="true" TEST_SYSTEM_MODEL="NS5x_NS7xPU" TEST_BOARD_MODEL="NS5x_NS7xPU"
@@ -148,9 +140,6 @@ E2E002.004 NCM NV4xPZ initial deployment (legacy -> Coreboot + UEFI) - community
     ...    of Dahsaro Firmware for NovaCustom NV4xPZ. This deployment
     ...    should pass without credentials.
     [Tags]    novacustom_comm
-    # 1) Get into DTS:
-    Power On And Enter DTS Shell
-
     # 2) Emulate needed env.:
     Execute Command In Terminal
     ...    export DTS_TESTING="true" TEST_SYSTEM_MODEL="NV4xPZ" TEST_BOARD_MODEL="NV4xPZ"
@@ -171,9 +160,6 @@ E2E002.005 NCM NV4xPZ transition (Coreboot + UEFI -> Coreboot + Heads) - DPP ver
     ...    keys, so we expect no update will be provided, but a message
     ...    encouraging subscription purchase should be visible.
     [Tags]    novacustom_heads
-    # 1) Get into DTS
-    Power On And Enter DTS Shell
-
     # 2) Emulate needed env.:
     Execute Command In Terminal
     ...    export DTS_TESTING="true" TEST_SYSTEM_MODEL="NV4xPZ" TEST_BOARD_MODEL="NV4xPZ"
@@ -193,9 +179,6 @@ E2E002.006 NCM transition NV4xPZ (Coreboot + UEFI -> Heads) - DPP version, with 
     ...    We start from Dasharo (coreboot + UEFI) firmware with version that should
     ...    allow for the transition. We insert correct DPP keys for heads variant.
     [Tags]    novacustom_heads
-    # 1) Get into DTS
-    Power On And Enter DTS Shell
-
     # 2) Emulate needed env.. We assume that transition is from Dasharo UEFI to
     # Dasharo HEAD, so we need to emulate appropriate EC firmware presence:
     Execute Command In Terminal
@@ -220,9 +203,6 @@ E2E002.007 NCM V540_6x_TU initial deployment (legacy -> Coreboot + UEFI) - commu
     ...    of Dahsaro Firmware for NovaCustom V540_6x_TU. This deployment
     ...    should pass without credentials.
     [Tags]    novacustom_comm
-    # 1) Get into DTS:
-    Power On And Enter DTS Shell
-
     # 2) Emulate needed env.:
     Execute Command In Terminal
     ...    export DTS_TESTING="true" TEST_SYSTEM_MODEL="V54x_6x_TU" TEST_BOARD_MODEL="V540TU"
@@ -242,9 +222,6 @@ E2E002.008 NCM V560_6x_TU initial deployment (legacy -> Coreboot + UEFI) - commu
     ...    of Dahsaro Firmware for NovaCustom V560_6x_TU. This deployment
     ...    should pass without credentials.
     [Tags]    novacustom_comm
-    # 1) Get into DTS:
-    Power On And Enter DTS Shell
-
     # 2) Emulate needed env.:
     Execute Command In Terminal
     ...    export DTS_TESTING="true" TEST_SYSTEM_MODEL="V54x_6x_TU" TEST_BOARD_MODEL="V560TU"
@@ -264,9 +241,6 @@ E2E002.009 NCM V540TNC_TND_TNE initial deployment (legacy -> Coreboot + UEFI) - 
     ...    of Dahsaro Firmware for NovaCustom V540TNC_TND_TNE. This deployment
     ...    should pass without credentials.
     [Tags]    novacustom_comm
-    # 1) Get into DTS:
-    Power On And Enter DTS Shell
-
     # 2) Emulate needed env.:
     Execute Command In Terminal
     ...    export DTS_TESTING="true" TEST_SYSTEM_MODEL="V5xTNC_TND_TNE" TEST_BOARD_MODEL="V540TNx"
@@ -305,9 +279,6 @@ E2E002.010 NCM V560TNC_TND_TNE initial deployment (legacy -> Coreboot + UEFI) - 
     ...    of Dahsaro Firmware for NovaCustom V560TNC_TND_TNE. This deployment
     ...    should pass without credentials.
     [Tags]    novacustom_comm
-    # 1) Get into DTS:
-    Power On And Enter DTS Shell
-
     # 2) Emulate needed env.:
     Execute Command In Terminal
     ...    export DTS_TESTING="true" TEST_SYSTEM_MODEL="V5xTNC_TND_TNE" TEST_BOARD_MODEL="V560TNx"
@@ -355,9 +326,6 @@ E2E003.001 MSI PRO Z690-A DDR4 initial deployment (legacy -> Coreboot + UEFI) - 
     ...    of Dahsaro Firmware for MSI PRO Z690-A WIFI DDR4(MS-7D25)/PRO Z690-A
     ...    WIFI DDR4(MS-7D25). This deployment should pass without credentials.
     [Tags]    msi_comm
-    # 1) Get into DTS:
-    Power On And Enter DTS Shell
-
     # 2) Emulate needed env.:
     Execute Command In Terminal
     ...    export DTS_TESTING="true" TEST_SYSTEM_MODEL="MS-7D25" TEST_BOARD_MODEL="PRO Z690-A WIFI DDR4(MS-7D25)"
@@ -376,9 +344,6 @@ E2E003.002 MSI PRO Z690-A initial deployment (legacy -> Coreboot + UEFI) - commu
     ...    of Dahsaro Firmware for MSI PRO Z690-A WIFI (MS-7D25)/PRO Z690-A
     ...    (MS-7D25). This deployment should pass without credentials.
     [Tags]    msi_comm
-    # 1) Get into DTS:
-    Power On And Enter DTS Shell
-
     # 2) Emulate needed env.:
     Execute Command In Terminal
     ...    export DTS_TESTING="true" TEST_SYSTEM_MODEL="MS-7D25" TEST_BOARD_MODEL="PRO Z690-A WIFI (MS-7D25)"
@@ -397,9 +362,6 @@ E2E003.003 MSI PRO Z690-A DDR-4 initial deployment (legacy -> Coreboot + UEFI) -
     ...    of Dahsaro Firmware for MSI PRO Z690-A WIFI DDR4(MS-7D25)/PRO Z690-A
     ...    (MS-7D25). This deployment should not pass without credentials.
     [Tags]    msi_dpp
-    # 1) Get into DTS:
-    Power On And Enter DTS Shell
-
     # 2) Emulate needed env.:
     Execute Command In Terminal
     ...    export DTS_TESTING="true" TEST_SYSTEM_MODEL="MS-7D25" TEST_BOARD_MODEL="PRO Z690-A WIFI DDR4(MS-7D25)"
@@ -424,9 +386,6 @@ E2E003.004 MSI PRO Z690-A initial deployment (legacy -> Coreboot + UEFI) - DPP v
     ...    of Dahsaro Firmware for MSI PRO Z690-A WIFI DDR4(MS-7D25)/PRO Z690-A
     ...    DDR 4(MS-7D25). This deployment should not pass without credentials.
     [Tags]    msi_dpp
-    # 1) Get into DTS:
-    Power On And Enter DTS Shell
-
     # 2) Emulate needed env.:
     Execute Command In Terminal
     ...    export DTS_TESTING="true" TEST_SYSTEM_MODEL="MS-7D25" TEST_BOARD_MODEL="PRO Z690-A WIFI (MS-7D25)"
@@ -451,9 +410,6 @@ E2E003.005 MSI PRO Z690-A DDR-4 initial deployment (legacy -> Coreboot + UEFI) -
     ...    of Dahsaro Firmware for MSI PRO Z690-A WIFI DDR4(MS-7D25)/PRO Z690-A
     ...    (MS-7D25). This deployment should pass with credentials.
     [Tags]    msi_dpp
-    # 1) Get into DTS:
-    Power On And Enter DTS Shell
-
     # 2) Emulate needed env.:
     Execute Command In Terminal
     ...    export DTS_TESTING="true" TEST_SYSTEM_MODEL="MS-7D25" TEST_BOARD_MODEL="PRO Z690-A WIFI DDR4(MS-7D25)"
@@ -475,9 +431,6 @@ E2E003.006 MSI PRO Z690-A initial deployment (legacy -> Coreboot + UEFI) - DPP v
     ...    of Dahsaro Firmware for MSI PRO Z690-A WIFI DDR4(MS-7D25)/PRO Z690-A
     ...    DDR 4(MS-7D25). This deployment should pass with credentials.
     [Tags]    msi_dpp
-    # 1) Get into DTS:
-    Power On And Enter DTS Shell
-
     # 2) Emulate needed env.:
     Execute Command In Terminal
     ...    export DTS_TESTING="true" TEST_SYSTEM_MODEL="MS-7D25" TEST_BOARD_MODEL="PRO Z690-A WIFI (MS-7D25)"
@@ -503,9 +456,6 @@ E2E003.007 MSI PRO Z690-A DDR-4 update (Coreboot + UEFI -> Coreboot + UEFI) - co
     ...    more inf.. Therefore to test update via capsules - you have to
     ...    provide credentials with access to capsules.
     [Tags]    msi_comm
-    # 1) Get into DTS
-    Power On And Enter DTS Shell
-
     # 2) Emulate needed env.:
     Execute Command In Terminal
     ...    export DTS_TESTING="true" TEST_SYSTEM_MODEL="MS-7D25" TEST_BOARD_MODEL="PRO Z690-A WIFI DDR4(MS-7D25)"
@@ -529,9 +479,6 @@ E2E003.008 MSI PRO Z690-A update (Coreboot + UEFI -> Coreboot + UEFI) - communit
     ...    more inf.. Therefore to test update via capsules - you have to
     ...    provide credentials with access to capsules.
     [Tags]    msi_comm
-    # 1) Get into DTS
-    Power On And Enter DTS Shell
-
     # 2) Emulate needed env.:
     Execute Command In Terminal
     ...    export DTS_TESTING="true" TEST_SYSTEM_MODEL="MS-7D25" TEST_BOARD_MODEL="PRO Z690-A WIFI (MS-7D25)"
@@ -555,10 +502,6 @@ E2E003.009 MSI PRO Z690-A DDR-4 update (Coreboot + UEFI -> Coreboot + UEFI) - DP
     ...    more inf.. Therefore to test update via capsules - you have to
     ...    provide credentials with access to capsules.
     [Tags]    msi_dpp
-
-    # 1) Get into DTS
-    Power On And Enter DTS Shell
-
     # 2) Emulate needed env.:
     Execute Command In Terminal
     ...    export DTS_TESTING="true" TEST_SYSTEM_MODEL="MS-7D25" TEST_BOARD_MODEL="PRO Z690-A WIFI DDR4(MS-7D25)"
@@ -585,10 +528,6 @@ E2E003.010 MSI PRO Z690-A update (Coreboot + UEFI -> Coreboot + UEFI) - DPP vers
     ...    more inf.. Therefore to test update via capsules - you have to
     ...    provide credentials with access to capsules.
     [Tags]    msi_dpp
-
-    # 1) Get into DTS
-    Power On And Enter DTS Shell
-
     # 2) Emulate needed env.:
     Execute Command In Terminal
     ...    export DTS_TESTING="true" TEST_SYSTEM_MODEL="MS-7D25" TEST_BOARD_MODEL="PRO Z690-A WIFI (MS-7D25)"
@@ -613,8 +552,6 @@ E2E003.011 MSI PRO Z690-A DDR4 transition (Coreboot + UEFI -> heads) - without c
     ...    insert no DPP keys, so we expect no update will be provided, but a
     ...    message encouraging subscription purchase should be visible.
     [Tags]    msi_heads
-    # 1) Get into DTS
-    Power On And Enter DTS Shell
 
     # 2) Emulate needed env.:
     Execute Command In Terminal
@@ -636,8 +573,6 @@ E2E003.012 MSI PRO Z690-A DDR4 transition (Coreboot + UEFI -> heads) - with cred
     ...    UEFI) firmware with version that should allow for the transition. We
     ...    insert correct DPP keys for heads variant.
     [Tags]    msi_heads
-    # 1) Get into DTS
-    Power On And Enter DTS Shell
 
     # 2) Emulate needed env.. We assume that transition is from Dasharo UEFI to
     # Dasharo HEAD, so we need to emulate appropriate EC firmware presence:
@@ -664,8 +599,6 @@ E2E003.013 MSI PRO Z690-A transition (UEFI -> heads) - without credentials
     ...    insert no DPP keys, so we expect no update will be provided, but a
     ...    message encouraging subscription purchase should be visible.
     [Tags]    msi_heads
-    # 1) Get into DTS
-    Power On And Enter DTS Shell
 
     # 2) Emulate needed env.:
     Execute Command In Terminal
@@ -687,8 +620,6 @@ E2E003.014 MSI PRO Z690-A transition (UEFI -> heads) - with credentials
     ...    UEFI) firmware with version that should allow for the transition. We
     ...    insert correct DPP keys for heads variant.
     [Tags]    msi_heads
-    # 1) Get into DTS
-    Power On And Enter DTS Shell
 
     # 2) Emulate needed env.. We assume that transition is from Dasharo UEFI to
     # Dasharo HEAD, so we need to emulate appropriate EC firmware presence:
@@ -718,8 +649,6 @@ E2E004.001 Dell OptiPlex 7010 DPP initial deployment (legacy -> Coreboot + UEFI)
     ...    7010 without credentials provided. User should not have access and
     ...    DTS should inform about it.
     [Tags]    optiplex_dpp
-    # 1) Get into DTS
-    Power On And Enter DTS Shell
 
     # 2) Emulate needed env.:
     Execute Command In Terminal
@@ -746,8 +675,6 @@ E2E004.002 Dell Optiplex 7010 DPP initial deployment (legacy -> Coreboot + UEFI)
     ...    7010 with credentials provided. User should have access, and firmware
     ...    should be deployed.
     [Tags]    optiplex_dpp
-    # 1) Get into DTS
-    Power On And Enter DTS Shell
 
     # 2) Emulate needed env.:
     Execute Command In Terminal
@@ -771,8 +698,6 @@ E2E004.003 Dell Optiplex 7010 DPP update (Coreboot + UEFI -> Coreboot + UEFI) - 
     ...    7010 without credentials provided. User should not have access and
     ...    DTS should inform about it.
     [Tags]    optiplex_dpp
-    # 1) Get into DTS
-    Power On And Enter DTS Shell
 
     # 2) Emulate needed env.:
     Execute Command In Terminal
@@ -794,8 +719,6 @@ E2E004.004 Dell Optiplex 7010 DPP update (Coreboot + UEFI -> Coreboot + UEFI) - 
     ...    7010 with credentials provided. User should have access, and firmware
     ...    should be deployed.
     [Tags]    optiplex_dpp
-    # 1) Get into DTS
-    Power On And Enter DTS Shell
 
     # 2) Emulate needed env.:
     Execute Command In Terminal
@@ -820,8 +743,6 @@ E2E004.005 Dell OptiPlex 9010 DPP initial deployment (legacy -> Coreboot + UEFI)
     ...    9010 without credentials provided. User should not have access and
     ...    DTS should inform about it.
     [Tags]    optiplex_dpp
-    # 1) Get into DTS
-    Power On And Enter DTS Shell
 
     # 2) Emulate needed env.:
     Execute Command In Terminal
@@ -848,8 +769,6 @@ E2E004.006 Dell Optiplex 9010 DPP initial deployment (legacy -> Coreboot + UEFI)
     ...    9010 with credentials provided. User should have access, and firmware
     ...    should be deployed.
     [Tags]    optiplex_dpp
-    # 1) Get into DTS
-    Power On And Enter DTS Shell
 
     # 2) Emulate needed env.:
     Execute Command In Terminal
@@ -873,8 +792,6 @@ E2E004.007 Dell Optiplex 9010 DPP update (Coreboot + UEFI -> Coreboot + UEFI) - 
     ...    9010 without credentials provided. User should not have access and
     ...    DTS should inform about it.
     [Tags]    optiplex_dpp
-    # 1) Get into DTS
-    Power On And Enter DTS Shell
 
     # 2) Emulate needed env.:
     Execute Command In Terminal
@@ -896,8 +813,6 @@ E2E004.008 Dell Optiplex 9010 DPP update (Coreboot + UEFI -> Coreboot + UEFI) - 
     ...    9010 with credentials provided. User should have access, and firmware
     ...    should be deployed.
     [Tags]    optiplex_dpp
-    # 1) Get into DTS
-    Power On And Enter DTS Shell
 
     # 2) Emulate needed env.:
     Execute Command In Terminal
@@ -927,8 +842,6 @@ E2E005.001 PC Engines DPP initial deployment (legacy -> Coreboot + UEFI) - no cr
     ...    and do not provide DPP credentials. There should be no access granted
     ...    for the firmware without credentials.
     [Tags]    pcengines_dpp
-    # 1) Get into DTS
-    Power On And Enter DTS Shell
 
     # 2) Emulate needed env.:
     Execute Command In Terminal
@@ -953,8 +866,6 @@ E2E005.002 PC Engines DPP initial deployment (legacy -> Coreboot + UEFI) - with 
     ...    PC Engines with credentials provided (these should be provided via
     ...    CMD).
     [Tags]    pcengines_dpp
-    # 1) Get into DTS:
-    Power On And Enter DTS Shell
 
     # 2) Emulate needed env.:
     Execute Command In Terminal
@@ -976,8 +887,6 @@ E2E005.003 PC Engines DPP initial deployment (legacy -> Coreboot + SeaBIOS) - wi
     ...    on PC Engines. We start from legacy firmware and insert correct DPP keys
     ...    for UEFI variant.
     [Tags]    pcengines_seabios
-    # 1) Get into DTS:
-    Power On And Enter DTS Shell
 
     # 2) Emulate needed env.:
     Execute Command In Terminal
@@ -1002,8 +911,6 @@ E2E005.004 PC Engines DPP initial deployment (legacy -> Coreboot + SeaBIOS) - wi
     ...    on PC Engines. We start from legacy firmware and insert correct DPP
     ...    keys for UEFI variant.
     [Tags]    pcengines_seabios
-    # 1) Get into DTS:
-    Power On And Enter DTS Shell
 
     # 2) Emulate needed env.:
     Execute Command In Terminal
@@ -1030,8 +937,6 @@ E2E006.001 Odroid H4 initial deployment (legacy -> Coreboot + UEFI) - without cr
     ...    without credentials provided. User should not have access and DTS
     ...    should inform about it.
     [Tags]    odroid_dpp
-    # 1) Get into DTS
-    Power On And Enter DTS Shell
 
     # 2) Emulate needed env.:
     Execute Command In Terminal
@@ -1058,8 +963,6 @@ E2E006.002 Odroid H4 DPP initial deployment (legacy -> Coreboot + UEFI) - with c
     ...    credentials provided. User should have access, and firmware should be
     ...    deployed.
     [Tags]    odroid_dpp
-    # 1) Get into DTS
-    Power On And Enter DTS Shell
 
     # 2) Emulate needed env.:
     Execute Command In Terminal
@@ -1083,8 +986,6 @@ E2E006.003 Odroid H4 update (Coreboot + UEFI -> Coreboot + UEFI) - without crede
     ...    without credentials provided. User should not have access and DTS
     ...    should inform about it.
     [Tags]    odroid_dpp
-    # 1) Get into DTS
-    Power On And Enter DTS Shell
 
     # 2) Emulate needed env.:
     Execute Command In Terminal
@@ -1106,8 +1007,6 @@ E2E006.004 Odroid H4 DPP update (Coreboot + UEFI -> Coreboot + UEFI) - with cred
     ...    9010 with credentials provided. User should have access, and firmware
     ...    should be deployed.
     [Tags]    odroid_dpp
-    # 1) Get into DTS
-    Power On And Enter DTS Shell
 
     # 2) Emulate needed env.:
     Execute Command In Terminal
@@ -1128,6 +1027,39 @@ E2E006.004 Odroid H4 DPP update (Coreboot + UEFI -> Coreboot + UEFI) - with cred
 
 
 *** Keywords ***
+Prepare DTS Test
+    Start New DTS SSH Session In QEMU
+
+Teardown DTS Test
+    [Documentation]    Close SSH session and cleanup all possible changes made
+    ...    during test
+    Restore Initial DUT Connection Method
+    # not sure if it's needed if we don't want to keep multiple sessions in
+    # background
+    SSHLibrary.Close Connection
+    Set Prompt For Terminal    bash-5.2#
+    Execute Linux Command    rm -rf /etc/cloud-pass /root/.mc
+
+Start New DTS SSH Session In QEMU
+    [Documentation]    Changes connection method to ssh and logs in to DTS
+    Set Global Variable    ${DUT_CONNECTION_METHOD}    SSH
+    Login To DTS Via SSH In QEMU
+
+Login To DTS Via SSH In QEMU
+    [Documentation]    Modified 'Login to Linux via SSH' keyword with ip set to
+    ...    localhost and port set to 5222.
+    [Arguments]    ${timeout}=180    ${prompt}=root@DasharoToolsSuite:~#
+    SSHLibrary.Open Connection    localhost    port=5222    prompt=${prompt}
+    SSHLibrary.Set Client Configuration
+    ...    timeout=${timeout}
+    ...    term_type=vt100
+    ...    width=400
+    ...    height=100
+    ...    escape_ansi=True
+    ...    newline=LF
+    Wait Until Keyword Succeeds    3x    1s
+    ...    SSHLibrary.Login    root
+
 Power On And Enter DTS Shell
     [Documentation]    This KW boots DTS using the method defined by user via
     ...    DTS_BOOT_TYPE or the default one. After booting DTS shell is being

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ robotframework-faker==5.0.0
 robotframework-requests==0.9.4
 robotframework-robocop==5.0.4
 robotframework-sherlock==0.3.0
-robotframework-sshlibrary==3.5.1
+robotframework-sshlibrary @ git+https://github.com/MarketSquare/SSHLibrary@ba6c3ee783bd6fd8b73c1341fe873a99991a353a
 robotframework-tidy==4.11.0
 rsa==4.9
 scp==0.14.5


### PR DESCRIPTION
Run each test in separate SSH shell to make sure environment variables are not polluted. Each test runs test teardown keyword which should clean up DTS state so it doesn't affect future tests.
Had to update robotframework-sshlibrary to include fix for empty passwords (due to this issue: https://github.com/MarketSquare/SSHLibrary/issues/374).
Testing is done here: https://github.com/Dasharo/meta-dts/pull/220, modified workflow a little so it checkouts this branch and downloads DTS from https://boot.dasharo.com instead of building it to make testing this PR a little faster

Should help with https://github.com/Dasharo/open-source-firmware-validation/issues/652. If time is reduced considerably then we could probably enable running those tests for all PRs (or at least PR targeting develop)