### PR TITLE
Windows wifi fix

### DIFF
--- a/dasharo-compatibility/wifi-bluetooth-support.robot
+++ b/dasharo-compatibility/wifi-bluetooth-support.robot
@@ -90,6 +90,9 @@ WLE002.002 Wi-Fi scanning (Windows)
     Power On
     Login To Windows
     Execute Command In Terminal    Start-Service WlanSvc
+    # Ensure WiFi is enabled
+    Execute Command In Terminal
+    ...    Set-NetAdapterAdvancedProperty -Name "Wi-Fi" -AllProperties -RegistryKeyword "SoftwareRadioOff" -RegistryValue "0"
     ${out}=    Execute Command In Terminal    netsh wlan show network
     Should Contain    ${out}    ${3_MDEB_WIFI_NETWORK}
     ${current_card}=


### PR DESCRIPTION
Fixes the problem where "netsh wlan show network" in Windows would return:

The wireless local area network interface is powered down and doesn't
support the requested operation.

When the WiFi is disabled, networks cannot be scanned. Enable the WiFi
first and then proceed with scanning.

TEST=WLE002.002 passes on Protectli VP2430