### PR TITLE
options-lib_dcu: Boot System...: compare same case entry names

### DIFF
--- a/lib/options/options-lib_dcu.robot
+++ b/lib/options/options-lib_dcu.robot
@@ -142,6 +142,7 @@ Set Nextboot
 
     ${os_boot_id}=    Set Variable    ${EMPTY}
     ${os_bootentry_name}=    Get From Dictionary    ${ENV_ID_OS_BOOTMENU_NAMES}    ${env_id}
+    ${os_bootentry_name}=    Convert To Lower Case    ${os_bootentry_name}
 
     ${boot_entries}=    Execute Command In Terminal    efibootmgr
 


### PR DESCRIPTION
The menus/dcu makes the bootentry lowercase, but the default implementation (via serial) does not. This causes the bootentry name in configs only compatible with one of them (dcu wants it to be lowercase, the other one requires it to take letter case into account). This change should make the dcu implementation find the bootentries even if they have upperace letters in them.