### PR TITLE
lib/network.robot: Update detection mechanisms

### DIFF
--- a/lib/network.robot
+++ b/lib/network.robot
@@ -16,6 +16,8 @@ Send File To DUT
             Set Local Variable    ${ip_address}    localhost
             Set Local Variable    ${port}    5222
         ELSE
+            Wait Until Keyword Succeeds    5x    10s
+            ...    Get Hostname Ip
             ${ip_address}=    Get Hostname Ip
             Set Local Variable    ${port}    22
         END
@@ -33,11 +35,6 @@ Send File To DUT
 
 Get Hostname Ip
     [Documentation]    Returns local IP address of the DUT.
-    # TODO: We do not necessarily need Internet to be reachable for the internal
-    # addresses to be assigned. But if it is, the local IPs are definitely
-    # already in place.
-    Wait Until Keyword Succeeds    5x    1s
-    ...    Check Internet Connection On Linux
     ${out_hostname}=    Execute Command In Terminal    hostname -I
     Should Not Contain    ${out_hostname}    link is not ready
     ${ip_address}=    String.Get Regexp Matches    ${out_hostname}    \\b(?:192\\.168|10\\.0)\\.\\d{1,3}\\.\\d{1,3}\\b
@@ -46,6 +43,8 @@ Get Hostname Ip
 
 Check Internet Connection On Linux
     [Documentation]    Check internet connection on Linux.
+    Wait Until Keyword Succeeds    5x    10s
+    ...    Get Hostname Ip
     ${out}=    Execute Linux Command    ping -c 4 google-public-dns-a.google.com
     Should Contain    ${out}    , 0% packet loss
 


### PR DESCRIPTION
On systems with docker-provided interfaces, or with a LTE module,
a DUT may acquire an IP address like 172.x.x.x, before the 192.168.10.x.
Such address is not valid for purpose of file transfer, for example,
during flashing process on freshly booted machine. Adding 50s
retry period ensures that all IP addresses were assigned.
Additionally, swap keyword cross-dependency. Previously, connection
detection would be attempted, even if our IP was not set. This makes
certain tests fail (especially on a package installation keyword).
Furthermore, we technically don't need Internet connection to have
IP address assigned, so we also bring this behavior to what might
be expected.