### PR TITLE
pikvm: use package instead of submodule

### DIFF
--- a/dasharo-compatibility/custom-boot-menu-key.robot
+++ b/dasharo-compatibility/custom-boot-menu-key.robot
@@ -11,7 +11,6 @@ Library             RequestsLibrary
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot
-Resource            ../pikvm-rest-api/pikvm_comm.robot
 
 # TODO:
 # - document which setup/teardown keywords to use and what are they doing

--- a/dasharo-compatibility/dcu.robot
+++ b/dasharo-compatibility/dcu.robot
@@ -12,7 +12,6 @@ Library             FakerLibrary
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot
-Resource            ../pikvm-rest-api/pikvm_comm.robot
 Resource            ../lib/dcu.robot
 
 # TODO:

--- a/dasharo-compatibility/device-detection.robot
+++ b/dasharo-compatibility/device-detection.robot
@@ -11,7 +11,6 @@ Library             RequestsLibrary
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot
-Resource            ../pikvm-rest-api/pikvm_comm.robot
 
 # TODO:
 # - document which setup/teardown keywords to use and what are they doing

--- a/dasharo-compatibility/dmidecode.robot
+++ b/dasharo-compatibility/dmidecode.robot
@@ -11,7 +11,6 @@ Library             RequestsLibrary
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot
-Resource            ../pikvm-rest-api/pikvm_comm.robot
 
 # TODO:
 # - document which setup/teardown keywords to use and what are they doing

--- a/dasharo-compatibility/flash-test-stub.robot
+++ b/dasharo-compatibility/flash-test-stub.robot
@@ -11,7 +11,6 @@ Library             RequestsLibrary
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot
-Resource            ../pikvm-rest-api/pikvm_comm.robot
 Resource            ../platform-configs/include/protectli-vp66xx.robot
 
 # TODO:

--- a/dasharo-compatibility/reset-to-defaults.robot
+++ b/dasharo-compatibility/reset-to-defaults.robot
@@ -11,7 +11,6 @@ Library             RequestsLibrary
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot
-Resource            ../pikvm-rest-api/pikvm_comm.robot
 
 # TODO:
 # - document which setup/teardown keywords to use and what are they doing

--- a/dasharo-compatibility/uefi-shell.robot
+++ b/dasharo-compatibility/uefi-shell.robot
@@ -11,7 +11,6 @@ Library             RequestsLibrary
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot
-Resource            ../pikvm-rest-api/pikvm_comm.robot
 
 # TODO:
 # - document which setup/teardown keywords to use and what are they doing

--- a/dasharo-compatibility/usb-boot.robot
+++ b/dasharo-compatibility/usb-boot.robot
@@ -11,7 +11,6 @@ Library             RequestsLibrary
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot
-Resource            ../pikvm-rest-api/pikvm_comm.robot
 
 # TODO:
 # - document which setup/teardown keywords to use and what are they doing

--- a/dasharo-compatibility/usb-detect.robot
+++ b/dasharo-compatibility/usb-detect.robot
@@ -11,7 +11,6 @@ Library             RequestsLibrary
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot
-Resource            ../pikvm-rest-api/pikvm_comm.robot
 
 # TODO:
 # - document which setup/teardown keywords to use and what are they doing

--- a/dasharo-compatibility/usb-hid-and-msc-support.robot
+++ b/dasharo-compatibility/usb-hid-and-msc-support.robot
@@ -8,7 +8,6 @@ Library             SSHLibrary    timeout=90 seconds
 Library             RequestsLibrary
 # TODO: maybe have a single file to include if we need to include the same
 # stuff in all test cases
-Resource            ../pikvm-rest-api/pikvm_comm.robot
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot

--- a/dasharo-security/me-neuter-static.robot
+++ b/dasharo-security/me-neuter-static.robot
@@ -11,7 +11,6 @@ Library             RequestsLibrary
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot
-Resource            ../pikvm-rest-api/pikvm_comm.robot
 
 # TODO:
 # - document which setup/teardown keywords to use and what are they doing

--- a/dasharo-security/me-neuter.robot
+++ b/dasharo-security/me-neuter.robot
@@ -11,7 +11,6 @@ Library             RequestsLibrary
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot
-Resource            ../pikvm-rest-api/pikvm_comm.robot
 
 # TODO:
 # - document which setup/teardown keywords to use and what are they doing

--- a/keywords.robot
+++ b/keywords.robot
@@ -1,7 +1,6 @@
 *** Settings ***
 Library         Collections
 Library         OperatingSystem
-Resource        pikvm-rest-api/pikvm_comm.robot
 Resource        lib/bios/menus.robot
 Resource        lib/secure-boot-lib.robot
 Resource        lib/usb-hid-msc-lib.robot
@@ -509,16 +508,28 @@ Import Osfv Libraries
     IF    '${SNIPEIT}' == 'yes'
         Import Library    osfv.rf.snipeit_robot
         Import Library    osfv.rf.rte_robot.RobotRTE    ${RTE_IP}    True
-    ELSE IF    'sonoff' == '${POWER_CTRL}'
-        Variable Should Exist    ${SONOFF_IP}
-        # The last parameter is the DUT config name. It needs to be provided if
-        # it SnipeIT is not used; otherwise the library would not be able to
-        # determine the platform type.
-        Import Library    osfv.rf.rte_robot.RobotRTE    ${RTE_IP}    False
-        ...    ${SONOFF_IP}    ${CONFIG}
+        IF    'pikvm' == '${INITIAL_DUT_CONNECTION_METHOD}'
+            ${pikvm_ip}=    Snipeit Get PiKVM IP    ${RTE_IP}
+            Import Library    pikvm.client.PiKVMClient    ${pikvm_ip}
+        END
     ELSE
-        Import Library    osfv.rf.rte_robot.RobotRTE    ${RTE_IP}    False
-        ...    config=${CONFIG}
+        IF    'sonoff' == '${POWER_CTRL}'
+            Variable Should Exist    ${SONOFF_IP}
+            # The last parameter is the DUT config name. It needs to be provided if
+            # it SnipeIT is not used; otherwise the library would not be able to
+            # determine the platform type.
+            Import Library    osfv.rf.rte_robot.RobotRTE    ${RTE_IP}    False
+            ...    ${SONOFF_IP}    ${CONFIG}
+        ELSE
+            Import Library    osfv.rf.rte_robot.RobotRTE    ${RTE_IP}    False
+            ...    config=${CONFIG}
+        END
+        IF    'pikvm' == '${INITIAL_DUT_CONNECTION_METHOD}'
+            Variable Should Exist
+            ...    ${pikvm_ip}
+            ...    PiKVM IP cannot be fetched from SnipeIT. Please provide it in the 'PIKVM_IP' variable
+            Import Library    pikvm.client.PiKVMClient    ${pikvm_ip}
+        END
     END
 
 Prepare To SSH Connection
@@ -590,14 +601,6 @@ Prepare To PiKVM Connection
     Remap Keys Variables To PiKVM
     Open Connection And Log In
     ${platform}=    Get Current RTE Param    platform
-    IF    '${SNIPEIT}' == 'yes'
-        ${pikvm_ip}=    Snipeit Get PiKVM IP    ${RTE_IP}
-        Set Global Variable    ${PIKVM_IP}
-    END
-    # If snipeit is set to "no", fetch it from command line
-    Variable Should Exist
-    ...    ${PIKVM_IP}
-    ...    PiKVM IP cannot be fetched from SnipeIT. Please provide it in the 'PIKVM_IP' variable
     Set Global Variable    ${PLATFORM}
     Get DUT To Start State
 

--- a/lib/usb-hid-msc-lib.robot
+++ b/lib/usb-hid-msc-lib.robot
@@ -22,9 +22,11 @@ Library     OperatingSystem
 Upload And Mount DTS Flash ISO
     [Documentation]    Mounts a bootable ISO as flash USB. Currently
     ...    only the Qubes OS ISO seems to work for the platform.
-    Upload Image To PiKVM    ${PIKVM_IP}    dts-base-image-v1.2.8.iso
+
+    Upload Image To PiKVM
     ...    https://dl.3mdeb.com/open-source-firmware/DTS/v1.2.8/dts-base-image-v1.2.8.iso
-    Mount Image On PiKVM    ${PIKVM_IP}    dts-base-image-v1.2.8.iso
+    ...    dts-base-image-v1.2.8.iso
+    Mount Image On PiKVM    dts-base-image-v1.2.8.iso
 
 Download ISO And Mount As USB
     [Documentation]    Mounts the desired ISO as USB stick,
@@ -43,8 +45,8 @@ Download ISO And Mount As USB
         Add USB To Qemu    img_name=${img_path}
     ELSE
         IF    "${DUT_CONNECTION_METHOD}" == "pikvm"
-            Upload Image To PiKVM    ${PIKVM_IP}    ${img_url}    ${img_name}
-            Mount Image On PiKVM    ${PIKVM_IP}    ${img_name}
+            Upload Image To PiKVM    ${img_url}    ${img_name}
+            Mount Image On PiKVM    ${img_name}
         ELSE
             Skip    unsupported
         END

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ osfv @ git+https://github.com/Dasharo/osfv-scripts.git@36a030eb006391c3761c25d69
 paramiko==3.4.0
 pathspec==0.9.0
 pexpect==4.9.0
-pikvm @ git+https://github.com/3mdeb/pikvm-rest-api@7e3a2b0fa5c27e7cf45c8afc9d820826f0e3d99b
+pikvm @ git+https://github.com/3mdeb/pikvm-rest-api@1a1cc579a286fe82aaa2eccea69f96223712664d
 platformdirs==4.2.1
 pre-commit==3.7.0
 ptyprocess==0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+attrs==24.3.0
 bcrypt==4.1.2
 certifi==2024.2.2
 cffi==1.17.1
@@ -31,6 +32,7 @@ osfv @ git+https://github.com/Dasharo/osfv-scripts.git@36a030eb006391c3761c25d69
 paramiko==3.4.0
 pathspec==0.9.0
 pexpect==4.9.0
+pikvm @ git+https://github.com/3mdeb/pikvm-rest-api@7e3a2b0fa5c27e7cf45c8afc9d820826f0e3d99b
 platformdirs==4.2.1
 pre-commit==3.7.0
 ptyprocess==0.7.0

--- a/self-tests/boolean-options.robot
+++ b/self-tests/boolean-options.robot
@@ -14,7 +14,6 @@ Library             RequestsLibrary
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot
-Resource            ../pikvm-rest-api/pikvm_comm.robot
 
 # TODO:
 # - document which setup/teardown keywords to use and what are they doing

--- a/self-tests/dasharo-system-features-menus.robot
+++ b/self-tests/dasharo-system-features-menus.robot
@@ -14,7 +14,6 @@ Library             RequestsLibrary
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot
-Resource            ../pikvm-rest-api/pikvm_comm.robot
 
 # TODO:
 # - document which setup/teardown keywords to use and what are they doing

--- a/self-tests/dcu.robot
+++ b/self-tests/dcu.robot
@@ -12,7 +12,6 @@ Library             FakerLibrary
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot
-Resource            ../pikvm-rest-api/pikvm_comm.robot
 
 # TODO:
 # - document which setup/teardown keywords to use and what are they doing

--- a/self-tests/list-options.robot
+++ b/self-tests/list-options.robot
@@ -14,7 +14,6 @@ Library             RequestsLibrary
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot
-Resource            ../pikvm-rest-api/pikvm_comm.robot
 
 # TODO:
 # - document which setup/teardown keywords to use and what are they doing

--- a/self-tests/make-sure-that-flash-locks-are-disabled.robot
+++ b/self-tests/make-sure-that-flash-locks-are-disabled.robot
@@ -14,7 +14,6 @@ Library             RequestsLibrary
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot
-Resource            ../pikvm-rest-api/pikvm_comm.robot
 
 # TODO:
 # - document which setup/teardown keywords to use and what are they doing

--- a/self-tests/numerical-options.robot
+++ b/self-tests/numerical-options.robot
@@ -14,7 +14,6 @@ Library             RequestsLibrary
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot
-Resource            ../pikvm-rest-api/pikvm_comm.robot
 
 # TODO:
 # - document which setup/teardown keywords to use and what are they doing

--- a/self-tests/os-boot.robot
+++ b/self-tests/os-boot.robot
@@ -15,7 +15,6 @@ Resource            ../sonoff-rest-api/sonoff-api.robot
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot
-Resource            ../pikvm-rest-api/pikvm_comm.robot
 
 # TODO:
 # - document which setup/teardown keywords to use and what are they doing

--- a/self-tests/scrolling-boot-manager.robot
+++ b/self-tests/scrolling-boot-manager.robot
@@ -15,7 +15,6 @@ Library             RequestsLibrary
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot
-Resource            ../pikvm-rest-api/pikvm_comm.robot
 
 # TODO:
 # - document which setup/teardown keywords to use and what are they doing

--- a/self-tests/secure-boot.robot
+++ b/self-tests/secure-boot.robot
@@ -13,7 +13,6 @@ Library             RequestsLibrary
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot
-Resource            ../pikvm-rest-api/pikvm_comm.robot
 
 # TODO:
 # - document which setup/teardown keywords to use and what are they doing

--- a/self-tests/setup-and-boot-menus.robot
+++ b/self-tests/setup-and-boot-menus.robot
@@ -15,7 +15,6 @@ Library             RequestsLibrary
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot
-Resource            ../pikvm-rest-api/pikvm_comm.robot
 
 # TODO:
 # - document which setup/teardown keywords to use and what are they doing

--- a/self-tests/terminal.robot
+++ b/self-tests/terminal.robot
@@ -14,7 +14,6 @@ Library             RequestsLibrary
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot
-Resource            ../pikvm-rest-api/pikvm_comm.robot
 
 # TODO:
 # - document which setup/teardown keywords to use and what are they doing

--- a/util/basic-platform-setup.robot
+++ b/util/basic-platform-setup.robot
@@ -12,7 +12,6 @@ Library             RequestsLibrary
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot
-Resource            ../pikvm-rest-api/pikvm_comm.robot
 Resource            ../keys-and-keywords/ubuntu-keywords.robot
 
 # TODO:

--- a/variables.robot
+++ b/variables.robot
@@ -112,20 +112,16 @@ ${OS_UBUNTU}=               ubuntu
 &{RTE33}=                   ip=192.168.10.107
 ...                         platform=msi-pro-z690-a-wifi-ddr4
 ...                         platform_vendor=MSI Co., Ltd    sonoff_ip=192.168.10.170
-...                         pikvm_ip=192.168.10.99
 &{RTE34}=                   ip=192.168.10.199
 ...                         platform=msi-pro-z690-a-wifi-ddr4
 ...                         platform_vendor=MSI Co., Ltd    sonoff_ip=192.168.10.169
-...                         pikvm_ip=192.168.10.16
 &{RTE39}=                   ip=192.168.10.188
 ...                         platform=msi-pro-z690-a-ddr5
 ...                         platform_vendor=MSI Co., Ltd    sonoff_ip=192.168.10.69
-...                         pikvm_ip=192.168.10.45
 # MSI-PRO-Z790-P platforms (Zir-Blazer) -----------------------------
 &{RTE46}=                   ip=192.168.10.127
 ...                         platform=msi-pro-z790-p-ddr5
 ...                         platform_vendor=MSI Co., Ltd    sonoff_ip=192.168.10.253
-...                         pikvm_ip=192.168.10.226
 # PC Engines APU7 platform -----------------------------------------------------
 &{RTE35}=                   ip=192.168.10.177
 ...                         platform=apu7
@@ -189,7 +185,7 @@ ${OS_UBUNTU}=               ubuntu
 # NovaCustom automated laptop testing station --------------------------------
 &{RTE52}=                   ip=192.168.10.91
 ...                         platform=novacustom-ts1    platform_vendor=3mdeb
-...                         sonoff_ip=192.168.10.53    pikvm_ip=192.168.10.52
+...                         sonoff_ip=192.168.10.53
 # 3mdeb Protectli VP6670 -----------------------------------------------------
 &{RTE53}=                   ip=192.168.10.110
 ...                         platform=protectli-vp6670    platform_vendor=protectli
@@ -236,7 +232,6 @@ ${OS_UBUNTU}=               ubuntu
 # Odroid-H4 Plus
 &{RTE66}=                   ip=192.168.10.193    platform=odroid-h4-Plus
 ...                         platform_vendor=Hardkernel
-...                         pikvm_ip=192.168.10.120
 # Protectli VP3230
 &{RTE67}=                   ip=192.168.10.35
 ...                         platform=protectli-vp3230


### PR DESCRIPTION
To be used with: https://github.com/3mdeb/pikvm-rest-api/pull/19

This is a prerequisite to continue with: https://github.com/Dasharo/open-source-firmware-validation/pull/485

The most basic test works: `dasharo-compatibility/custom-boot-menu-key.robot`. 

Still need to check and confirm other uses of PiKVM keywords, and update them if necessary (although care has been taken in pikmv-rest-api changes so that no changes in tests should be necessary).

Submodule has been removed and Python package is used instead in requiremts.txt, as this allows to import Library from class and initialize it just once with static values (such as credentials PIKVM_IP).