### PR TITLE
Fix Inter Suite Cross Contamination

### DIFF
--- a/dasharo-compatibility/apu-configuration-menu.robot
+++ b/dasharo-compatibility/apu-configuration-menu.robot
@@ -18,6 +18,8 @@ Suite Setup         Run Keywords
 ...                     Prepare Test Suite    AND
 ...                     Skip If    not ${APU_CONFIGURATION_MENU_SUPPORT}    APU configuration tests not supported.
 Suite Teardown      Run Keywords
+...                     Log Out And Close Connection
+...                     AND
 ...                     Skip If    '${SUITE_STATUS}' == 'SKIP'    Skipping Teardown since Suite was skipped as well
 ...                     AND
 ...                     Flash Firmware    ${FW_FILE}

--- a/dasharo-compatibility/apu-configuration-menu.robot
+++ b/dasharo-compatibility/apu-configuration-menu.robot
@@ -17,14 +17,8 @@ Resource            ../lib/linux.robot
 Suite Setup         Run Keywords
 ...                     Prepare Test Suite    AND
 ...                     Skip If    not ${APU_CONFIGURATION_MENU_SUPPORT}    APU configuration tests not supported.
-Suite Teardown      Run Keywords
-...                     Log Out And Close Connection
-...                     AND
-...                     Skip If    '${SUITE_STATUS}' == 'SKIP'    Skipping Teardown since Suite was skipped as well
-...                     AND
-...                     Flash Firmware    ${FW_FILE}
-...                     AND
-...                     Log Out And Close Connection
+Suite Teardown      Run Keyword
+...                     Tiebreaker
 
 
 *** Test Cases ***

--- a/keywords.robot
+++ b/keywords.robot
@@ -1694,3 +1694,14 @@ Should Contain All
     FOR    ${substring}    IN    @{substrings}
         Should Contain    ${string}    ${substring}
     END
+
+Tiebreaker
+    [Documentation]    Decide what to do if skipping the suite (originally
+    ...    created for APU suite)
+    IF    '${SUITE_STATUS}' == 'SKIP'
+        Log Out And Close Connection
+        Skip
+    ELSE
+        Flash Firmware    ${FW_FILE}
+        Log Out And Close Connection
+    END


### PR DESCRIPTION
Some tests behave differently when launching them inside whole suite vs individually. This fact suggest that after one suite is complete (by returning either Pass Fail or Skip) the environment doesn't return to it's original state. The most common (but not the only one) manifestation of this issue is telnet related error:  "EOFError: telnet connection closed"

This MR aims to find these problematic spots and in effect, bring the regression and individually run tests as close in result as possible.