### PR TITLE
Create more detailed naming convetion of the result test dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,10 @@ SONOFF_IP=$SONOFF_IP PIKVM_IP=$PIKVM_IP
 Mind that `SNIPEIT_NO`, only need to be set, meaning that whatever value it
 has, it will be treated as true.
 
+You may also specify a DIR_PREFIX when executing this wrapper script.
+The given prefix will be added to the beginning of the test results
+directory name.
+
 ### Running tests with additional arguments
 
 Any additional parameters to `robot` can be passed using the wrapper by giving

--- a/scripts/lib/robot.sh
+++ b/scripts/lib/robot.sh
@@ -86,6 +86,13 @@ execute_robot() {
   # Check if the required environment variables are set
   check_env_variable "CONFIG"
 
+  # DIR_PREFIX (optional) additional description of test result dir
+  if [ -n "${DIR_PREFIX}" ]; then
+    dir_prefix="${DIR_PREFIX}_"
+  else
+    dir_prefix=""
+  fi
+
   # RTE_IP environment variable is not required for some platforms
   if [ -n "${RTE_IP}" ]; then
     rte_ip_option="-v rte_ip:${RTE_IP}"
@@ -138,12 +145,24 @@ execute_robot() {
   # Thanks to detecting spacebars in arguments before _robot_args can now
   # safely be concatenated into a string and these arguments will still be
   # passed correctly.
+  #
+  # Firstly, the provided argument will be parsed to get the proper name
+  # for the results directory.
   for _test_name in "${_test_path[@]}"; do
-    local _logs_dir="logs/${CONFIG}/${RUN_DATE}"
-    local _log_file="${_logs_dir}/${_test_name}_log.html"
-    local _report_file="${_logs_dir}/${_test_name}_report.html"
-    local _output_file="${_logs_dir}/${_test_name}_out.xml"
-    local _debug_file="${_logs_dir}/${_test_name}_debug.log"
+    if [[ "$_test_name" == *"/"* && "$_test_name" != */ ]]; then
+      _test_scope_name="${_test_name##*/}"
+      if [[ "$_test_scope_name" == *".robot"* ]]; then
+        _test_scope_name="${_test_scope_name%%.*}"
+      fi
+    else
+      _test_scope_name="${_test_name%%/*}"
+    fi
+
+    local _logs_dir="logs/${CONFIG}/${dir_prefix}${_test_scope_name}_${RUN_DATE}"
+    local _log_file="${_logs_dir}/${_test_scope_name}_log.html"
+    local _report_file="${_logs_dir}/${_test_scope_name}_report.html"
+    local _output_file="${_logs_dir}/${_test_scope_name}_out.xml"
+    local _debug_file="${_logs_dir}/${_test_scope_name}_debug.log"
 
     echo "Logs will be saved at ${_logs_dir}"
     echo "Watch \"${_debug_file}\" to monitor the progress of the test"

--- a/scripts/lib/robot.sh
+++ b/scripts/lib/robot.sh
@@ -158,7 +158,11 @@ execute_robot() {
       _test_scope_name="${_test_name%%/*}"
     fi
 
-    local _logs_dir="logs/${CONFIG}/${dir_prefix}${_test_scope_name}_${RUN_DATE}"
+    if [ -n "${_REGRESSION_RUN}" ]; then
+      local _logs_dir="logs/${CONFIG}/${dir_prefix}regresion_${RUN_DATE}"
+    else
+      local _logs_dir="logs/${CONFIG}/${dir_prefix}${_test_scope_name}_${RUN_DATE}"
+    fi
     local _log_file="${_logs_dir}/${_test_scope_name}_log.html"
     local _report_file="${_logs_dir}/${_test_scope_name}_report.html"
     local _output_file="${_logs_dir}/${_test_scope_name}_out.xml"

--- a/scripts/regression.sh
+++ b/scripts/regression.sh
@@ -16,6 +16,9 @@ if [ ! -f "$FW_FILE" ]; then
     exit 1
 fi
 
+_REGRESSION_RUN="True"
+export _REGRESSION_RUN
+
 check_test_station_variables
 
 if [ -z "$NO_SETUP" ]; then


### PR DESCRIPTION
- In this PR I enchanced naming so now for example the command:
DIR_PREFIX=**release-testing** RTE_IP=0.0.0.0 DEVICE_IP=192.168.4.184 SNIPEIT_NO=True CONFIG=novacustom-v540tu ./scripts/run.sh dasharo-compatibility/**dcu**.robot
will result of test result path: logs/novacustom-v540tu/**release-testing**_**dcu**_2025_04_09_12_32_30/dcu_debug.log.
- The variable `DIR_PREFIX` is optional.
- In case that just one test suite is being run then the directory and logs will have the name of the test suite file. 
- If the whole test module is  being run then the directory and logs will have the name of that test module.
- Also this PR removes creating subfolder with module name - I have reasons to suspect that was never the intended outcome.
- I removed `.robot` as a part of logs names.
- I aslo protected this solution from some edge cases (that I could think of).

