### PR TITLE
Semi-manual 2.5G network perf test

### DIFF
--- a/dasharo-compatibility/network-speed.robot
+++ b/dasharo-compatibility/network-speed.robot
@@ -33,9 +33,9 @@ ETHPERF001.201 Check Performance of 2.5G Wired Network Interface (Ubuntu)
     IF    '${eth_ports_number}' == '2'
         Skip If    '${DUT_CONNECTION_METHOD}' != 'Telnet'
         Pause Execution
-        ...    [1/10] This is semi-manual execution, in next step there will be instruction checklist of DUT setup modification.
+        ...    [1/6] This is semi-manual execution, in next step there will be instruction checklist of DUT setup modification.
         ${lab_network_port}=    Get Value From User
-        ...    [2/10] Enter DUT ethernet port number connected to lab network.    1
+        ...    [2/6] Enter DUT ethernet port number connected to lab network.    1
 
         @{manual_eth_loop_setup}=    Create List
         ...    1. On DUT, disconnect lab network ethernet cable from port ${lab_network_port}
@@ -45,12 +45,12 @@ ETHPERF001.201 Check Performance of 2.5G Wired Network Interface (Ubuntu)
         ...    2. On DUT, reconnect lab network ethernet cable to port ${lab_network_port}
 
         @{dut_setup_values}=    Get Selections From User
-        ...    [3/10] Follow the steps, mark each when done, click OK when finished.
+        ...    [3/6] Follow the steps, mark each when done, click OK when finished.
         ...    ${manual_eth_loop_setup}[0]
         ...    ${manual_eth_loop_setup}[1]
         Lists Should Be Equal    ${manual_eth_loop_setup}    ${dut_setup_values}
 
-        Pause Execution    [3/10] Click OK to begin speed testing.
+        Pause Execution    [4/6] Click OK to begin speed testing.
     END
 
     Power On
@@ -66,9 +66,9 @@ ETHPERF001.201 Check Performance of 2.5G Wired Network Interface (Ubuntu)
 
     IF    '${eth_ports_number}' == '2'
         Pause Execution
-        ...    [4/10] This is semi-manual execution, in next step there will be instruction checklist of DUT setup modification.
+        ...    [5/6] This is semi-manual execution, in next step there will be instruction checklist of DUT setup modification.
         @{dut_restore_values}=    Get Selections From User
-        ...    [5/10] Follow the steps, mark each when done, click OK when finished.
+        ...    [6/6] Follow the steps, mark each when done, click OK when finished.
         ...    ${manual_eth_restore}[0]
         ...    ${manual_eth_restore}[1]
         Lists Should Be Equal    ${manual_eth_restore}    ${dut_restore_values}

--- a/dasharo-compatibility/network-speed.robot
+++ b/dasharo-compatibility/network-speed.robot
@@ -1,5 +1,6 @@
 *** Settings ***
 Library             Collections
+Library             Dialogs
 Library             OperatingSystem
 Library             Process
 Library             String
@@ -23,9 +24,35 @@ Suite Teardown      Run Keyword
 
 
 *** Test Cases ***
-ETHPERF001.001 Check Performance of 2.5G Wired Network Interface (Ubuntu)
+ETHPERF001.201 Check Performance of 2.5G Wired Network Interface (Ubuntu)
     [Documentation]    This test aims to verify the performance of Ethernet connection
     Depends On    ${ETH_PERF_PAIR_2_G}
+    Depends On    ${ETH_PORTS}
+
+    ${eth_ports_number}=    Get Length    ${ETH_PORTS}
+    IF    '${eth_ports_number}' == '2'
+        Skip If    '${DUT_CONNECTION_METHOD}' != 'Telnet'
+        Pause Execution
+        ...    [1/10] This is semi-manual execution, in next step there will be instruction checklist of DUT setup modification.
+        ${lab_network_port}=    Get Value From User
+        ...    [2/10] Enter DUT ethernet port number connected to lab network.    1
+
+        @{manual_eth_loop_setup}=    Create List
+        ...    1. On DUT, disconnect lab network ethernet cable from port ${lab_network_port}
+        ...    2. On DUT, connect both ethernet ports with Cat 6a patch cable.
+        @{manual_eth_restore}=    Create List
+        ...    1. On DUT, disconnect Cat 6a patch cable from both ethernet ports
+        ...    2. On DUT, reconnect lab network ethernet cable to port ${lab_network_port}
+
+        @{dut_setup_values}=    Get Selections From User
+        ...    [3/10] Follow the steps, mark each when done, click OK when finished.
+        ...    ${manual_eth_loop_setup}[0]
+        ...    ${manual_eth_loop_setup}[1]
+        Lists Should Be Equal    ${manual_eth_loop_setup}    ${dut_setup_values}
+
+        Pause Execution    [3/10] Click OK to begin speed testing.
+    END
+
     Power On
     Boot System Or From Connected Disk    ${ENV_ID_UBUNTU}
     Login To Linux
@@ -34,9 +61,20 @@ ETHPERF001.001 Check Performance of 2.5G Wired Network Interface (Ubuntu)
     ${eth_1}=    Get From List    ${ETH_PERF_PAIR_2_G}    0
     ${eth_2}=    Get From List    ${ETH_PERF_PAIR_2_G}    1
     Configure Network Interfaces For Testing    ${eth_1}    ${eth_2}
+
     Test Network Performance    2.35
 
-ETHPERF002.001 Check Performance of 10G Wired Network Interface (Ubuntu)
+    IF    '${eth_ports_number}' == '2'
+        Pause Execution
+        ...    [4/10] This is semi-manual execution, in next step there will be instruction checklist of DUT setup modification.
+        @{dut_restore_values}=    Get Selections From User
+        ...    [5/10] Follow the steps, mark each when done, click OK when finished.
+        ...    ${manual_eth_restore}[0]
+        ...    ${manual_eth_restore}[1]
+        Lists Should Be Equal    ${manual_eth_restore}    ${dut_restore_values}
+    END
+
+ETHPERF002.201 Check Performance of 10G Wired Network Interface (Ubuntu)
     [Documentation]    This test aims to verify the performance of Ethernet connection
     Depends On    ${ETH_PERF_PAIR_10_G}
     Power On

--- a/platform-configs/include/protectli-vp32xx.robot
+++ b/platform-configs/include/protectli-vp32xx.robot
@@ -9,5 +9,6 @@ ${FLASH_SIZE}=              ${16*1024*1024}
 ${MAX_CPU_TEMP}=            82
 ${DEVICE_USB_KEYBOARD}=     Logitech, Inc. Keyboard K120
 ${ETHERNET_ID}=             8086:125c
+@{ETH_PERF_PAIR_2_G}=       enp2s0    enp4s0
 
 ${SENSORS_CONFIG_FILE}=     include/sensors/default-sensors-config.yaml

--- a/platform-configs/protectli-v1210.robot
+++ b/platform-configs/protectli-v1210.robot
@@ -15,3 +15,4 @@ ${PLATFORM_RAM_SIZE}=           4096
 @{ETH_PORTS}=                   64-62-66-2f-00-12
 ...                             64-62-66-2f-00-13
 ${ETHERNET_ID}=                 8086:125c
+@{ETH_PERF_PAIR_2_G}=           eno0    eno1

--- a/platform-configs/protectli-v1211.robot
+++ b/platform-configs/protectli-v1211.robot
@@ -15,3 +15,4 @@ ${PLATFORM_RAM_SIZE}=           8192
 @{ETH_PORTS}=                   64-62-66-2f-07-d2
 ...                             64-62-66-2f-07-d3
 ${ETHERNET_ID}=                 8086:125c
+@{ETH_PERF_PAIR_2_G}=           eno0    eno1


### PR DESCRIPTION
Semi-manual 2.5G network performance test for platforms with two ethernet ports.

[network-speed_2025_04_18_11_04_29_vp3210.zip](https://github.com/user-attachments/files/19810777/network-speed_2025_04_18_11_04_29_vp3210.zip)
[network-speed_2025_04_18_11_01_03_vp3230.zip](https://github.com/user-attachments/files/19810785/network-speed_2025_04_18_11_01_03_vp3230.zip)
[network-speed_2025_04_18_11_05_51_vp6650.zip](https://github.com/user-attachments/files/19810783/network-speed_2025_04_18_11_05_51_vp6650.zip)
