### PR TITLE
DCU004.201: Moving to USBMassStorage menu option

### DIFF
--- a/lib/dcu.robot
+++ b/lib/dcu.robot
@@ -55,12 +55,12 @@ DCU Variable Read SMMSTORE
 
     Execute Command In Terminal    flashrom -p internal -r coreboot.rom --fmap -i FMAP -i SMMSTORE &> /dev/null
     Execute Command In Terminal    chmod 666 coreboot.rom
-    SSHLibrary.Get File    coreboot.rom    ${out_file}
+    Get File From DUT    coreboot.rom    ${out_file}
 
 DCU Variable Flash SMMSTORE
     [Documentation]    Write the UEFI SMMSTORE to commit the changes
     [Arguments]    ${fw_file}
-    SSHLibrary.Put File    ${fw_file}    coreboot.rom
+    Send File To DUT    ${fw_file}    coreboot.rom
     Execute Command In Terminal    flashrom -p internal -w coreboot.rom --fmap -i SMMSTORE --noverify-all &> /dev/null
 
 DCU Variable Get UEFI Option From File

--- a/platform-configs/include/protectli-common.robot
+++ b/platform-configs/include/protectli-common.robot
@@ -74,6 +74,7 @@ ${USB_DISKS_DETECTION_SUPPORT}=                 ${TRUE}
 ${USB_KEYBOARD_DETECTION_SUPPORT}=              ${TRUE}
 ${DCU_UUID_SUPPORT}=                            ${TRUE}
 ${DCU_SERIAL_SUPPORT}=                          ${TRUE}
+${DCU_SUPPORTED_BOOLEAN_SMMSTORE_VARIABLE}=     UsbMassStorage
 ${HDMI_AUDIO_SUPPORT}=                          ${TRUE}
 
 # Test module: dasharo-security


### PR DESCRIPTION
- Moved from "Enable network boot" to "Enable USB Mass Storage" as tested option on Protectli platforms
- Getting rid of unwrapped SSHLibrary keywords from lib/dcu.robot

Execution log:
[dcu_2025_04_15_12_09_00.zip](https://github.com/user-attachments/files/19755933/dcu_2025_04_15_12_09_00.zip)
