### PR TITLE
util/basic-platform-setup.robot: connection check in Run Ansible Play…

### DIFF
--- a/util/basic-platform-setup.robot
+++ b/util/basic-platform-setup.robot
@@ -237,6 +237,7 @@ Run Ansible Playbooks
         # ansible will fail no matter the timeouts if host is unreachable
         # (not booted yet)
         Login To Linux
+        Check Internet Connection On Linux
 
         # Create temporary inventory file for given platform and OS
         ${inventory_file}=    Catenate    [host] \n


### PR DESCRIPTION
…book

Added Check Internet Connection On Linux in Run Ansible Playbook keyword, to avoid SSH "host unreachable" error when network interface initialization takes a little longer.