### PR TITLE
dasharo-security/tpm2-commands.robot: Fix incorrect skip condition

### DIFF
--- a/dasharo-security/tpm2-commands.robot
+++ b/dasharo-security/tpm2-commands.robot
@@ -263,7 +263,7 @@ Check If SHA1 And SHA256 Banks Are Enabled
 
 TPM2 Suite Setup
     Prepare Test Suite
-    Skip If    ${TPM_SUPPORTED_VERSION} != '2'    TPM commands tests supported only TPM2
+    Skip If    '${TPM_SUPPORTED_VERSION}' != '2'    TPM commands tests supported only TPM2
     Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    TPM commands tests supported only on Ubuntu
     Power On
     Boot System Or From Connected Disk    ubuntu


### PR DESCRIPTION
I forgot to respect to-string conversion in some of the recent patches; it makes tpm2-commands to be skipped no matter what the config is.