### PR TITLE
dasharo-security/secure-boot.robot - UEFI Shell less SBO tests

### DIFF
--- a/dasharo-security/secure-boot.robot
+++ b/dasharo-security/secure-boot.robot
@@ -25,7 +25,7 @@ Suite Setup         Run Keywords
 ...                     AND
 ...                     Skip If    not ${SECURE_BOOT_SUPPORT}    Secure Boot is not supported
 ...                     AND
-...                     Mount USB Disk Image    ${TEST_DATA_DIR}/secure-boot/sb_test_data.img
+...                     Run Keyword If    "${DUT_CONNECTION_METHOD}" != "Telnet"    Mount USB Disk Image    ${TEST_DATA_DIR}/secure-boot/sb_test_data.img    file    TRUE
 ...                     AND
 ...                     Restore Secure Boot Defaults
 Suite Teardown      Run Keywords
@@ -128,11 +128,11 @@ SBO002.002 UEFI Secure Boot (Windows)
 # keywords and menu layout changes.
 #
 
-SBO003.001 Attempt to boot file with the correct key from Shell (firmware)
-    [Documentation]    This test verifies that Secure Boot allows booting
-    ...    a signed file with a correct key.
-    Skip If    not ${TESTS_IN_FIRMWARE_SUPPORT}    SBO003.001 not supported
-    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    SBO003.001 not supported
+SBO003.001 Attempt to boot file with the correct key from Boot Maintenance Manager (firmware)
+    [Documentation]    This test verifies that Secure Boot allows booting a
+    ...    signed file with a correct key.
+    Skip If    not ${TESTS_IN_FIRMWARE_SUPPORT}    SBO004.001 not supported
+    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    SBO004.001 not supported
     Power On
     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
     Enable Secure Boot    ${sb_menu}
@@ -142,17 +142,18 @@ SBO003.001 Attempt to boot file with the correct key from Shell (firmware)
     ${sb_menu}=    Get Secure Boot Menu Construction
     ${advanced_menu}=    Enter Advanced Secure Boot Keys Management And Return Construction    ${sb_menu}
     Enter Enroll DB Signature Using File In DB Options    ${advanced_menu}
-    Enter Volume In File Explorer    SB_TEST
-    Select File In File Explorer    good_keys_DB.cer
+    Enter Volume In File Explorer    BAD_INFLUE
+    Select File In File Explorer    cert_good.der
     # Save Changes And Reset
     # Changes to Secure Boot menu take action immediately, so we can just reset
     Tianocore Reset System
 
-    Enter UEFI Shell
-    ${out}=    Execute File In UEFI Shell    good_keys_hello.efi
-    Should Contain    ${out}    Hello, world!
+    Enter Boot From File
+    Enter Volume In File Explorer    BAD_INFLUE
+    Execute File In File Explorer    hello-dasharo-signed-good.efi
+    Read From Terminal Until    ${HELLO_EFI_STRING}
 
-SBO004.001 Attempt to boot file without the key from Shell (firmware)
+SBO004.001 Attempt to boot file without the key from Boot Maintenance Manager (firmware)
     [Documentation]    This test verifies that Secure Boot blocks booting a file
     ...    without a key.
     Skip If    not ${TESTS_IN_FIRMWARE_SUPPORT}    SBO004.001 not supported
@@ -164,11 +165,13 @@ SBO004.001 Attempt to boot file without the key from Shell (firmware)
     # Save Changes And Reset
     # Changes to Secure Boot menu takes action immediately, so we can just reset
     Tianocore Reset System
-    Enter UEFI Shell
-    ${out}=    Execute File In UEFI Shell    not_signed_hello.efi
-    Should Contain    ${out}    Access Denied
 
-SBO005.001 Attempt to boot file with the wrong-signed key from Shell (firmware)
+    Enter Boot From File
+    Enter Volume In File Explorer    BAD_INFLUE
+    Execute File In File Explorer    hello-dasharo.efi
+    Read From Terminal Until    ${SB_ERROR_STRING}
+
+SBO005.001 Attempt to boot file with the wrong-signed key from Boot Maintenance Manager (firmware)
     [Documentation]    This test verifies that Secure Boot disallows booting
     ...    a signed file with a wrong-signed key.
     Skip If    not ${TESTS_IN_FIRMWARE_SUPPORT}    SBO005.001 not supported
@@ -180,9 +183,11 @@ SBO005.001 Attempt to boot file with the wrong-signed key from Shell (firmware)
     # Save Changes And Reset
     # Changes to Secure Boot menu takes action immediately, so we can just reset
     Tianocore Reset System
-    Enter UEFI Shell
-    ${out}=    Execute File In UEFI Shell    bad_keys_hello.efi
-    Should Contain    ${out}    Access Denied
+
+    Enter Boot From File
+    Enter Volume In File Explorer    BAD_INFLUE
+    Execute File In File Explorer    hello-dasharo-signed-bad.efi
+    Read From Terminal Until    ${SB_ERROR_STRING}
 
 SBO006.001 Reset Secure Boot Keys option availability (firmware)
     [Documentation]    This test verifies that the Reset Secure Boot Keys
@@ -215,15 +220,16 @@ SBO007.001 Attempt to boot the file after restoring keys to default (firmware)
     ${sb_menu}=    Get Secure Boot Menu Construction
     ${advanced_menu}=    Enter Advanced Secure Boot Keys Management And Return Construction    ${sb_menu}
     Enter Enroll DB Signature Using File In DB Options    ${advanced_menu}
-    Enter Volume In File Explorer    SB_TEST
-    Select File In File Explorer    good_keys_DB.cer
+    Enter Volume In File Explorer    BAD_INFLUE
+    Select File In File Explorer    cert_good.der
     # Save Changes And Reset
     # Changes to Secure Boot menu take action immediately, so we can just reset
     Tianocore Reset System
 
-    Enter UEFI Shell
-    ${out}=    Execute File In UEFI Shell    good_keys_hello.efi
-    Should Contain    ${out}    Hello, world!
+    Enter Boot From File
+    Enter Volume In File Explorer    BAD_INFLUE
+    Execute File In File Explorer    hello-dasharo-signed-good.efi
+    Read From Terminal Until    ${HELLO_EFI_STRING}
 
     Power On
     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
@@ -233,9 +239,10 @@ SBO007.001 Attempt to boot the file after restoring keys to default (firmware)
     # Changes to Secure Boot menu take action immediately, so we can just reset
     Tianocore Reset System
 
-    Enter UEFI Shell
-    ${out}=    Execute File In UEFI Shell    good_keys_hello.efi
-    Should Contain    ${out}    Access Denied
+    Enter Boot From File
+    Enter Volume In File Explorer    BAD_INFLUE
+    Execute File In File Explorer    hello-dasharo-signed-good.efi
+    Read From Terminal Until    ${SB_ERROR_STRING}
 
 SBO008.001 Attempt to enroll the key in the incorrect format (firmware)
     [Documentation]    This test verifies that it is impossible to load
@@ -251,8 +258,8 @@ SBO008.001 Attempt to enroll the key in the incorrect format (firmware)
     ${sb_menu}=    Get Secure Boot Menu Construction
     ${advanced_menu}=    Enter Advanced Secure Boot Keys Management And Return Construction    ${sb_menu}
     Enter Enroll DB Signature Using File In DB Options    ${advanced_menu}
-    Enter Volume In File Explorer    SB_TEST
-    Select File In File Explorer    bad_format_DB.txt
+    Enter Volume In File Explorer    BAD_INFLUE
+    Select File In File Explorer    cert_fake.der
     Read From Terminal Until    ERROR: Unsupported file type!
 
 

--- a/dasharo-security/secure-boot.robot
+++ b/dasharo-security/secure-boot.robot
@@ -25,7 +25,7 @@ Suite Setup         Run Keywords
 ...                     AND
 ...                     Skip If    not ${SECURE_BOOT_SUPPORT}    Secure Boot is not supported
 ...                     AND
-...                     Run Keyword If    "${DUT_CONNECTION_METHOD}" != "Telnet"    Mount USB Disk Image    ${TEST_DATA_DIR}/secure-boot/sb_test_data.img    file    TRUE
+...                     Mount USB Disk Image    ${TEST_DATA_DIR}/secure-boot/sb_test_data.img    file    TRUE
 ...                     AND
 ...                     Restore Secure Boot Defaults
 Suite Teardown      Run Keywords

--- a/dasharo-security/secure-boot.robot
+++ b/dasharo-security/secure-boot.robot
@@ -265,6 +265,7 @@ SBO008.001 Attempt to enroll the key in the incorrect format (firmware)
 
 *** Keywords ***
 Set Secure Boot State To Disabled
+    [Tags]    robot:private
     Power On
     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
     Disable Secure Boot    ${sb_menu}

--- a/lib/secure-boot-lib.robot
+++ b/lib/secure-boot-lib.robot
@@ -205,8 +205,17 @@ Enter Volume In File Explorer
         Press Key N Times    1    ${ENTER}
     END
 
-Select File In File Explorer
-    [Documentation]    Select the given file
+Enter Boot From File
+    [Documentation]    Navigates from Tianocore Setup Menu
+    ...    to    Boot Maintenance Manager and to Boot From File
+    ${setup_menu}=    Enter Setup Menu Tianocore And Return Construction
+    ${boot_maintenance_mgr_menu}=    Enter Submenu From Snapshot And Return Construction
+    ...    ${setup_menu}
+    ...    Boot Maintenance Manager
+    Enter Submenu From Snapshot    ${boot_maintenance_mgr_menu}    Boot From File
+
+Execute File In File Explorer
+    [Documentation]    Execute the given file (with ENTER key)
     [Arguments]    ${target_file}
     # 1. Select desired file
     ${files}=    Get Submenu Construction
@@ -214,6 +223,12 @@ Select File In File Explorer
     ${index}=    Get Index Of Matching Option In Menu    ${files}    ${target_file}
     # FIXME: We must add 1 due to empty selecatble space in File Manager
     Press Key N Times And Enter    ${index}+1    ${ARROW_DOWN}
+
+Select File In File Explorer
+    [Documentation]    Select the given file
+    [Arguments]    ${target_file}
+    # 1. Select desired file
+    Execute File In File Explorer    ${target_file}
     # 2. Save Changes
     ${enroll_sig_menu}=    Get Submenu Construction
     # Unselectable filename appears between options after file was selected

--- a/lib/usb-hid-msc-lib.robot
+++ b/lib/usb-hid-msc-lib.robot
@@ -23,6 +23,12 @@ Mount USB Disk Image
     [Documentation]    Mounts USB disk image - either from URL or from local file.
     [Arguments]    ${img_source}    ${upload_type}=file    ${required}=${TRUE}
 
+    # FXIME: Currently works only for QEMU and PiKVM. Remove when support for
+    # other methods is added.
+    IF    "${MANUFACTURER}" != "QEMU" or "${DUT_CONNECTION_METHOD}" != "pikvm"
+        RETURN
+    END
+
     # TODO:: Move to interface approach, not IF/ELSE tree
     IF    "${upload_type}" == "file"
         ${img_dir}    ${img_name}=    Split Path    ${img_source}

--- a/platform-configs/include/default.robot
+++ b/platform-configs/include/default.robot
@@ -31,6 +31,10 @@ ${SNIPEIT}=                                         yes
 ${SEABIOS_BOOT_DEVICE}=                             ${EMPTY}
 ${CHECK_POWER_LED_SUPPORT}=                         ${TRUE}
 
+# Hello, world!
+${HELLO_EFI_STRING}=                                UEFI Hello, Dasharo Universe!
+${SB_ERROR_STRING}=                                 The image signature is invalid or missing!
+
 # See: https://github.com/Dasharo/dasharo-issues/issues/614
 ${LAPTOP_EC_SERIAL_WORKAROUND}=                     ${FALSE}
 


### PR DESCRIPTION
SBO003.001 & SBO004.001 - WiP.
lib/secure-boot-lib.robot keywords for setup menu Secure Boot testing platform-configs/include/default.robot - output strings expected by SBO tests in menu-based execution