### PR TITLE
Log all variables after setup

### DIFF
--- a/keywords.robot
+++ b/keywords.robot
@@ -478,6 +478,7 @@ Prepare Test Suite
     IF    '${CONFIG}' == 'rpi-3b'    Verify Number Of Connected SD Wire Devices
 
     Set Library Search Order    ${CONFIG}    ${OPTIONS_LIB}
+    Log Variables
 
 Import Osfv Libraries
     [Documentation]    Import osfv_cli libraries based on config and command


### PR DESCRIPTION
Sometimes the values are not printed in the log.html file. It might be useful to know exactly what platform config variable values were used in every tests run.