### PR TITLE
osfv: Add UEFI Shell back

### DIFF
--- a/dasharo-compatibility/uefi-shell.robot
+++ b/dasharo-compatibility/uefi-shell.robot
@@ -24,15 +24,18 @@ Suite Teardown      Run Keyword
 
 *** Test Cases ***
 USH001.001 UEFI Shell
-    [Documentation]    Check whether the DUT has the ability to boot into an
-    ...    integrated UEFI Shell application or that the UEFI Shell does
-    ...    not appear, based on the UEFI_SHELL_SUPPORT value.
+    [Documentation]    Check whether the UEFI Shell is available, and whether
+    ...    UEFI Shell was sourced from coreboot image, or from OS drive.
     Skip If    not ${TESTS_IN_FIRMWARE_SUPPORT}    USH001.001 not supported
     Power On
     ${boot_menu}=    Enter Boot Menu Tianocore And Return Construction
-    IF    ${UEFI_SHELL_SUPPORT}
-        Enter Submenu From Snapshot    ${boot_menu}    UEFI Shell
-        Read From Terminal Until    UEFI Interactive Shell
-    ELSE
-        Should Not Contain    ${boot_menu}    UEFI Shell
-    END
+    Enter Submenu From Snapshot    ${boot_menu}    UEFI Shell
+    Read From Terminal Until    Shell>
+    Write Bare Into Terminal    dh
+    Press Enter
+    ${shell_dump_handle}=    Read From Terminal Until    Shell>
+
+    Should Not Contain    ${shell_dump_handle}    LoadedImage(Shell)
+    ...    UEFI Shell sourced from Dasharo FW image!
+    Should Contain    ${shell_dump_handle}    LoadedImage(\\EFI\\Shell\\Shell.efi)
+    ...    UEFI Shell not sourced from EFI partition!

--- a/dasharo-compatibility/usb-hid-and-msc-support.robot
+++ b/dasharo-compatibility/usb-hid-and-msc-support.robot
@@ -39,7 +39,6 @@ USB002.001 USB keyboard detected in FW
     ...    according to their labels.
     [Tags]    minimal-regression
     Depends On    ${TESTS_IN_FIRMWARE_SUPPORT}
-    Depends On    ${UEFI_SHELL_SUPPORT}
     Depends On    ${HAS_KEYBOARD}
     Power On
     Enter UEFI Shell

--- a/os-config/ansible/os-specific-tasks/201.yaml
+++ b/os-config/ansible/os-specific-tasks/201.yaml
@@ -1,3 +1,15 @@
 # SPDX-FileCopyrightText: 2024 3mdeb <contact@3mdeb.com>
 #
 # SPDX-License-Identifier: Apache-2.0
+
+- name: Prepare UEFI Shell components
+  ansible.builtin.copy:
+    src: "{{ item.src }}"
+    dest: /tmp/
+    mode: 755
+  loop:
+    - src: "./../../../osfv-test-data/uefi-shell/Shell.efi"
+    - src: "./../../../osfv-test-data/uefi-shell/deploy-shell-efi.sh"
+
+- name: Install UEFI Shell
+  ansible.builtin.command: /tmp/deploy-shell-efi.sh /tmp/Shell.efi

--- a/platform-configs/include/default.robot
+++ b/platform-configs/include/default.robot
@@ -106,7 +106,6 @@ ${USB_DISKS_DETECTION_SUPPORT}=                     ${FALSE}
 ${USB_KEYBOARD_DETECTION_SUPPORT}=                  ${FALSE}
 ${USB_CAMERA_DETECTION_SUPPORT}=                    ${FALSE}
 ${USB_TYPE_C_DISPLAY_SUPPORT}=                      ${FALSE}
-${UEFI_SHELL_SUPPORT}=                              ${FALSE}
 ${UEFI_COMPATIBLE_INTERFACE_SUPPORT}=               ${FALSE}
 ${IPXE_BOOT_SUPPORT}=                               ${FALSE}
 ${NVME_DISK_SUPPORT}=                               ${FALSE}

--- a/platform-configs/include/msi-z690-common.robot
+++ b/platform-configs/include/msi-z690-common.robot
@@ -61,7 +61,6 @@ ${EXTERNAL_DISPLAY_PORT_SUPPORT}=               ${TRUE}
 ${CUSTOM_LOGO_SUPPORT}=                         ${TRUE}
 ${USB_DISKS_DETECTION_SUPPORT}=                 ${TRUE}
 ${USB_KEYBOARD_DETECTION_SUPPORT}=              ${TRUE}
-${UEFI_SHELL_SUPPORT}=                          ${TRUE}
 ${UEFI_COMPATIBLE_INTERFACE_SUPPORT}=           ${TRUE}
 ${IPXE_BOOT_SUPPORT}=                           ${TRUE}
 ${NVME_DISK_SUPPORT}=                           ${TRUE}

--- a/platform-configs/include/novacustom-common.robot
+++ b/platform-configs/include/novacustom-common.robot
@@ -59,7 +59,6 @@ ${EC_AND_SUPER_IO_SUPPORT}=                         ${TRUE}
 ${CUSTOM_LOGO_SUPPORT}=                             ${TRUE}
 ${USB_CAMERA_DETECTION_SUPPORT}=                    ${TRUE}
 ${USB_TYPE_C_DISPLAY_SUPPORT}=                      ${TRUE}
-${UEFI_SHELL_SUPPORT}=                              ${TRUE}
 ${UEFI_COMPATIBLE_INTERFACE_SUPPORT}=               ${TRUE}
 ${IPXE_BOOT_SUPPORT}=                               ${TRUE}
 ${NVME_DISK_SUPPORT}=                               ${TRUE}

--- a/platform-configs/include/optiplex-common.robot
+++ b/platform-configs/include/optiplex-common.robot
@@ -43,7 +43,6 @@ ${EXTERNAL_DISPLAY_PORT_SUPPORT}=               ${TRUE}
 ${CUSTOM_LOGO_SUPPORT}=                         ${TRUE}
 ${USB_DISKS_DETECTION_SUPPORT}=                 ${TRUE}
 ${USB_KEYBOARD_DETECTION_SUPPORT}=              ${TRUE}
-${UEFI_SHELL_SUPPORT}=                          ${TRUE}
 ${UEFI_COMPATIBLE_INTERFACE_SUPPORT}=           ${TRUE}
 ${IPXE_BOOT_SUPPORT}=                           ${TRUE}
 ${NVME_DISK_SUPPORT}=                           ${TRUE}

--- a/platform-configs/include/pcengines.robot
+++ b/platform-configs/include/pcengines.robot
@@ -53,7 +53,6 @@ ${CUSTOM_BOOT_MENU_KEY_SUPPORT}=            ${TRUE}
 ${CUSTOM_SETUP_MENU_KEY_SUPPORT}=           ${TRUE}
 ${EC_AND_SUPER_IO_SUPPORT}=                 ${TRUE}
 ${USB_DISKS_DETECTION_SUPPORT}=             ${TRUE}
-${UEFI_SHELL_SUPPORT}=                      ${TRUE}
 ${UEFI_COMPATIBLE_INTERFACE_SUPPORT}=       ${TRUE}
 ${IPXE_BOOT_SUPPORT}=                       ${TRUE}
 ${SD_CARD_READER_SUPPORT}=                  ${TRUE}

--- a/platform-configs/odroid-h4-plus.robot
+++ b/platform-configs/odroid-h4-plus.robot
@@ -37,7 +37,6 @@ ${DCU_SUPPORTED_BOOLEAN_SMMSTORE_VARIABLE}=     ${EMPTY}
 ${ETH_PORTS}=                                   ${EMPTY}
 ${USB_DISKS_DETECTION_SUPPORT}=                 ${TRUE}
 ${USB_KEYBOARD_DETECTION_SUPPORT}=              ${TRUE}
-${UEFI_SHELL_SUPPORT}=                          ${TRUE}
 ${NVME_DISK_SUPPORT}=                           ${TRUE}
 ${EMMC_SUPPORT}=                                ${TRUE}
 ${AUDIO_SUBSYSTEM_SUPPORT}=                     ${TRUE}

--- a/platform-configs/qemu.robot
+++ b/platform-configs/qemu.robot
@@ -45,7 +45,6 @@ ${CUSTOM_NETWORK_BOOT_ENTRIES_SUPPORT}=     ${TRUE}
 ${CUSTOM_LOGO_SUPPORT}=                     ${TRUE}
 ${USB_DISKS_DETECTION_SUPPORT}=             ${TRUE}
 ${USB_KEYBOARD_DETECTION_SUPPORT}=          ${TRUE}
-${UEFI_SHELL_SUPPORT}=                      ${TRUE}
 ${IPXE_BOOT_SUPPORT}=                       ${TRUE}
 ${AUDIO_SUBSYSTEM_SUPPORT}=                 ${TRUE}
 ${FIRMWARE_NUMBER_VERIFICATION}=            ${TRUE}

--- a/self-tests/terminal.robot
+++ b/self-tests/terminal.robot
@@ -26,23 +26,6 @@ Suite Teardown      Run Keyword
 
 
 *** Test Cases ***
-Execute UEFI Shell Command
-    [Documentation]    Test Execute Shell Command kwd
-    Power On
-    Enter UEFI Shell
-    Set Prompt For Terminal    Shell>
-    FOR    ${iteration}    IN RANGE    1    50
-        Log To Console    Iteration: ${iteration}
-        ${out}=    Execute UEFI Shell Command    map
-        Should Contain    ${out}    Alias(s):
-        ${out}=    Execute UEFI Shell Command    devices
-        Should Contain    ${out}    Device Name
-        ${out}=    Execute UEFI Shell Command    bcfg boot dump
-        Should Contain    ${out}    Optional- N
-        ${out}=    Execute UEFI Shell Command    dmpstore    # this command prints data for a long time
-        Should Contain    ${out}    GlobalVariable
-    END
-
 Execute Command In Terminal over SSH (Windows)
     [Documentation]    Test Execute Command In Terminal keyword over SSH. This is related
     ...    to bug: https://github.com/Dasharo/open-source-firmware-validation/issues/355


### PR DESCRIPTION
Combined with https://github.com/Dasharo/osfv-test-data/pull/8 this introduces UEFI Shell installation as part of util/basic-platform-setup.robot

Additionally, clean up UEFI_SHELL_SUPPORT variable, as well as update dasharo-compatibility/uefi-shell.robot

Relevant logs:
[basic-platform-setup_.zip](https://github.com/user-attachments/files/19735287/basic-platform-setup_.zip)
[uefi-shell_.zip](https://github.com/user-attachments/files/19735437/uefi-shell_.zip)