### PR TITLE
Vp3210 config

### DIFF
--- a/dasharo-security/verified-boot.robot
+++ b/dasharo-security/verified-boot.robot
@@ -11,7 +11,6 @@ Library             RequestsLibrary
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot
-Resource            ../os-config/ubuntu-credentials.robot
 
 # TODO:
 # - document which setup/teardown keywords to use and what are they doing
@@ -33,19 +32,12 @@ Test Setup          Run Keyword
 ...                     Power On
 
 
-*** Variables ***
-# The fw_file_original is the fw_file received as an input to the test suite
-${FW_FILE_ORIGINAL}=    /home/${UBUNTU_USERNAME}/test-firmware.rom
-# # The fw_file_resigned is the fw_file resigned with newly generated keys (so
-# # booting it should trigger vboot recovery events)
-${FW_FILE_RESIGNED}=    /home/${UBUNTU_USERNAME}/test-firmware_resigned.rom
-
-
 *** Test Cases ***
 VBO006.002 Check whether the verstage was run
     [Documentation]    Check whether the Verified Boot is enabled and
     ...    functional.
     Boot System Or From Connected Disk    ${ENV_ID_UBUNTU}
+
     Login To Linux
     Switch To Root User
     Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    VBO006.002 not supported
@@ -264,6 +256,13 @@ Prepare Tools, Keys And Binaries
     # TODO: store the disk boot entry in platform config, or figure out how
     # to handle UEFI boot entries in a reliable manner
     Boot System Or From Connected Disk    ${ENV_ID_UBUNTU}
+
+    # The fw_file_original is the fw_file received as an input to the test suite
+    Set Suite Variable    ${FW_FILE_ORIGINAL}    /home/${DEVICE_OS_USERNAME}/test-firmware.rom
+    # The fw_file_resigned is the fw_file resigned with newly generated keys
+    # (so booting it should trigger vboot recovery events)
+    Set Suite Variable    ${FW_FILE_RESIGNED}    /home/${DEVICE_OS_USERNAME}/test-firmware_resigned.rom
+
     Login To Linux
     Switch To Root User
     Get Coreboot Tools

--- a/keywords.robot
+++ b/keywords.robot
@@ -670,7 +670,7 @@ Power Cycle On
     IF    '${DEFAULT_POWER_STATE_AFTER_FAIL}' == 'Powered Off'    Rte Power On
 
     IF    '${CHECK_POWER_LED_SUPPORT}' == '${TRUE}'
-        FOR    ${i}    IN RANGE    50
+        FOR    ${i}    IN RANGE    10
             ${out}=    Rte Check Power Led
             IF    '${out}' == 'high'    RETURN
             Sleep    0.5s

--- a/platform-configs/include/protectli-vp32xx.robot
+++ b/platform-configs/include/protectli-vp32xx.robot
@@ -4,8 +4,10 @@ Resource    protectli-common.robot
 
 
 *** Variables ***
-${FLASH_SIZE}=      ${16*1024*1024}
+${FLASH_SIZE}=              ${16*1024*1024}
 
-${MAX_CPU_TEMP}=    82
+${MAX_CPU_TEMP}=            82
+${DEVICE_USB_KEYBOARD}=     Logitech, Inc. Keyboard K120
+${ETHERNET_ID}=             8086:125c
 
-${ETHERNET_ID}=     8086:125c
+${SENSORS_CONFIG_FILE}=     include/sensors/default-sensors-config.yaml

--- a/platform-configs/protectli-vp3210.robot
+++ b/platform-configs/protectli-vp3210.robot
@@ -3,7 +3,43 @@ Resource    include/protectli-vp32xx.robot
 
 
 *** Variables ***
-${DMIDECODE_PRODUCT_NAME}=      VP3210
+${DEVICE_USB_KEYBOARD}=             Logitech, Inc. Keyboard K120
 
-@{ETH_PORTS}=                   64-62-66-23-90-47
-...                             64-62-66-23-90-48
+${INITIAL_CPU_FREQUENCY}=           700
+${PLATFORM_CPU_SPEED}=              3.80
+${CPU_MIN_FREQUENCY}=               700
+${CPU_MAX_FREQUENCY}=               3400
+${PLATFORM_RAM_SPEED}=              4800
+${PLATFORM_RAM_SIZE}=               16384
+
+${WIFI_CARD}=                       Qualcomm Atheros QCA6174 802.11ac Wireless Network Adapter
+${WIFI_CARD_UBUNTU}=                Qualcomm Atheros QCA6174 802.11ac Wireless Network Adapter
+${BLUETOOTH_CARD_UBUNTU}=           Qualcomm Atheros Communications AR3012 Bluetooth 4.0
+
+${E_MMC_NAME}=                      BJTD4R
+${CPU}=                             Intel(R) N100
+
+${DMIDECODE_MANUFACTURER}=          Protectli
+${DMIDECODE_SERIAL_NUMBER}=         123456789
+${DMIDECODE_PRODUCT_NAME}=          VP3210
+${DMIDECODE_FAMILY}=                Vault Pro
+${DMIDECODE_TYPE}=                  Desktop
+${DMIDECODE_FIRMWARE_VERSION}=      Dasharo (coreboot+UEFI) v0.9.0-rc9
+${DMIDECODE_RELEASE_DATE}=          02/26/2025
+${DEF_THREADS_TOTAL}=               4
+${DEF_THREADS_PER_CORE}=            1
+${DEF_CORES_PER_SOCKET}=            4
+${DEF_SOCKETS}=                     1
+${DEF_ONLINE_CPU}=                  0-3
+${DEVICE_AUDIO1}=                   Alderlake-P HDMI
+${DEVICE_AUDIO2}=                   ${EMPTY}
+${DEVICE_AUDIO1_WIN}=               High Definition Audio Controller
+
+${DEVICE_NVME_DISK}=                N/A
+${CLEVO_DISK}=                      N/A
+
+@{ETH_PORTS}=                       64-62-66-23-90-47
+...                                 64-62-66-23-90-48
+
+${TPM_SUPPORTED_VERSION}=           2
+${TPM_EXPECTED_CHIP}=               SLB9670

--- a/platform-configs/protectli-vp3210.robot
+++ b/platform-configs/protectli-vp3210.robot
@@ -3,16 +3,14 @@ Resource    include/protectli-vp32xx.robot
 
 
 *** Variables ***
-${DEVICE_USB_KEYBOARD}=             Logitech, Inc. Keyboard K120
-
 ${INITIAL_CPU_FREQUENCY}=           700
-${PLATFORM_CPU_SPEED}=              3.80
+${PLATFORM_CPU_SPEED}=              0.80
 ${CPU_MIN_FREQUENCY}=               700
 ${CPU_MAX_FREQUENCY}=               3400
 ${PLATFORM_RAM_SPEED}=              4800
 ${PLATFORM_RAM_SIZE}=               16384
 
-${WIFI_CARD}=                       Qualcomm Atheros QCA6174 802.11ac Wireless Network Adapter
+${WIFI_CARD}=                       Qualcomm Atheros QCA61x4A Wireless Network Adapter
 ${WIFI_CARD_UBUNTU}=                Qualcomm Atheros QCA6174 802.11ac Wireless Network Adapter
 ${BLUETOOTH_CARD_UBUNTU}=           Qualcomm Atheros Communications AR3012 Bluetooth 4.0
 
@@ -24,8 +22,8 @@ ${DMIDECODE_SERIAL_NUMBER}=         123456789
 ${DMIDECODE_PRODUCT_NAME}=          VP3210
 ${DMIDECODE_FAMILY}=                Vault Pro
 ${DMIDECODE_TYPE}=                  Desktop
-${DMIDECODE_FIRMWARE_VERSION}=      Dasharo (coreboot+UEFI) v0.9.0-rc9
-${DMIDECODE_RELEASE_DATE}=          02/26/2025
+${DMIDECODE_FIRMWARE_VERSION}=      Dasharo (coreboot+UEFI) v0.9.0-rc10
+${DMIDECODE_RELEASE_DATE}=          03/14/2025
 ${DEF_THREADS_TOTAL}=               4
 ${DEF_THREADS_PER_CORE}=            1
 ${DEF_CORES_PER_SOCKET}=            4
@@ -35,7 +33,7 @@ ${DEVICE_AUDIO1}=                   Alderlake-P HDMI
 ${DEVICE_AUDIO2}=                   ${EMPTY}
 ${DEVICE_AUDIO1_WIN}=               High Definition Audio Controller
 
-${DEVICE_NVME_DISK}=                N/A
+${DEVICE_NVME_DISK}=                Non-Volatile memory controller
 ${CLEVO_DISK}=                      N/A
 
 @{ETH_PORTS}=                       64-62-66-23-90-47

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ mdurl==0.1.2
 nodeenv==1.8.0
 numpy==2.2.3
 oauth2client==4.1.3
-osfv @ git+https://github.com/Dasharo/osfv-scripts.git@8a565cad6214b426a0d01ebdcdb5a7df3d3aef01#subdirectory=osfv_cli
+osfv @ git+https://github.com/Dasharo/osfv-scripts.git@06bf5d45b21bdec86486aba8aafd5664d470beff#subdirectory=osfv_cli
 packaging==24.2
 pandas==2.2.3
 paramiko==3.4.0

--- a/util/basic-platform-setup.robot
+++ b/util/basic-platform-setup.robot
@@ -50,20 +50,21 @@ BPS003.001 RTE Power On
     ${result}=    Wait For Serial Output
     Should Be True    ${result}    msg=Power On keyword failed
 
-    Rte Power Off
+    Power Off Ex
     Sleep    10s
     Read From Terminal
     ${result}=    Wait For Serial Output    timeout=10
     Should Not Be True    ${result}    msg=Failed to power off DUT via power button
 
-    Rte Power On
+    Power On Ex
     ${result}=    Wait For Serial Output
     Should Be True    ${result}    msg=Failed to power on DUT via power button
 
 BPS004.001 RTE Reset
     [Documentation]    Verifies if reset button can reset the DUT.
     Power On
-    Wait For Serial Output
+    ${result}=    Wait For Serial Output
+    Should Be True    ${result}    msg=Power On keyword failed
     Rte Reset
     Read From Terminal
     ${result}=    Wait For Serial Output
@@ -173,3 +174,33 @@ Wait For Serial Output
         IF    ${result} == ${FALSE}    RETURN    ${TRUE}
     END
     RETURN    ${FALSE}
+
+# TODO: incorporate LED checks into RTE OSFV lib
+
+Power Off Ex
+    Rte Power Off
+    IF    '${CHECK_POWER_LED_SUPPORT}' == '${TRUE}'
+        FOR    ${i}    IN RANGE    20
+            ${out}=    Rte Check Power Led
+            IF    '${out}' == 'low'    RETURN
+            Sleep    0.5s
+        END
+        IF    '${out}' != 'high'
+            FAIL    Power LED didn't light up! Setup needs manual verification,
+            ...    or Power State After Power Failure is set incorrectly.
+        END
+    END
+
+Power On Ex
+    Rte Power On
+    IF    '${CHECK_POWER_LED_SUPPORT}' == '${TRUE}'
+        FOR    ${i}    IN RANGE    10
+            ${out}=    Rte Check Power Led
+            IF    '${out}' == 'high'    RETURN
+            Sleep    0.5s
+        END
+        IF    '${out}' != 'high'
+            FAIL    Power LED didn't light up! Setup needs manual verification,
+            ...    or Power State After Power Failure is set incorrectly.
+        END
+    END

--- a/variables.robot
+++ b/variables.robot
@@ -247,7 +247,6 @@ ${OS_UBUNTU}=               ubuntu
 &{RTE69}=                   ip=192.168.10.211
 ...                         platform=protectli-vp3210
 ...                         platform_vendor=protectli
-...                         sonoff_ip=192.168.10.195
 
 @{RTE_LIST}=                &{RTE05}
 ...                         &{RTE06}    &{RTE07}    &{RTE08}    &{RTE09}    &{RTE10}


### PR DESCRIPTION
The VP3230 uses 90W (12V 7.5A) PSU, which requires sonoff, but VP3210 uses 60W (12V 5A) PSU which is still suitable for RTE relay power control.

Also add missing information about VP3210 based on lspci and lscpu output from DTS.