### PR TITLE
Usb fixes integration

### DIFF
--- a/dasharo-compatibility/coreboot-fan-control.robot
+++ b/dasharo-compatibility/coreboot-fan-control.robot
@@ -28,10 +28,11 @@ Suite Teardown      Run Keyword
 CFN001.001 CPU temperature and fan speed can be read (Debian)
     [Documentation]    Check whether the data of CPU temperature and CPU fan
     ...    is available and can be read.
-    Skip If    not ${TESTS_IN_DEBIAN_SUPPORT}    CFN001.001 not supported
+    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    CFN001.001 not supported
     Power On
-    Boot From USB
-    Serial Root Login Linux    debian
+    Boot System Or From Connected Disk    ubuntu
+    Login To Linux
+    Switch To Root User
     ${rpm}    ${temperature}=    Get CPU Temperature And CPU Fan Speed
     IF    ${rpm}==${0}    FAIL    Fan speed not measured
     IF    ${temperature}==${0}    FAIL    Temperature not measured
@@ -39,10 +40,11 @@ CFN001.001 CPU temperature and fan speed can be read (Debian)
 CFN002.001 CPU fan speed increases if the temperature rises (Debian)
     [Documentation]    Check whether CPU fan speed increases if the CPU
     ...    temperature rises.
-    Skip If    not ${TESTS_IN_DEBIAN_SUPPORT}    CFN002.001 not supported
+    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    CFN002.001 not supported
     Power On
-    Boot From USB
-    Serial Root Login Linux    debian
+    Boot System Or From Connected Disk    ubuntu
+    Login To Linux
+    Switch To Root User
     # Colling procedure: sometimes before starting the test case, CPU
     # temperature or CPU's fan speed might be too high. To prevent test case
     # from failing a cooling procedure is used. This procedure is to delay the

--- a/dasharo-compatibility/flash-write-protection.robot
+++ b/dasharo-compatibility/flash-write-protection.robot
@@ -29,16 +29,18 @@ HWP001.001 Hardware flash write protection support
     [Documentation]    Check whether the DUT support hardware write protection
     ...    mechanism.
     Power On
-    Boot From USB
-    Serial Root Login Linux    debian
+    Boot System Or From Connected Disk    ubuntu
+    Login To Linux
+    Switch To Root User
     Check Write Protection Availability
 
 HWP002.001 Hardware flash write protection enable / disable
     [Documentation]    Check whether there is a possibility to set and erase
     ...    hardware write protection on the DUT.
     Power On
-    Boot From USB
-    Serial Root Login Linux    debian
+    Boot System Or From Connected Disk    ubuntu
+    Login To Linux
+    Switch To Root User
     Erase Write Protection
     Set Write Protection    0x00000000    ${FLASH_LENGTH}
     Check Write Protection Status

--- a/dasharo-compatibility/usb-boot.robot
+++ b/dasharo-compatibility/usb-boot.robot
@@ -50,10 +50,10 @@ UBT001.001 USB detect and boot after coldboot
             END
         EXCEPT
             ${failed_boot}=    Evaluate    ${failed_boot} + 1
+            IF    '${failed_boot}' > '${ALLOWED_FAILS_USB_BOOT}'
+                Fail    Boot from USB failed too many times (${failed_boot})
+            END
         END
-    END
-    IF    '${failed_boot}' > '${ALLOWED_FAILS_USB_BOOT}'
-        Fail    Boot from USB failed too many times (${failed_boot})
     END
 
 UBT002.001 USB detect and boot after warmboot
@@ -78,10 +78,10 @@ UBT002.001 USB detect and boot after warmboot
             END
         EXCEPT
             ${failed_boot}=    Evaluate    ${failed_boot} + 1
+            IF    '${failed_boot}' > '${ALLOWED_FAILS_USB_BOOT}'
+                Fail    Boot from USB failed too many times (${failed_boot})
+            END
         END
-    END
-    IF    '${failed_boot}' > '${ALLOWED_FAILS_USB_BOOT}'
-        Fail    Boot from USB failed too many times (${failed_boot})
     END
 
 UBT003.001 USB detect and boot after system reboot
@@ -97,16 +97,16 @@ UBT003.001 USB detect and boot after system reboot
             Power On
             Boot System Or From Connected Disk    ${usb}
             IF    '${PLATFORM}' != 'raptor-cs_talos2'    Reboot Via Linux On USB
-            IF    '${PLATFORM}' == 'raptor-cs_talos2'    Login To Linux
             IF    '${PLATFORM}' == 'raptor-cs_talos2'
+                Login To Linux
                 Write Into Terminal    reboot
             END
         EXCEPT
             ${failed_boot}=    Evaluate    ${failed_boot} + 1
+            IF    '${failed_boot}' > '${ALLOWED_FAILS_USB_BOOT}'
+                Fail    Boot from USB failed too many times (${failed_boot})
+            END
         END
-    END
-    IF    '${failed_boot}' > '${ALLOWED_FAILS_USB_BOOT}'
-        Fail    Boot from USB failed too many times (${failed_boot})
     END
 
 

--- a/dasharo-compatibility/usb-boot.robot
+++ b/dasharo-compatibility/usb-boot.robot
@@ -37,7 +37,9 @@ UBT001.001 USB detect and boot after coldboot
     FOR    ${index}    IN RANGE    0    ${BOOT_FROM_USB_ITERATIONS_NUMBER}
         TRY
             Power Cycle On
-            Boot From USB
+            ${usb}=    Get USB Boot Option
+            Power On
+            Boot System Or From Connected Disk    ${usb}
             IF    '${PLATFORM}' == 'raptor-cs_talos2'
                 Login To Linux
             ELSE
@@ -63,7 +65,9 @@ UBT002.001 USB detect and boot after warmboot
     FOR    ${index}    IN RANGE    0    ${BOOT_FROM_USB_ITERATIONS_NUMBER}
         TRY
             Power On
-            Boot From USB
+            ${usb}=    Get USB Boot Option
+            Power On
+            Boot System Or From Connected Disk    ${usb}
             IF    '${PLATFORM}' == 'raptor-cs_talos2'
                 Login To Linux
             ELSE
@@ -89,7 +93,9 @@ UBT003.001 USB detect and boot after system reboot
     Power On
     FOR    ${index}    IN RANGE    0    ${BOOT_FROM_USB_ITERATIONS_NUMBER}
         TRY
-            Boot From USB
+            ${usb}=    Get USB Boot Option
+            Power On
+            Boot System Or From Connected Disk    ${usb}
             IF    '${PLATFORM}' != 'raptor-cs_talos2'    Reboot Via Linux On USB
             IF    '${PLATFORM}' == 'raptor-cs_talos2'    Login To Linux
             IF    '${PLATFORM}' == 'raptor-cs_talos2'

--- a/dasharo-compatibility/usb-boot.robot
+++ b/dasharo-compatibility/usb-boot.robot
@@ -20,7 +20,7 @@ Resource            ../pikvm-rest-api/pikvm_comm.robot
 Suite Setup         Run Keywords
 ...                     Prepare Test Suite
 ...                     AND
-...                     Skip If    "${BOOT_FROM_USB_ITERATIONS_NUMBER}" == "0"    USB booting tests skipped
+...                     Skip If    ${BOOT_FROM_USB_ITERATIONS_NUMBER} == 0    USB booting tests skipped
 ...                     AND
 ...                     Skip If    not ${TESTS_IN_FIRMWARE_SUPPORT}    Tests in firmware not supported
 Suite Teardown      Run Keyword
@@ -32,22 +32,11 @@ UBT001.001 USB detect and boot after coldboot
     [Documentation]    Check whether the DUT properly detects USB device and
     ...    boots into the operating system after coldboot (reboot
     ...    realized by power supply cutting off then cutting on).
-    Platform Verification
     Set Local Variable    ${failed_boot}    0
     FOR    ${index}    IN RANGE    0    ${BOOT_FROM_USB_ITERATIONS_NUMBER}
         TRY
             Power Cycle On
-            ${usb}=    Get USB Boot Option
-            Power On
-            Boot System Or From Connected Disk    ${usb}
-            IF    '${PLATFORM}' == 'raptor-cs_talos2'
-                Login To Linux
-            ELSE
-                Login To Linux Over Serial Console
-                ...    ${DEVICE_USB_USERNAME}
-                ...    ${DEVICE_USB_PASSWORD}
-                ...    ${DEVICE_USB_PROMPT}
-            END
+            Boot Dasharo Tools Suite    USB
         EXCEPT
             ${failed_boot}=    Evaluate    ${failed_boot} + 1
             IF    '${failed_boot}' > '${ALLOWED_FAILS_USB_BOOT}'
@@ -60,22 +49,11 @@ UBT002.001 USB detect and boot after warmboot
     [Documentation]    Check whether the DUT properly detects USB device and
     ...    boots into the operating system after warmboot (reboot
     ...    realized by device turning off then turning on).
-    Platform Verification
     Set Local Variable    ${failed_boot}    0
     FOR    ${index}    IN RANGE    0    ${BOOT_FROM_USB_ITERATIONS_NUMBER}
         TRY
             Power On
-            ${usb}=    Get USB Boot Option
-            Power On
-            Boot System Or From Connected Disk    ${usb}
-            IF    '${PLATFORM}' == 'raptor-cs_talos2'
-                Login To Linux
-            ELSE
-                Login To Linux Over Serial Console
-                ...    ${DEVICE_USB_USERNAME}
-                ...    ${DEVICE_USB_PASSWORD}
-                ...    ${DEVICE_USB_PROMPT}
-            END
+            Boot Dasharo Tools Suite    USB
         EXCEPT
             ${failed_boot}=    Evaluate    ${failed_boot} + 1
             IF    '${failed_boot}' > '${ALLOWED_FAILS_USB_BOOT}'
@@ -88,37 +66,17 @@ UBT003.001 USB detect and boot after system reboot
     [Documentation]    Check whether the DUT properly detects USB device and
     ...    boots into the operating system after system reboot
     ...    (reboot performing by relevant command).
-    Platform Verification
     Set Local Variable    ${failed_boot}    0
     Power On
     FOR    ${index}    IN RANGE    0    ${BOOT_FROM_USB_ITERATIONS_NUMBER}
         TRY
-            ${usb}=    Get USB Boot Option
-            Power On
-            Boot System Or From Connected Disk    ${usb}
-            IF    '${PLATFORM}' != 'raptor-cs_talos2'    Reboot Via Linux On USB
-            IF    '${PLATFORM}' == 'raptor-cs_talos2'
-                Login To Linux
-                Write Into Terminal    reboot
-            END
+            Boot Dasharo Tools Suite    USB
+            Enter Shell In DTS
+            Execute Reboot Command
         EXCEPT
             ${failed_boot}=    Evaluate    ${failed_boot} + 1
             IF    '${failed_boot}' > '${ALLOWED_FAILS_USB_BOOT}'
                 Fail    Boot from USB failed too many times (${failed_boot})
             END
         END
-    END
-
-
-*** Keywords ***
-Platform Verification
-    [Documentation]    Check whether according to hardware matrix, any USB
-    ...    stick is connected to the platform.
-    IF    '${PLATFORM}' == 'raptor-cs_talos2'    RETURN
-    ${conf}=    Get Current CONFIG    ${CONFIG_LIST}
-    ${result}=    Evaluate    "USB_Storage" in """${conf}"""
-    IF    not ${result}
-        SKIP    \nPlatform doesn't have USB storage attached.
-    ELSE
-        Log    Selected platform is correct.
     END

--- a/dasharo-compatibility/usb-detect.robot
+++ b/dasharo-compatibility/usb-detect.robot
@@ -39,16 +39,7 @@ UDT001.001 USB detection after coldboot
         TRY
             ${usb}=    Evaluate    0
             Power Cycle On
-            IF    '${PAYLOAD}' == 'tianocore'
-                Enter Boot Menu Tianocore
-                ${menu}=    Read From Terminal Until    ESC to exit
-            ELSE IF    '${PAYLOAD}' == 'seabios'
-                ${menu}=    Enter SeaBIOS And Return Menu
-            ELSE IF    '${PAYLOAD}' == 'petitboot'
-                ${menu}=    Enter Petitboot And Return Menu
-            ELSE
-                ${menu}=    FAIL    Unknown payload: ${PAYLOAD}
-            END
+            ${menu}=    Enter Boot Menu Tianocore And Return Construction
             FOR    ${stick}    IN    @{ATTACHED_USB}
                 ${usb_tmp}=    Get Count    ${menu}    ${stick}
                 ${usb}=    Evaluate    ${usb} + ${usb_tmp}
@@ -80,15 +71,7 @@ UDT001.002 USB detection after warmboot
         TRY
             ${usb}=    Evaluate    0
             Power On
-            IF    '${PAYLOAD}' == 'tianocore'
-                ${menu}=    Enter Tianocore And Return Menu
-            ELSE IF    '${PAYLOAD}' == 'seabios'
-                ${menu}=    Enter SeaBIOS And Return Menu
-            ELSE IF    '${PAYLOAD}' == 'petitboot'
-                ${menu}=    Enter Petitboot And Return Menu
-            ELSE
-                ${menu}=    FAIL    Unknown payload: ${PAYLOAD}
-            END
+            ${menu}=    Enter Boot Menu Tianocore And Return Construction
             FOR    ${stick}    IN    @{ATTACHED_USB}
                 ${usb_tmp}=    Get Count    ${menu}    ${stick}
                 ${usb}=    Evaluate    ${usb} + ${usb_tmp}
@@ -128,15 +111,7 @@ UDT001.003 USB detection after system reboot
             ELSE
                 FAIL    Unknown payload: ${PAYLOAD}
             END
-            IF    '${PAYLOAD}' == 'tianocore'
-                ${menu}=    Enter Tianocore And Return Menu
-            ELSE IF    '${PAYLOAD}' == 'seabios'
-                ${menu}=    Enter SeaBIOS And Return Menu
-            ELSE IF    '${PAYLOAD}' == 'petitboot'
-                ${menu}=    Enter Petitboot And Return Menu
-            ELSE
-                ${menu}=    FAIL    Unknown payload: ${PAYLOAD}
-            END
+            ${menu}=    Enter Boot Menu Tianocore And Return Construction
             FOR    ${stick}    IN    @{ATTACHED_USB}
                 ${usb_tmp}=    Get Count    ${menu}    ${stick}
                 ${usb}=    Evaluate    ${usb} + ${usb_tmp}

--- a/dasharo-compatibility/usb-detect.robot
+++ b/dasharo-compatibility/usb-detect.robot
@@ -54,10 +54,10 @@ UDT001.001 USB detection after coldboot
             Should Be Equal As Integers    ${usb}    ${usb_count}
         EXCEPT
             ${failed_detection}=    Evaluate    ${FAILED_DETECTION} + 1
+            IF    '${failed_detection}' > '${ALLOWED_FAILS_USB_DETECT}'
+                Fail    Detection failed too many times (${failed_detection})
+            END
         END
-    END
-    IF    '${failed_detection}' > '${ALLOWED_FAILS_USB_DETECT}'
-        Fail    Detection failed too many times (${failed_detection})
     END
 
 UDT001.002 USB detection after warmboot
@@ -86,10 +86,10 @@ UDT001.002 USB detection after warmboot
             Should Be Equal As Integers    ${usb}    ${usb_count}
         EXCEPT
             ${failed_detection}=    Evaluate    ${FAILED_DETECTION} + 1
+            IF    '${failed_detection}' > '${ALLOWED_FAILS_USB_DETECT}'
+                Fail    Detection failed too many times (${failed_detection})
+            END
         END
-    END
-    IF    '${failed_detection}' > '${ALLOWED_FAILS_USB_DETECT}'
-        Fail    Detection failed too many times (${failed_detection})
     END
 
 UDT001.003 USB detection after system reboot
@@ -126,10 +126,10 @@ UDT001.003 USB detection after system reboot
             Should Be Equal As Integers    ${usb}    ${usb_count}
         EXCEPT
             ${failed_detection}=    Evaluate    ${failed_detection} + 1
+            IF    '${failed_detection}' > '${ALLOWED_FAILS_USB_DETECT}'
+                Fail    Detection failed too many times (${failed_detection})
+            END
         END
-    END
-    IF    '${failed_detection}' > '${ALLOWED_FAILS_USB_DETECT}'
-        Fail    Detection failed too many times (${failed_detection})
     END
 
 

--- a/dasharo-compatibility/usb-detect.robot
+++ b/dasharo-compatibility/usb-detect.robot
@@ -32,28 +32,14 @@ UDT001.001 USB detection after coldboot
     [Documentation]    Check whether the DUT detects properly USB device after
     ...    the coldboot (reboot realized by power supply cutting off
     ...    then cutting on).
-    Platform Verification
-    Set Global Variable    ${FAILED_DETECTION}    0
-    Set Local Variable    ${usb}    0
+    Set Local Variable    ${failed_detection}    0
     FOR    ${index}    IN RANGE    0    ${USB_DETECTION_ITERATIONS_NUMBER}
-        TRY
-            ${usb}=    Evaluate    0
-            Power Cycle On
-            ${menu}=    Enter Boot Menu Tianocore And Return Construction
-            FOR    ${stick}    IN    @{ATTACHED_USB}
-                ${usb_tmp}=    Get Count    ${menu}    ${stick}
-                ${usb}=    Evaluate    ${usb} + ${usb_tmp}
-            END
-            IF    '${PLATFORM}' in ['apu1', 'apu5']
-                ${usb}=    Evaluate
-                ...    ${usb} - sum([1 for line in """${menu}""".splitlines() if 'Multiple Card' in line])
-            ELSE
-                ${usb}=    Evaluate    '${usb}'
-            END
-            ${usb_count}=    Get All USB
-            Should Be Equal As Integers    ${usb}    ${usb_count}
-        EXCEPT
-            ${failed_detection}=    Evaluate    ${FAILED_DETECTION} + 1
+        Power Cycle On
+        ${boot_menu}=    Enter Boot Menu Tianocore And Return Construction
+        ${found}=    Check USB Stick Detection in Edk2    ${boot_menu}
+
+        IF    '${found}' != '${TRUE}'
+            ${failed_detection}=    Evaluate    ${failed_detection} + 1
             IF    '${failed_detection}' > '${ALLOWED_FAILS_USB_DETECT}'
                 Fail    Detection failed too many times (${failed_detection})
             END
@@ -64,28 +50,14 @@ UDT001.002 USB detection after warmboot
     [Documentation]    Check whether the DUT detects properly USB device after
     ...    the warmboot (reboot realized by device turning off then
     ...    turning on).
-    Platform Verification
-    Set Global Variable    ${FAILED_DETECTION}    0
-    Set Local Variable    ${usb}    0
+    Set Local Variable    ${failed_detection}    0
     FOR    ${index}    IN RANGE    0    ${USB_DETECTION_ITERATIONS_NUMBER}
-        TRY
-            ${usb}=    Evaluate    0
-            Power On
-            ${menu}=    Enter Boot Menu Tianocore And Return Construction
-            FOR    ${stick}    IN    @{ATTACHED_USB}
-                ${usb_tmp}=    Get Count    ${menu}    ${stick}
-                ${usb}=    Evaluate    ${usb} + ${usb_tmp}
-            END
-            IF    '${PLATFORM}' in ['apu1', 'apu5']
-                ${usb}=    Evaluate
-                ...    ${usb} - sum([1 for line in """${menu}""".splitlines() if 'Multiple Card' in line])
-            ELSE
-                ${usb}=    Evaluate    '${usb}'
-            END
-            ${usb_count}=    Get All USB
-            Should Be Equal As Integers    ${usb}    ${usb_count}
-        EXCEPT
-            ${failed_detection}=    Evaluate    ${FAILED_DETECTION} + 1
+        Power On
+        ${boot_menu}=    Enter Boot Menu Tianocore And Return Construction
+        ${found}=    Check USB Stick Detection in Edk2    ${boot_menu}
+
+        IF    '${found}' != '${TRUE}'
+            ${failed_detection}=    Evaluate    ${failed_detection} + 1
             IF    '${failed_detection}' > '${ALLOWED_FAILS_USB_DETECT}'
                 Fail    Detection failed too many times (${failed_detection})
             END
@@ -95,49 +67,21 @@ UDT001.002 USB detection after warmboot
 UDT001.003 USB detection after system reboot
     [Documentation]    Check whether the DUT detects properly USB device after
     ...    the system reboot (reboot performing by relevant command).
-    Platform Verification
     Set Local Variable    ${failed_detection}    0
-    Set Local Variable    ${usb}    0
+
+    Power On
     FOR    ${index}    IN RANGE    0    ${USB_DETECTION_ITERATIONS_NUMBER}
-        TRY
-            ${usb}=    Evaluate    0
-            Power On
-            IF    '${PAYLOAD}' == 'tianocore'
-                Reboot Via Ubuntu By Tianocore
-            ELSE IF    '${PAYLOAD}' == 'seabios'
-                Reboot Via IPXE Boot By SeaBIOS
-            ELSE IF    '${PAYLOAD}' == 'petitboot'
-                Reboot Via OS Boot By Petitboot
-            ELSE
-                FAIL    Unknown payload: ${PAYLOAD}
-            END
-            ${menu}=    Enter Boot Menu Tianocore And Return Construction
-            FOR    ${stick}    IN    @{ATTACHED_USB}
-                ${usb_tmp}=    Get Count    ${menu}    ${stick}
-                ${usb}=    Evaluate    ${usb} + ${usb_tmp}
-            END
-            IF    '${PLATFORM}' in ['apu1', 'apu5']
-                ${usb}=    Evaluate
-                ...    ${usb} - sum([1 for line in """${menu}""".splitlines() if 'Multiple Card' in line])
-            ELSE
-                ${usb}=    Evaluate    '${usb}'
-            END
-            ${usb_count}=    Get All USB
-            Should Be Equal As Integers    ${usb}    ${usb_count}
-        EXCEPT
+        ${boot_menu}=    Enter Boot Menu Tianocore And Return Construction
+        ${found}=    Check USB Stick Detection in Edk2    ${boot_menu}
+        Boot System Or From Connected Disk    ubuntu    boot_menu=${boot_menu}
+        Login To Linux
+        Switch To Root User
+        Execute Reboot Command
+
+        IF    '${found}' != '${TRUE}'
             ${failed_detection}=    Evaluate    ${failed_detection} + 1
             IF    '${failed_detection}' > '${ALLOWED_FAILS_USB_DETECT}'
                 Fail    Detection failed too many times (${failed_detection})
             END
         END
     END
-
-
-*** Keywords ***
-Platform Verification
-    [Documentation]    Check whether according to hardware matrix, any USB
-    ...    stick is connected to the platform.
-    IF    '${PLATFORM}' == 'raptor-cs_talos2'    RETURN
-    ${conf}=    Get Current CONFIG    ${CONFIG_LIST}
-    ${result}=    Evaluate    "USB_Storage" in """${conf}"""
-    IF    not ${result}    SKIP    Platform doesn't have USB storage attached.

--- a/dasharo-compatibility/usb-hid-and-msc-support.robot
+++ b/dasharo-compatibility/usb-hid-and-msc-support.robot
@@ -27,21 +27,18 @@ Suite Teardown      Run Keyword
 USB001.001 USB devices detected in FW
     [Documentation]    Check whether USB devices are detected in Tianocore
     ...    (edk2).
-    Skip If    not ${USB_DISKS_DETECTION_SUPPORT}    USB001.001 not supported
-    Skip If    not ${HAS_USB_STORAGE}    USB001.001 not supported
-    Skip If    not ${TESTS_IN_FIRMWARE_SUPPORT}
-    IF    "${DUT_CONNECTION_METHOD}" == "pikvm"
-        Upload And Mount DTS Flash Iso
-    END
+    Depends On    ${TESTS_IN_FIRMWARE_SUPPORT}
+    Depends On    ${USB_DISKS_DETECTION_SUPPORT}
+    Depends On    ${HAS_USB_STORAGE}
     Power On
     ${boot_menu}=    Enter Boot Menu Tianocore And Return Construction
-    Check That USB Devices Are Detected    ${boot_menu}
+    Check USB Stick Detection in Edk2    ${boot_menu}
 
 USB001.002 USB devices detected by OS (Ubuntu)
     [Documentation]    Check whether the external USB devices are detected
     ...    correctly in Linux OS.
-    Skip If    not ${USB_DISKS_DETECTION_SUPPORT}    USB001.002 not supported
-    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    USB001.002 not supported
+    Depends On    ${USB_DISKS_DETECTION_SUPPORT}
+    Depends On    ${TESTS_IN_UBUNTU_SUPPORT}
     Power On
     Boot System Or From Connected Disk    ubuntu
     Login To Linux
@@ -55,8 +52,8 @@ USB001.002 USB devices detected by OS (Ubuntu)
 USB001.003 USB devices detected by OS (Windows)
     [Documentation]    Check whether the external USB devices are detected
     ...    correctly in Windows OS.
-    Skip If    not ${USB_DISKS_DETECTION_SUPPORT}    USB001.003 not supported
-    Skip If    not ${TESTS_IN_WINDOWS_SUPPORT}    USB001.003 not supported
+    Depends On    ${USB_DISKS_DETECTION_SUPPORT}
+    Depends On    ${TESTS_IN_WINDOWS_SUPPORT}
     Power On
     Login To Windows
     ${out}=    Execute Command In Terminal
@@ -69,8 +66,8 @@ USB002.001 USB keyboard detected in FW
     ...    correctly by the firmware and all basic keys work
     ...    according to their labels.
     [Tags]    minimal-regression
-    Skip If    not ${TESTS_IN_FIRMWARE_SUPPORT}
-    Skip If    not ${HAS_KEYBOARD}    USB002.001 not supported
+    Depends On    ${TESTS_IN_FIRMWARE_SUPPORT}
+    Depends On    ${HAS_KEYBOARD}
     Power On
     Enter UEFI Shell
     ${out}=    Execute UEFI Shell Command    devices
@@ -79,9 +76,9 @@ USB002.001 USB keyboard detected in FW
 USB002.002 USB keyboard in OS (Ubuntu)
     [Documentation]    Check whether the external USB keyboard is detected
     ...    correctly by the Linux OS.
-    Skip If    not ${USB_KEYBOARD_DETECTION_SUPPORT}    USB002.002 not supported
-    Skip If    "${DEVICE_USB_KEYBOARD}" == "${EMPTY}"    USB002.002 not supported
-    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    USB002.002 not supported
+    Depends On    ${USB_KEYBOARD_DETECTION_SUPPORT}
+    Depends On    "${DEVICE_USB_KEYBOARD}" == "${EMPTY}"
+    Depends On    ${TESTS_IN_UBUNTU_SUPPORT}
     Power On
     Boot System Or From Connected Disk    ubuntu
     Login To Linux
@@ -92,9 +89,9 @@ USB002.002 USB keyboard in OS (Ubuntu)
 USB002.003 USB keyboard in OS (Windows)
     [Documentation]    Check whether the external USB keyboard is detected
     ...    correctly by the Windows OS.
-    Skip If    not ${USB_KEYBOARD_DETECTION_SUPPORT}    USB002.003 not supported
-    Skip If    not ${HAS_KEYBOARD}    USB002.003 not supported
-    Skip If    not ${TESTS_IN_WINDOWS_SUPPORT}    USB002.003 not supported
+    Depends On    ${USB_KEYBOARD_DETECTION_SUPPORT}
+    Depends On    ${HAS_KEYBOARD}
+    Depends On    ${TESTS_IN_WINDOWS_SUPPORT}
     Power On
     Login To Windows
     ${out}=    Execute Command In Terminal    Get-CimInstance win32_KEYBOARD
@@ -104,9 +101,9 @@ USB002.003 USB keyboard in OS (Windows)
 USB003.001 Upload 1GB file on USB storage (Ubuntu)
     [Documentation]    Check whether the 1GB file can be transferred from the
     ...    operating system to the USB storage.
-    Skip If    not ${UPLOAD_ON_USB_SUPPORT}    USB003.001 not supported
-    Skip If    not ${HAS_USB_STORAGE}    USB003.001 not supported
-    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    USB003.001 not supported
+    Depends On    ${UPLOAD_ON_USB_SUPPORT}
+    Depends On    ${HAS_USB_STORAGE}
+    Depends On    ${TESTS_IN_UBUNTU_SUPPORT}
     Power On
     Boot System Or From Connected Disk    ubuntu
     Login To Linux
@@ -121,9 +118,9 @@ USB003.001 Upload 1GB file on USB storage (Ubuntu)
 USB003.002 Upload 1GB file on USB storage (Windows)
     [Documentation]    Check whether the 1GB file can be transferred from the
     ...    operating system to the USB storage.
-    Skip If    not ${UPLOAD_ON_USB_SUPPORT}    USB003.002 not supported
-    Skip If    not ${HAS_USB_STORAGE}    USB003.002 not supported
-    Skip If    not ${TESTS_IN_WINDOWS_SUPPORT}    USB003.002 not supported
+    Depends On    ${UPLOAD_ON_USB_SUPPORT}
+    Depends On    ${HAS_USB_STORAGE}
+    Depends On    ${TESTS_IN_WINDOWS_SUPPORT}
     Power On
     Login To Windows
     Generate 1GB File In Windows

--- a/dasharo-compatibility/usb-hid-and-msc-support.robot
+++ b/dasharo-compatibility/usb-hid-and-msc-support.robot
@@ -29,7 +29,9 @@ USB001.001 USB devices detected in FW
     ...    (edk2).
     Skip If    not ${USB_DISKS_DETECTION_SUPPORT}    USB001.001 not supported
     Skip If    not ${TESTS_IN_FIRMWARE_SUPPORT}
-    Upload And Mount DTS Flash Iso
+    IF    "${DUT_CONNECTION_METHOD}" == "pikvm"
+        Upload And Mount DTS Flash Iso
+    END
     Power On
     ${boot_menu}=    Enter Boot Menu Tianocore And Return Construction
     Check That USB Devices Are Detected    ${boot_menu}

--- a/dasharo-compatibility/usb-hid-and-msc-support.robot
+++ b/dasharo-compatibility/usb-hid-and-msc-support.robot
@@ -28,6 +28,7 @@ USB001.001 USB devices detected in FW
     [Documentation]    Check whether USB devices are detected in Tianocore
     ...    (edk2).
     Skip If    not ${USB_DISKS_DETECTION_SUPPORT}    USB001.001 not supported
+    Skip If    not ${HAS_USB_STORAGE}    USB001.001 not supported
     Skip If    not ${TESTS_IN_FIRMWARE_SUPPORT}
     IF    "${DUT_CONNECTION_METHOD}" == "pikvm"
         Upload And Mount DTS Flash Iso
@@ -48,7 +49,7 @@ USB001.002 USB devices detected by OS (Ubuntu)
     Detect Or Install Package    usbutils
     ${out}=    Execute Command In Terminal    lsusb -v | grep bInterfaceClass
     IF    ${HAS_KEYBOARD}    Should Contain    ${out}    Human Interface Device
-    Should Contain    ${out}    Mass Storage
+    IF    ${HAS_USB_STORAGE}    Should Contain    ${out}    Mass Storage
     Exit From Root User
 
 USB001.003 USB devices detected by OS (Windows)
@@ -61,7 +62,7 @@ USB001.003 USB devices detected by OS (Windows)
     ${out}=    Execute Command In Terminal
     ...    Get-PnpDevice -PresentOnly | Where-Object { $_.InstanceId -match '^USB' }
     IF    ${HAS_KEYBOARD}    Should Contain    ${out}    HIDClass
-    Should Contain    ${out}    DiskDrive
+    IF    ${HAS_USB_STORAGE}    Should Contain    ${out}    DiskDrive
 
 USB002.001 USB keyboard detected in FW
     [Documentation]    Check whether the external USB keyboard is detected
@@ -103,8 +104,9 @@ USB002.003 USB keyboard in OS (Windows)
 USB003.001 Upload 1GB file on USB storage (Ubuntu)
     [Documentation]    Check whether the 1GB file can be transferred from the
     ...    operating system to the USB storage.
-    IF    not ${UPLOAD_ON_USB_SUPPORT}    SKIP    USB003.001 not supported
-    IF    not ${TESTS_IN_UBUNTU_SUPPORT}    SKIP    USB003.001 not supported
+    Skip If    not ${UPLOAD_ON_USB_SUPPORT}    USB003.001 not supported
+    Skip If    not ${HAS_USB_STORAGE}    USB003.001 not supported
+    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    USB003.001 not supported
     Power On
     Boot System Or From Connected Disk    ubuntu
     Login To Linux
@@ -119,8 +121,9 @@ USB003.001 Upload 1GB file on USB storage (Ubuntu)
 USB003.002 Upload 1GB file on USB storage (Windows)
     [Documentation]    Check whether the 1GB file can be transferred from the
     ...    operating system to the USB storage.
-    IF    not ${UPLOAD_ON_USB_SUPPORT}    SKIP    USB003.002 not supported
-    IF    not ${TESTS_IN_WINDOWS_SUPPORT}    SKIP    USB003.002 not supported
+    Skip If    not ${UPLOAD_ON_USB_SUPPORT}    USB003.002 not supported
+    Skip If    not ${HAS_USB_STORAGE}    USB003.002 not supported
+    Skip If    not ${TESTS_IN_WINDOWS_SUPPORT}    USB003.002 not supported
     Power On
     Login To Windows
     Generate 1GB File In Windows
@@ -143,3 +146,16 @@ Prepare USB HID Test Suite
     ELSE
         Set Suite Variable    $HAS_KEYBOARD    ${FALSE}
     END
+    ${conf}=    Get Current CONFIG    ${CONFIG_LIST}
+    ${has_storage}=    Evaluate    "USB_Storage" in """${conf}"""
+    IF    "${DUT_CONNECTION_METHOD}" == "pikvm"
+        Upload And Mount DTS Flash Iso
+        ${has_storage}=    Set Variable    ${TRUE}
+    END
+    IF    "${ATTACHED_USB}" != "${EMPTY}" or ${has_storage}
+        Set Suite Variable    $HAS_USB_STORAGE    ${TRUE}
+    ELSE
+        Set Suite Variable    $HAS_USB_STORAGE    ${FALSE}
+    END
+    Skip If    not ${HAS_KEYBOARD} and not ${HAS_USB_STORAGE}
+    ...    Platform doesn't have USB keyboard or USB storage attached

--- a/dasharo-compatibility/usb-hid-and-msc-support.robot
+++ b/dasharo-compatibility/usb-hid-and-msc-support.robot
@@ -129,11 +129,13 @@ USB003.002 Upload 1GB file on USB storage (Windows)
     Generate 1GB File In Windows
     # Work only with one attached USB storage
     ${drive_letter}=    Get Drive Letter Of USB
-    Execute Command In Terminal    Copy-Item -Path C:\\Users\\user\\test_file.txt ${drive_letter}:
+    Execute Command In Terminal
+    ...    Copy-Item -Path C:\\Users\\user\\test_file.txt ${drive_letter}:    120
     ${hash1}=    Get Hash Of File    test_file.txt
     ${hash2}=    Get Hash Of File    ${drive_letter}:\\test_file.txt
     Execute Command In Terminal    Remove-Item -Path C:\\Users\\user\\test_file.txt
-    Execute Command In Terminal    Remove-Item -Path ${drive_letter}:\\test_file.txt
+    Execute Command In Terminal
+    ...    Remove-Item -Path ${drive_letter}:\\test_file.txt    120
     Should Be Equal    ${hash1}    ${hash2}
 
 

--- a/dasharo-compatibility/usb-hid-and-msc-support.robot
+++ b/dasharo-compatibility/usb-hid-and-msc-support.robot
@@ -32,7 +32,7 @@ USB001.001 USB devices detected in FW
     Depends On    ${HAS_USB_STORAGE}
     Power On
     ${boot_menu}=    Enter Boot Menu Tianocore And Return Construction
-    Check USB Stick Detection in Edk2    ${boot_menu}
+    Check USB Stick Detection In Edk2    ${boot_menu}
 
 USB001.002 USB devices detected by OS (Ubuntu)
     [Documentation]    Check whether the external USB devices are detected
@@ -77,7 +77,7 @@ USB002.002 USB keyboard in OS (Ubuntu)
     [Documentation]    Check whether the external USB keyboard is detected
     ...    correctly by the Linux OS.
     Depends On    ${USB_KEYBOARD_DETECTION_SUPPORT}
-    Depends On    "${DEVICE_USB_KEYBOARD}" == "${EMPTY}"
+    Depends On    "${DEVICE_USB_KEYBOARD}" != "${EMPTY}"
     Depends On    ${TESTS_IN_UBUNTU_SUPPORT}
     Power On
     Boot System Or From Connected Disk    ubuntu

--- a/dasharo-compatibility/usb-hid-and-msc-support.robot
+++ b/dasharo-compatibility/usb-hid-and-msc-support.robot
@@ -18,7 +18,7 @@ Resource            ../keys.robot
 # Required teardown keywords:
 # Log Out And Close Connection - elementary teardown keyword for all tests.
 Suite Setup         Run Keyword
-...                     Prepare Test Suite
+...                     Prepare USB HID Test Suite
 Suite Teardown      Run Keyword
 ...                     Log Out And Close Connection
 
@@ -45,7 +45,7 @@ USB001.002 USB devices detected by OS (Ubuntu)
     Switch To Root User
     Detect Or Install Package    usbutils
     ${out}=    Execute Command In Terminal    lsusb -v | grep bInterfaceClass
-    Should Contain    ${out}    Human Interface Device
+    IF    ${HAS_KEYBOARD}    Should Contain    ${out}    Human Interface Device
     Should Contain    ${out}    Mass Storage
     Exit From Root User
 
@@ -56,8 +56,9 @@ USB001.003 USB devices detected by OS (Windows)
     Skip If    not ${TESTS_IN_WINDOWS_SUPPORT}    USB001.003 not supported
     Power On
     Login To Windows
-    ${out}=    Execute Command In Terminal    Get-PnpDevice -PresentOnly | Where-Object { $_.InstanceId -match '^USB' }
-    Should Contain    ${out}    HIDClass
+    ${out}=    Execute Command In Terminal
+    ...    Get-PnpDevice -PresentOnly | Where-Object { $_.InstanceId -match '^USB' }
+    IF    ${HAS_KEYBOARD}    Should Contain    ${out}    HIDClass
     Should Contain    ${out}    DiskDrive
 
 USB002.001 USB keyboard detected in FW
@@ -65,7 +66,8 @@ USB002.001 USB keyboard detected in FW
     ...    correctly by the firmware and all basic keys work
     ...    according to their labels.
     [Tags]    minimal-regression
-    Skip If    not ${TESTS_IN_FIRMWARE_SUPPORT}    USB002.001 not supported
+    Skip If    not ${TESTS_IN_FIRMWARE_SUPPORT}
+    Skip If    not ${HAS_KEYBOARD}    USB002.001 not supported
     Power On
     Enter UEFI Shell
     ${out}=    Execute UEFI Shell Command    devices
@@ -73,12 +75,10 @@ USB002.001 USB keyboard detected in FW
 
 USB002.002 USB keyboard in OS (Ubuntu)
     [Documentation]    Check whether the external USB keyboard is detected
-    ...    correctly by the Linux OS and all basic keys work
-    ...    according to their labels.
-    IF    not ${USB_KEYBOARD_DETECTION_SUPPORT}
-        SKIP    USB002.002 not supported
-    END
-    IF    not ${TESTS_IN_UBUNTU_SUPPORT}    SKIP    USB002.002 not supported
+    ...    correctly by the Linux OS.
+    Skip If    not ${USB_KEYBOARD_DETECTION_SUPPORT}    USB002.002 not supported
+    Skip If    "${DEVICE_USB_KEYBOARD}" == "${EMPTY}"    USB002.002 not supported
+    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    USB002.002 not supported
     Power On
     Boot System Or From Connected Disk    ubuntu
     Login To Linux
@@ -89,10 +89,9 @@ USB002.002 USB keyboard in OS (Ubuntu)
 USB002.003 USB keyboard in OS (Windows)
     [Documentation]    Check whether the external USB keyboard is detected
     ...    correctly by the Windows OS.
-    IF    not ${USB_KEYBOARD_DETECTION_SUPPORT}
-        SKIP    USB002.003 not supported
-    END
-    IF    not ${TESTS_IN_WINDOWS_SUPPORT}    SKIP    USB002.003 not supported
+    Skip If    not ${USB_KEYBOARD_DETECTION_SUPPORT}    USB002.003 not supported
+    Skip If    not ${HAS_KEYBOARD}    USB002.003 not supported
+    Skip If    not ${TESTS_IN_WINDOWS_SUPPORT}    USB002.003 not supported
     Power On
     Login To Windows
     ${out}=    Execute Command In Terminal    Get-CimInstance win32_KEYBOARD
@@ -131,3 +130,14 @@ USB003.002 Upload 1GB file on USB storage (Windows)
     Execute Command In Terminal    Remove-Item -Path C:\\Users\\user\\test_file.txt
     Execute Command In Terminal    Remove-Item -Path ${drive_letter}:\\test_file.txt
     Should Be Equal    ${hash1}    ${hash2}
+
+
+*** Keywords ***
+Prepare USB HID Test Suite
+    [Documentation]    Prepare this test suite
+    Prepare Test Suite
+    IF    "${DEVICE_USB_KEYBOARD}" != "${EMPTY}" or "${DUT_CONNECTION_METHOD}" == "pikvm"
+        Set Suite Variable    $HAS_KEYBOARD    ${TRUE}
+    ELSE
+        Set Suite Variable    $HAS_KEYBOARD    ${FALSE}
+    END

--- a/dasharo-compatibility/usb-hid-and-msc-support.robot
+++ b/dasharo-compatibility/usb-hid-and-msc-support.robot
@@ -77,7 +77,7 @@ USB002.002 USB keyboard in OS (Ubuntu)
     [Documentation]    Check whether the external USB keyboard is detected
     ...    correctly by the Linux OS.
     Depends On    ${USB_KEYBOARD_DETECTION_SUPPORT}
-    Depends On    "${DEVICE_USB_KEYBOARD}" != "${EMPTY}"
+    Depends On    ${HAS_KEYBOARD}
     Depends On    ${TESTS_IN_UBUNTU_SUPPORT}
     Power On
     Boot System Or From Connected Disk    ubuntu
@@ -146,15 +146,14 @@ Prepare USB HID Test Suite
         Set Suite Variable    $HAS_KEYBOARD    ${FALSE}
     END
     ${conf}=    Get Current CONFIG    ${CONFIG_LIST}
-    ${has_storage}=    Evaluate    "USB_Storage" in """${conf}"""
+
     IF    "${DUT_CONNECTION_METHOD}" == "pikvm"
         Upload And Mount DTS Flash Iso
-        ${has_storage}=    Set Variable    ${TRUE}
     END
-    IF    "${ATTACHED_USB}" != "${EMPTY}" or ${has_storage}
-        Set Suite Variable    $HAS_USB_STORAGE    ${TRUE}
-    ELSE
-        Set Suite Variable    $HAS_USB_STORAGE    ${FALSE}
-    END
+
+    # Assume for now that we always have USB storage attached. In fact, all of
+    # the platforms as of today should have the USB drive with DTS attached.
+    # Refer to the lib/usb-hid-msc-lib.robot
+    Set Suite Variable    $HAS_USB_STORAGE    ${TRUE}
     Skip If    not ${HAS_KEYBOARD} and not ${HAS_USB_STORAGE}
     ...    Platform doesn't have USB keyboard or USB storage attached

--- a/dasharo-security/usb-stack.robot
+++ b/dasharo-security/usb-stack.robot
@@ -35,7 +35,7 @@ USS001.001 Enable USB stack (firmware)
     Set UEFI Option    UsbDriverStack    ${TRUE}
     Set UEFI Option    UsbMassStorage    ${TRUE}
     ${boot_menu}=    Enter Boot Menu Tianocore And Return Construction
-    Check That USB Devices Are Detected    ${boot_menu}
+    Check USB Stick Detection In Edk2    ${boot_menu}
 
 USS002.001 Disable USB stack (firmware)
     [Documentation]    Check whether If the stack is deactivated, there will be
@@ -47,7 +47,6 @@ USS002.001 Disable USB stack (firmware)
     Set UEFI Option    UsbMassStorage    ${FALSE}
     Set UEFI Option    UsbDriverStack    ${FALSE}
     ${boot_menu}=    Enter Boot Menu Tianocore And Return Construction
-    # Check That USB Devices Are Not Detected    ${boot_menu}
 
 USS003.001 Enable USB Mass Storage (firmware)
     [Documentation]    Check whether If the storage support is activated, there
@@ -71,7 +70,7 @@ USS003.001 Enable USB Mass Storage (firmware)
     Set Option State    ${usb_menu}    Enable USB Mass Storage    ${TRUE}
     Save Changes And Reset
     ${boot_menu}=    Enter Boot Menu Tianocore And Return Construction
-    Check That USB Devices Are Detected    ${boot_menu}
+    Check USB Stick Detection In Edk2    ${boot_menu}
 
 USS004.001 Disable USB Mass Storage (firmware)
     [Documentation]    Check whether If the storage support is deactivated,
@@ -96,4 +95,3 @@ USS004.001 Disable USB Mass Storage (firmware)
     Set Option State    ${usb_menu}    Enable USB Mass Storage    ${FALSE}
     Save Changes And Reset
     ${boot_menu}=    Enter Boot Menu Tianocore And Return Construction
-    # Check That USB Devices Are Not Detected    ${boot_menu}

--- a/keywords.robot
+++ b/keywords.robot
@@ -1340,7 +1340,8 @@ Coldboot Via RTE Relay
 Reboot Via OS Boot By Petitboot
     [Documentation]    Reboot system with system installed on the DUT while
     ...    already logged into Petitboot.
-    Boot From USB
+    ${usb_option}=    Get USB Boot Option
+    Boot System Or From Connected Disk    ${usb_option}
     Login To Linux
     Execute Linux Command    reboot
     Sleep    60s

--- a/keywords.robot
+++ b/keywords.robot
@@ -850,9 +850,10 @@ Execute Reboot Command
     ELSE
         Fail    Unknown OS: ${os} given as an argument.
     END
-    IF    '${DUT_CONNECTION_METHOD}' == 'SSH'    Sleep    30s
-    Set DUT Response Timeout    180 seconds
+    # We do not want to sleep if we switched to SSH only temporarily.
     Restore Initial DUT Connection Method
+    Set DUT Response Timeout    180 seconds
+    IF    '${DUT_CONNECTION_METHOD}' == 'SSH'    Sleep    30s
 
 Check Displays Windows
     [Documentation]    Check and return all displays with PowerShell in Windows.

--- a/keywords.robot
+++ b/keywords.robot
@@ -1463,22 +1463,34 @@ Remove Entry From List
 
 Generate 1GB File In Windows
     [Documentation]    Generates 1G file in Windows in .txt format.
+    Execute Command In Terminal
+    ...    if (Test-Path test_file.txt) { Remove-Item test_file.txt }
     ${out}=    Execute Command In Terminal    fsutil file createnew test_file.txt 1073741824
     Should Contain    ${out}    is created
 
 Get Drive Letter Of USB
-    [Documentation]    Gets drive letter of attached USB, work with only one USB
-    ...    attached.
-    ${drive_letter}=    Execute Command In Terminal
-    ...    (Get-Volume | where drivetype -eq removable | where filesystemtype -eq FAT32).driveletter
-    ${drive_letter}=    Fetch From Left    ${drive_letter}    \r
+    [Documentation]    Gets drive letter of attached USB, returns first letter
+    ...    on list.
+    ${drive_letter_cmd}=    Set Variable
+    ...    (Get-Volume | where DriveType -eq removable | where FileSystemType -eq FAT32).DriveLetter
+    ${drive_count}=    Execute Command In Terminal    ${drive_letter_cmd}.Count
+    ${drive_count}=    Fetch From Right    ${drive_count}    \n
+    IF    ${drive_count} > 0
+        ${drive_letter}=    Execute Command In Terminal
+        ...    ${drive_letter_cmd}\[0\]
+    ELSE
+        Fail    Couldn't find any USB drive letter
+    END
+    ${drive_letter}=    Fetch From Right    ${drive_letter}    \n
     RETURN    ${drive_letter}
 
 Get Hash Of File
     [Documentation]    Gets line with hash of file.
     [Arguments]    ${path_file}
     ${out}=    Execute Command In Terminal    Get-FileHash -Path ${path_file} | Format-List
-    ${hash}=    Get Lines Containing String    ${out}    Hash
+    ${start_index}=    Call Method    ${out}    rindex    Hash
+    ${hash}=    Get Substring    ${out}    ${start_index}
+    ${hash}=    Fetch From Left    ${hash}    \r
     RETURN    ${hash}
 
 Identify Path To USB
@@ -1494,9 +1506,10 @@ Identify Path To USB
         Set Local Variable    ${usb_disk}    ${disk}
         IF    '${model_name}' == '${USB_MODEL}'    BREAK
     END
-    ${out}=    Execute Linux Command    lsblk | grep ${usb_disk} | grep part | cat
+    ${out}=    Execute Linux Command
+    ...    lsblk --list --noheadings --output NAME,TYPE,PATH | grep ${usb_disk} | grep part
     ${split}=    Split String    ${out}
-    ${path_to_usb}=    Get From List    ${split}    7
+    ${path_to_usb}=    Get From List    ${split}    2
     RETURN    ${path_to_usb}
 
 Get Intel ME Mode State

--- a/keywords.robot
+++ b/keywords.robot
@@ -433,57 +433,6 @@ Get Current CONFIG Item Param
     ${device}=    Get Current CONFIG Item    ${item}
     RETURN    ${device.${param}}
 
-Get Slot Count
-    [Documentation]    Returns count parameter value from slot key specified in
-    ...    the argument if found, otherwise return 0.
-    [Arguments]    ${slot}
-    ${is_found}=    Evaluate    "count" in """${slot}"""
-    ${return}=    Set Variable If
-    ...    ${is_found}==False    0
-    ...    ${is_found}==True    ${slot.count}
-    RETURN    ${return}
-
-Get USB Slot Count
-    [Documentation]    Returns count parameter value from USB slot key specified
-    ...    in the argument if found, otherwise return 0.
-    [Arguments]    ${slots}
-    ${is_found1}=    Evaluate    "USB_Storage" in """${slots.slot1}"""
-    ${is_found2}=    Evaluate    "USB_Storage" in """${slots.slot2}"""
-    IF    ${is_found1}==True
-        ${count1}=    Get Slot Count    ${slots.slot1}
-    ELSE
-        ${count1}=    Evaluate    0
-    END
-    IF    ${is_found2}==True
-        ${count2}=    Get Slot Count    ${slots.slot2}
-    ELSE
-        ${count2}=    Evaluate    0
-    END
-    ${sum}=    Evaluate    ${count1}+${count2}
-    RETURN    ${sum}
-
-Get All USB
-    [Documentation]    Returns number of attached USB storages in current CONFIG.
-    ${conf}=    Get Current CONFIG    ${CONFIG_LIST}
-    ${is_found}=    Evaluate    "USB_Storage" in """${conf}"""
-    IF    ${is_found}==True
-        ${usb_count}=    Get Current CONFIG Item Param    USB_Storage    count
-        ${count_usb}=    Evaluate    ${usb_count}
-    ELSE
-        ${usb_count}=    Evaluate    ""
-        ${count_usb}=    Evaluate    0
-    END
-    ${is_found}=    Evaluate    "USB_Expander" in """${conf}"""
-    IF    ${is_found}==True
-        ${external}=    Get Current CONFIG Item    USB_Expander
-        ${external_count}=    Get USB Slot Count    ${external}
-    ELSE
-        ${external}=    Evaluate    ""
-        ${external_count}=    Evaluate    0
-    END
-    ${count}=    Evaluate    ${count_usb}+${external_count}
-    RETURN    ${count}
-
 Prepare Lm-sensors
     [Documentation]    Install lm-sensors and probe sensors.
     Detect Or Install Package    lm-sensors
@@ -1513,13 +1462,6 @@ Identify Path To USB
     ${path_to_usb}=    Get From List    ${split}    2
     RETURN    ${path_to_usb}
 
-Get Intel ME Mode State
-    [Documentation]    Returns the current state of Intel ME mode.
-    [Arguments]    ${menu_me}
-    ${menu_me}=    Fetch From Right    ${menu_me}    <
-    ${actual_state}=    Fetch From Left    ${menu_me}    >
-    RETURN    ${actual_state}
-
 Calculate Smoothing
     [Documentation]    Compares the actual and expected value of the fan speed,
     ...    taking smoothing into account.
@@ -1564,100 +1506,6 @@ Get RPM Value From System76 Acpi
     ${rpm}=    Get From List    ${speed_split}    2
     RETURN    ${rpm}
 
-Disable Option In Submenu
-    [Documentation]    Disables selected option in submenu provided in ${menu_construction}
-    [Arguments]    ${menu_construction}    ${option_str}
-    ${option}=    Set Variable    ${option_str[1:]}
-    ${line}=    Get Matches    ${menu_construction}    *${option}*
-    TRY
-        Should Match Regexp    ${line[0]}    .*\\[\ \\].*
-        Refresh Serial Screen In BIOS Editable Settings Menu
-    EXCEPT
-        FOR    ${element}    IN    @{menu_construction}
-            ${matches}=    Run Keyword And Return Status
-            ...    Should Match    ${element}    pattern=*${option}*
-            IF    ${matches}
-                ${option}=    Set Variable    ${element}
-                BREAK
-            END
-        END
-        Strip String    ${option}    mode=left
-        ${system_index}=    Get Index From List    ${menu_construction}    ${option}
-        Press Key N Times And Enter    ${system_index}    ${ARROW_DOWN}
-        Press Key N Times    1    ${F10}
-        Write Bare Into Terminal    y
-    END
-
-Enable Option In USB Configuration Submenu
-    [Documentation]    Enables option in USB Configuration SubMenu.
-    [Arguments]    ${menu_construction}    ${option}
-    ${line}=    Get Matches    ${menu_construction}    *${option}*
-    TRY
-        Should Contain Match    ${line}    *[X]*
-    EXCEPT
-        FOR    ${element}    IN    @{menu_construction}
-            ${matches}=    Run Keyword And Return Status
-            ...    Should Match    ${element}    pattern=*${option}*
-            IF    ${matches}
-                ${option}=    Set Variable    ${element}
-                BREAK
-            END
-        END
-        Strip String    ${option}    mode=left
-        ${system_index}=    Get Index From List    ${menu_construction}    ${option}
-        ${steps}=    Evaluate    ${system_index}-1
-        Press Key N Times And Enter    ${steps}    ${ARROW_DOWN}
-        Write Bare Into Terminal    ${F10}
-        Write Bare Into Terminal    Y
-    END
-
-Disable Option In USB Configuration Submenu
-    [Documentation]    Disables option in USB Configuration SubMenu.
-    [Arguments]    ${menu_construction}    ${option}
-    ${line}=    Get Matches    ${menu_construction}    *${option}*
-    TRY
-        Should Not Contain Match    ${line}    *[X]*
-    EXCEPT
-        FOR    ${element}    IN    @{menu_construction}
-            ${matches}=    Run Keyword And Return Status
-            ...    Should Match    ${element}    pattern=*${option}*
-            IF    ${matches}
-                ${option}=    Set Variable    ${element}
-                BREAK
-            END
-        END
-        ${system_index}=    Get Index From List    ${menu_construction}    ${option}
-        ${steps}=    Evaluate    ${system_index}-1
-        Press Key N Times And Enter    ${steps}    ${ARROW_DOWN}
-        Write Bare Into Terminal    ${F10}
-        Write Bare Into Terminal    Y
-    END
-
-Enable Option In Submenu
-    [Documentation]    Enables option in submenu
-    [Arguments]    ${menu_construction}    ${option_str}
-    ${option}=    Set Variable    ${option_str[1:]}
-    ${line}=    Get Matches    ${menu_construction}    *${option}*
-    TRY
-        Should Not Match Regexp    ${line[0]}    .*\\[ \\].*
-        Refresh Serial Screen In BIOS Editable Settings Menu
-    EXCEPT
-        FOR    ${element}    IN    @{menu_construction}
-            ${matches}=    Run Keyword And Return Status
-            ...    Should Match    ${element}    pattern=*${option}*
-            IF    ${matches}
-                ${option}=    Set Variable    ${element}
-                BREAK
-            END
-        END
-        Strip String    ${option}    mode=left
-        ${system_index}=    Get Index From List    ${menu_construction}    ${option}
-        ${steps}=    Evaluate    ${system_index}-1
-        Press Key N Times And Enter    ${steps}    ${ARROW_DOWN}
-        Write Bare Into Terminal    ${F10}
-        Write Bare Into Terminal    Y
-    END
-
 Get Current CONFIG List Param
     [Documentation]    Returns current CONFIG list parameters specified in the
     ...    arguments.
@@ -1672,14 +1520,6 @@ Get Current CONFIG List Param
         END
     END
     RETURN    @{attached_usb_list}
-
-Switch To Root User In Ubuntu Server
-    [Documentation]    Switch to the root environment in Ubuntu Server.
-    Write Into Terminal    sudo su
-    Read From Terminal Until    [sudo] password for user:
-    Write Into Terminal    ubuntuserver
-    Set Prompt For Terminal    \#
-    Read From Terminal Until Prompt
 
 Reboot In OPNsense
     [Documentation]    Perform reboot in OPNsense.

--- a/keywords.robot
+++ b/keywords.robot
@@ -1673,17 +1673,6 @@ Get Current CONFIG List Param
     END
     RETURN    @{attached_usb_list}
 
-Check That USB Devices Are Detected
-    [Documentation]    Checks if the bootable USB devices are visible in the
-    ...    boot menu.
-    [Arguments]    ${boot_menu}
-
-    @{attached_usb_list}=    Get Current CONFIG List Param    USB_Storage    name
-    FOR    ${stick}    IN    @{attached_usb_list}
-        # ${stick} should match with one element of ${boot_menu}
-        Should Contain Match    ${boot_menu}    *${stick}*
-    END
-
 Switch To Root User In Ubuntu Server
     [Documentation]    Switch to the root environment in Ubuntu Server.
     Write Into Terminal    sudo su

--- a/lib/bios/menus.robot
+++ b/lib/bios/menus.robot
@@ -584,7 +584,7 @@ Save Changes And Reset
 Boot System Or From Connected Disk    # robocop: disable=too-long-keyword
     [Documentation]    Tries to boot ${system_name}. If it is not possible then it tries
     ...    to boot from connected disk set up in config
-    [Arguments]    ${system_name}
+    [Arguments]    ${system_name}    ${boot_menu}=NOT_SET
     IF    '${DUT_CONNECTION_METHOD}' == 'SSH'    RETURN
 
     IF    '''${SEABIOS_BOOT_DEVICE}''' != ''
@@ -594,8 +594,17 @@ Boot System Or From Connected Disk    # robocop: disable=too-long-keyword
         Write Bare Into Terminal    ${SEABIOS_BOOT_DEVICE}
         RETURN
     END
-    ${menu_construction}=    Enter Boot Menu Tianocore And Return Construction
-    # With ESP scanning feature boot entries are named differently:
+
+    # Allow providing boot menu construction, if we are already in boot menu screen
+    # and want to boot into OS from there
+    IF    '''${boot_menu}''' == 'NOT_SET'
+        ${menu_construction}=    Enter Boot Menu Tianocore And Return Construction
+    ELSE
+        ${menu_construction}=    Set Variable    @{boot_menu}
+    END
+
+    # When ESP scanning feature is there, boot entries are named differently than
+    # they used to
     IF    ${ESP_SCANNING_SUPPORT} == ${TRUE}
         IF    "${system_name}" == "ubuntu"
             ${system_name}=    Set Variable    Ubuntu

--- a/lib/bios/menus.robot
+++ b/lib/bios/menus.robot
@@ -648,3 +648,14 @@ Get Firmware Version From Tianocore Setup Menu
     ${firmware_line}=    Get Lines Containing String    ${output}    Dasharo (coreboot+UEFI)
     ${firmware_version}=    Get Regexp Matches    ${firmware_line}    v\\d{1,}\.\\d{1,}\.\\d{1,}
     RETURN    ${firmware_version}
+
+Get USB Boot Option
+    [Documentation]    Returns the full name of the first boot option
+    ...    containing "USB"
+    ${menu_construction}=    Enter Boot Menu Tianocore And Return Construction
+    FOR    ${option}    IN    @{menu_construction}
+        ${match}=    Run Keyword And Return Status    Should Match Regexp
+        ...    ${option}    .*[Uu][Ss][Bb].*
+        IF    ${match}    RETURN    ${option}
+    END
+    FAIL    "No USB boot option found"

--- a/lib/dts-lib.robot
+++ b/lib/dts-lib.robot
@@ -49,15 +49,10 @@ Boot Dasharo Tools Suite
     ...    boot method (from USB or from iPXE) as parameter.
     [Arguments]    ${dts_booting_method}
     IF    '${dts_booting_method}'=='USB'
+        # Assuming ESP scanning works as supposed to, DTS on USB stick
+        # should generate such entry
         ${boot_menu}=    Enter Boot Menu Tianocore And Return Construction
-        IF    '${DUT_CONNECTION_METHOD}' == 'pikvm'
-            Enter Submenu From Snapshot    ${boot_menu}    PiKVM Composite KVM Device
-        ELSE IF    '${MANUFACTURER}' == 'QEMU'
-            Enter Submenu From Snapshot    ${boot_menu}    Dasharo Tools Suite (on QEMU HARDDISK)
-        ELSE
-            # Requires specifying the USB model in the platform's config
-            Enter Submenu From Snapshot    ${boot_menu}    ${USB_MODEL}
-        END
+        Enter Submenu From Snapshot    ${boot_menu}    Dasharo Tools Suite
     ELSE IF    '${dts_booting_method}'=='iPXE'
         IF    ${BOOT_DTS_FROM_IPXE_SHELL} == ${TRUE} or ${NETBOOT_UTILITIES_SUPPORT} == ${TRUE}
             # DTS_IPXE_LINK can be defined before running tests, e.g. via CMD or
@@ -67,7 +62,7 @@ Boot Dasharo Tools Suite
             Boot Dasharo Tools Suite Via IPXE Menu
         END
     ELSE
-        FAIL    Unknown or improper connection method: ${dts_booting_method}
+        FAIL    Unknown DTS boot method: ${dts_booting_method}
     END
 
     # For PiKVM devices, we have only input on serial, not output. The video and serial consoles are
@@ -81,7 +76,6 @@ Boot Dasharo Tools Suite
         Set Timeout    ${old_timeout}
         # Enable SSH server and switch to SSH connection by writing on video console "in blind"
         Write Into Terminal    K
-        ${dut_connection_method}=    Set Variable    SSH
         Set Global Variable    ${DUT_CONNECTION_METHOD}    SSH
         Login To Linux Via SSH Without Password    root    root@DasharoToolsSuite:~#
         # Spawn DTS menu on SSH console
@@ -107,7 +101,7 @@ Enter Shell In DTS
     [Documentation]    Keyword allows to drop to Shell in the Dasharo Tools
     ...    Suite.
     Write Into Terminal    S
-    Set Prompt For Terminal    bash-5.1#
+    Set Prompt For Terminal    bash-5.2#
     # These could be removed once routes priorities in DTS are resolved.
     Sleep    10
     Press Enter

--- a/lib/usb-hid-msc-lib.robot
+++ b/lib/usb-hid-msc-lib.robot
@@ -2,6 +2,22 @@
 Library     OperatingSystem
 
 
+*** Variables ***
+# A list of USB boot device entries that may appear in the Dasharo edk2 boot
+# menu. This way we do not care that much which particular stick is connected
+# to the DUT. This is not perfect, as we might lose some information there,
+# but it's been really problematic so far to track the USB devices in platform
+# configs. What is more, we may have one platform config and multiple instances
+# of the same physical devices setup in the lab, with slightly different USB
+# sticks.
+#
+# We may also decide that we always put DTS stick, and test booting with that.
+# Thanks to ESP scanning, we always generate similar entry like:
+# "Dasharo Tools Suite (on USB XXXX)"
+
+@{USB_DEVICES_IN_EDK2}=     Dasharo Tools Suite
+
+
 *** Keywords ***
 Upload And Mount DTS Flash ISO
     [Documentation]    Mounts a bootable ISO as flash USB. Currently
@@ -33,3 +49,22 @@ Download ISO And Mount As USB
             Skip    unsupported
         END
     END
+
+Check USB Stick Detection In Edk2
+    [Documentation]    Checks if the bootable USB devices are visible in the
+    ...    boot menu.
+    [Arguments]    ${boot_menu}
+    Set Local Variable    ${found}    ${FALSE}
+
+    FOR    ${stick}    IN    @{USB_DEVICES_IN_EDK2}
+        ${found}=    Run Keyword And Return Status    Should Contain Match    ${boot_menu}    *${stick}*
+        IF    '${found}' == '${TRUE}'    BREAK
+    END
+
+    IF    '${found}' == '${FALSE}'
+        Log To Console
+        ...    None of the known USB sticks have been found in the boot menu. If a stick is connected, you might need to update USB_DEVICES_IN_EDK2 variable.
+        Log    ${boot_menu}
+    END
+
+    RETURN    ${found}

--- a/platform-configs/include/default.robot
+++ b/platform-configs/include/default.robot
@@ -69,6 +69,7 @@ ${DEVICE_AUDIO1_WIN}=                               ${TBD}
 ${WIFI_CARD_UBUNTU}=                                ${TBD}
 ${USB_MODEL}=                                       ${TBD}
 ${USB_DEVICE}=                                      ${TBD}
+@{ATTACHED_USB}=                                    ${TBD}
 
 ${FLASHROM_FLAGS}=                                  ${TBD}
 

--- a/platform-configs/include/msi-z690-common.robot
+++ b/platform-configs/include/msi-z690-common.robot
@@ -114,6 +114,8 @@ ${USB_TYPE-A_DEVICES_DETECTION_SUPPORT}=        ${TRUE}
 ${NETWORK_INTERFACE_AFTER_SUSPEND_SUPPORT}=     ${TRUE}
 ${CAPSULE_UPDATE_SUPPORT}=                      ${TRUE}
 ${ROMHOLE_SUPPORT}=                             ${TRUE}
+${USB_DETECTION_ITERATIONS_NUMBER}=             5
+${BOOT_FROM_USB_ITERATIONS_NUMBER}=             5
 
 
 *** Keywords ***

--- a/platform-configs/odroid-h4-plus.robot
+++ b/platform-configs/odroid-h4-plus.robot
@@ -81,6 +81,8 @@ ${DASHARO_POWER_MGMT_MENU_SUPPORT}=             ${TRUE}
 ${ESP_SCANNING_SUPPORT}=                        ${TRUE}
 ${SUSPEND_AND_RESUME_SUPPORT}=                  ${TRUE}
 ${AUTO_BOOT_TIME_OUT_DEFAULT_VALUE}=            2
+${USB_DETECTION_ITERATIONS_NUMBER}=             5
+${BOOT_FROM_USB_ITERATIONS_NUMBER}=             5
 
 # Dasharo performance
 ${CPU_FREQUENCY_MEASURE}=                       ${TRUE}

--- a/platform-configs/protectli-vp2410.robot
+++ b/platform-configs/protectli-vp2410.robot
@@ -17,8 +17,6 @@ ${CPU_MIN_FREQUENCY}=                   300
 # eMMC driver support
 ${E_MMC_NAME}=                          8GTF4R
 
-@{ATTACHED_USB}=                        @{EMPTY}
-
 ${DMIDECODE_SERIAL_NUMBER}=             N/A
 ${DMIDECODE_FIRMWARE_VERSION}=          Dasharo (coreboot+UEFI) v
 ${DMIDECODE_PRODUCT_NAME}=              VP2410

--- a/platform-configs/protectli-vp2410.robot
+++ b/platform-configs/protectli-vp2410.robot
@@ -26,6 +26,8 @@ ${DMIDECODE_VENDOR}=                    3mdeb
 ${DMIDECODE_FAMILY}=                    Vault Pro
 ${DMIDECODE_TYPE}=                      Desktop
 
+${DEVICE_AUDIO1}=                       "Gemini Lake HDMI"
+
 ${L3_CACHE_SUPPORT}=                    ${FALSE}
 ${DASHARO_SECURITY_MENU_SUPPORT}=       ${TRUE}
 

--- a/platform-configs/protectli-vp2420.robot
+++ b/platform-configs/protectli-vp2420.robot
@@ -8,6 +8,7 @@ ${FLASHING_METHOD}=                 internal
 
 # eMMC driver support
 ${E_MMC_NAME}=                      8GTF4R
+
 ${DMIDECODE_SERIAL_NUMBER}=         N/A
 ${DMIDECODE_FIRMWARE_VERSION}=      Dasharo (coreboot+UEFI) v1.2.1-rc1
 ${DMIDECODE_PRODUCT_NAME}=          VP2420

--- a/scripts/refactoring-state.sh
+++ b/scripts/refactoring-state.sh
@@ -30,6 +30,16 @@ kwds_to_remove=(
 "RTE REST APU Setup"
 "RTE REST APU Setup"
 "RteCtrl Get GPIO State"
+"Check That USB Devices Are Detected"
+"Switch To Root User In Ubuntu Server"
+"Get Slot Count"
+"Get USB Slot Count"
+"Get All USB"
+"Enable Option In USB Configuration Submenu"
+"Disable Option In USB Configuration Submenu"
+"Enable Option In Submenu"
+"Disable Option In Submenu"
+"Get Intel ME Mode State"
 )
 
 echo "Keywords that should not be used, but are still used:"

--- a/variables.robot
+++ b/variables.robot
@@ -366,53 +366,6 @@ ${OS_UBUNTU}=               ubuntu
 @{MMC_LIST}=                &{EMMC01}
 
 # -----------------------------------------------------------------------------
-&{USB01}=                   vendor=Kingston    volume=16GB    type=USB_Storage
-...                         protocol=3.0    interface=USB    count=2
-...                         sbo_name=USB
-&{USB02}=                   vendor=ADATA    volume=16GB    type=USB_Storage
-...                         protocol=3.0    interface=USB    count=2
-...                         sbo_name=USB
-&{USB03}=                   vendor=SanDisk    volume=16GB    type=USB_Storage
-...                         protocol=3.0    interface=USB    count=2
-...                         sbo_name=USB
-&{USB04}=                   vendor=Corsair    volume=16GB    type=USB_Storage
-...                         protocol=3.0    interface=USB    count=2
-...                         sbo_name=USB
-# pfSense stick installer
-&{USB05}=                   vendor=Kingston    volume=16GB    type=USB_Storage
-...                         protocol=2.0    interface=USB    count=1
-...                         sbo_name=USB
-&{USB06}=                   vendor=SiliconMotion    volume=8GB    type=USB_Storage
-...                         protocol=3.0    interface=USB    count=1
-...                         sbo_name=USB
-&{USB07}=                   vendor=SanDisk    volume=16GB    type=USB_Storage
-...                         protocol=3.0    interface=USB    count=1
-...                         sbo_name=USB
-&{USB08}=                   vendor=Adata    volume=16GB    type=USB_Storage
-...                         protocol=3.1    interface=USB    count=1
-...                         sbo_name=USB
-&{USB09}=                   vendor=Kingston    volume=16GB    type=USB_Storage
-...                         protocol=3.0    interface=USB    count=1
-...                         sbo_name=USB
-&{USB10}=                   vendor=Goodram    volume=16GB    type=USB_Storage
-...                         protocol=2.0    interface=USB    count=1
-...                         sbo_name=USB
-&{USB11}=                   vendor=SanDisk    volume=32GB    type=USB_Storage
-...                         protocol=3.0    interface=USB    count=1
-...                         sbo_name=USB    name=USB SanDisk 3.2Gen1
-&{USB12}=                   vendor=SanDisk    volume=32GB    type=USB_Storage
-...                         protocol=3.0    interface=USB    count=1
-...                         sbo_name=USB    name=SanDisk Ultra USB 3.0
-&{USB13}=                   vendor=Artificial    volume=1GB    type=USB_Storage
-...                         protocol=3.0    interface=USB    count=1
-...                         sbo_name=USB    name=PiKVM Composite KVM Device
-&{USB14}=                   vendor=Kingston    volume=32GB    type=USB_Storage
-...                         protocol=3.0    interface=USB    count=2
-...                         sbo_name=USB    name=USB DISK 3.0
-@{USB_LIST}=                &{USB01}    &{USB02}    &{USB03}    &{USB04}    &{USB05}
-...                         &{USB06}    &{USB07}    &{USB08}    &{USB09}    &{USB10}
-...                         &{USB11}    &{USB12}    &{USB13}    &{USB14}
-# -----------------------------------------------------------------------------
 &{MODULE01}=                vendor=HUAWEI    type=LTE_Module    interface=mPCIe
 ...                         count=1
 &{MODULE02}=                vendor=WLE200NX    type=WiFi_Module    interface=mPCIe
@@ -439,31 +392,25 @@ ${OS_UBUNTU}=               ubuntu
 ...                         &{MODULE06}    &{MODULE07}    &{MODULE08}    &{MODULE09}
 ...                         &{MODULE10}    &{MODULE11}    &{MODULE12}
 # -----------------------------------------------------------------------------
-&{EXPANDER01}=              type=USB_Expander    slots=2    slot1=&{USB05}
-...                         slot2=&{MODULE04}    interface=USB    count=1
-&{EXPANDER02}=              type=USB_Expander    slots=2    slot1=&{USB07}
-...                         slot2=&{EMPTY}    interface=USB    count=1
-@{EXPANDER_LIST}=           &{EXPANDER01}    &{EXPANDER02}
-# -----------------------------------------------------------------------------
 &{ADAPTER01}=               type=UART_USB_Adapter    interface=UART    count=1
 @{ADAPTER_LIST}=            &{ADAPTER01}
 # -----------------------------------------------------------------------------
 
 # hardware configurations:
-@{CONFIG01}=                &{RTE08}    &{MODULE10}    &{SSD04}    &{USB04}
-...                         &{CARD03}    &{ADAPTER01}    &{EXPANDER02}
-@{CONFIG02}=                &{RTE09}    &{SSD19}    &{CARD05}    &{USB03}
+@{CONFIG01}=                &{RTE08}    &{MODULE10}    &{SSD04}
+...                         &{CARD03}    &{ADAPTER01}
+@{CONFIG02}=                &{RTE09}    &{SSD19}    &{CARD05}
 ...                         &{MODULE08}    &{MODULE10}    &{MODULE06}    &{ADAPTER01}
-@{CONFIG03}=                &{RTE10}    &{HDD01}    &{CARD02}    &{USB01}
-...                         &{MODULE01}    &{MODULE02}    &{MODULE04}    &{EXPANDER01}
+@{CONFIG03}=                &{RTE10}    &{HDD01}    &{CARD02}
+...                         &{MODULE01}    &{MODULE02}    &{MODULE04}
 ...                         &{MODULE10}    &{ADAPTER01}
-@{CONFIG04}=                &{RTE11}    &{SSD06}    &{CARD06}    &{USB03}
+@{CONFIG04}=                &{RTE11}    &{SSD06}    &{CARD06}
 ...                         &{MODULE06}    &{ADAPTER01}    &{MODULE10}
-@{CONFIG05}=                &{RTE12}    &{USB03}    &{MODULE07}    &{CARD05}
+@{CONFIG05}=                &{RTE12}    &{MODULE07}    &{CARD05}
 ...                         &{ADAPTER01}    &{MODULE10}
-@{CONFIG06}=                &{RTE13}    &{SSD05}    &{CARD01}    &{USB03}
+@{CONFIG06}=                &{RTE13}    &{SSD05}    &{CARD01}
 ...                         &{MODULE09}    &{MODULE10}    &{MODULE11}    &{ADAPTER01}
-@{CONFIG07}=                &{RTE14}    &{USB06}    &{MODULE10}    &{SSD03}
+@{CONFIG07}=                &{RTE14}    &{MODULE10}    &{SSD03}
 @{CONFIG08}=                &{RTE15}
 @{CONFIG09}=                &{RTE16}
 @{CONFIG10}=                &{RTE17}
@@ -474,42 +421,42 @@ ${OS_UBUNTU}=               ubuntu
 @{CONFIG15}=                &{RTE22}    &{SSD04}    &{MODULE10}    &{MODULE09}
 @{CONFIG16}=                &{RTE23}
 @{CONFIG17}=                &{RTE24}
-@{CONFIG18}=                &{RTE25}    &{USB07}
+@{CONFIG18}=                &{RTE25}
 @{CONFIG19}=                &{RTE26}
 @{CONFIG20}=                &{RTE27}
-@{CONFIG21}=                &{RTE28}    &{USB10}    &{MODULE10}
-@{CONFIG22}=                &{RTE29}    &{USB10}    &{MODULE12}
-@{CONFIG23}=                &{RTE30}    &{MODULE11}    &{CARD04}    &{USB08}
-...                         &{MODULE09}    &{USB09}    &{SSD05}    &{MODULE10}
-@{CONFIG24}=                &{RTE32}    &{USB09}
-@{CONFIG25}=                &{RTE33}    &{USB14}    &{SSD08}
-@{CONFIG26}=                &{RTE34}    &{USB14}    &{SSD08}
-@{CONFIG27}=                &{RTE35}    &{USB07}    &{SSD02}    &{MODULE10}
-@{CONFIG28}=                &{RTE36}    &{USB11}    &{SSD09}
+@{CONFIG21}=                &{RTE28}    &{MODULE10}
+@{CONFIG22}=                &{RTE29}    &{MODULE12}
+@{CONFIG23}=                &{RTE30}    &{MODULE11}    &{CARD04}
+...                         &{MODULE09}    &{SSD05}    &{MODULE10}
+@{CONFIG24}=                &{RTE32}
+@{CONFIG25}=                &{RTE33}    &{SSD08}
+@{CONFIG26}=                &{RTE34}    &{SSD08}
+@{CONFIG27}=                &{RTE35}    &{SSD02}    &{MODULE10}
+@{CONFIG28}=                &{RTE36}    &{SSD09}
 @{CONFIG29}=                &{RTE37}    &{SSD12}
-@{CONFIG30}=                &{RTE38}    &{USB11}
-@{CONFIG31}=                &{RTE39}    &{USB14}    &{SSD08}
-@{CONFIG32}=                &{RTE40}    &{USB12}    &{SSD11}
+@{CONFIG30}=                &{RTE38}
+@{CONFIG31}=                &{RTE39}    &{SSD08}
+@{CONFIG32}=                &{RTE40}    &{SSD11}
 @{CONFIG33}=                &{RTE41}
 @{CONFIG34}=                &{RTE42}    &{SSD13}    &{EMMC02}
 @{CONFIG35}=                &{RTE43}    &{EMMC01}
 @{CONFIG36}=                &{RTE44}    &{EMMC01}
 @{CONFIG37}=                &{RTE45}    &{EMMC01}
-@{CONFIG38}=                &{RTE46}    &{USB13}    &{SSD08}
+@{CONFIG38}=                &{RTE46}    &{SSD08}
 @{CONFIG39}=                &{RTE47}
 @{CONFIG40}=                &{RTE48}
-@{CONFIG42}=                &{RTE50}    &{USB11}    &{SSD08}
-@{CONFIG43}=                &{RTE51}    &{USB11}    &{SSD10}
-@{CONFIG44}=                &{RTE52}    &{USB11}    &{SSD10}
-@{CONFIG45}=                &{RTE53}    &{USB11}    &{SSD15}
-@{CONFIG46}=                &{RTE54}    &{USB11}    &{SSD07}
+@{CONFIG42}=                &{RTE50}    &{SSD08}
+@{CONFIG43}=                &{RTE51}    &{SSD10}
+@{CONFIG44}=                &{RTE52}    &{SSD10}
+@{CONFIG45}=                &{RTE53}    &{SSD15}
+@{CONFIG46}=                &{RTE54}    &{SSD07}
 @{CONFIG47}=                &{RTE63}    &{EMMC01}
 @{CONFIG48}=                &{RTE64}    &{SSD17}
 @{CONFIG49}=                &{RTE65}    &{SSD17}
 @{CONFIG50}=                &{RTE66}    &{SSD18}    # Borrowed from NV41PZ
-@{CONFIG51}=                &{RTE67}    &{USB11}
-@{CONFIG52}=                &{RTE68}    &{USB12}    &{SSD18}
-@{CONFIG53}=                &{RTE69}    &{USB11}
+@{CONFIG51}=                &{RTE67}
+@{CONFIG52}=                &{RTE68}    &{SSD18}
+@{CONFIG53}=                &{RTE69}
 
 @{CONFIG_LIST}=             @{CONFIG01}    @{CONFIG02}    @{CONFIG03}    @{CONFIG04}
 ...                         @{CONFIG05}    @{CONFIG06}    @{CONFIG08}    @{CONFIG09}


### PR DESCRIPTION
Integrates (and reworks) changes from:
- https://github.com/Dasharo/open-source-firmware-validation/pull/312
- https://github.com/Dasharo/open-source-firmware-validation/pull/351

Tested `usb-detect.robot` and `usb-boot.robot` in two configurations:
- PiKVM (MSI Z690)
- Telnet (Odroid H4)

These tests now assume that `Dasharo Tools Suite` USB stick is inserted to the DUT.

This is required for the `usb-boot` especially, as we assume to test booting DTS from USB as a refernce OS.

For the `usb-detect`, we may define other types of devices as well. At this moment, `Dasharo Tools Suite` entry is the one we are looking for in the boot menu.