### PR TITLE
requirements.txt: Bump osfv-cli dependency to v0.5.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ MarkupSafe==2.1.5
 mdurl==0.1.2
 nodeenv==1.8.0
 oauth2client==4.1.3
-osfv @ git+https://github.com/Dasharo/osfv-scripts.git@36a030eb006391c3761c25d6972036a5a34fb73b#subdirectory=osfv_cli
+osfv @ git+https://github.com/Dasharo/osfv-scripts.git@a6b18bb88051474ec2a44d8f2b37b1405977ab54#subdirectory=osfv_cli
 paramiko==3.4.0
 pathspec==0.9.0
 pexpect==4.9.0


### PR DESCRIPTION
v0.5.10 contains few fixes to exception handling, currently missing in OSFV