### PR TITLE
dasharo-compatibility/custom-boot-order.robot: Add new test suite

### DIFF
--- a/dasharo-compatibility/custom-boot-order.robot
+++ b/dasharo-compatibility/custom-boot-order.robot
@@ -1,0 +1,21 @@
+*** Settings ***
+Resource            ../lib/platform/power.robot
+Resource            ../lib/platform/boot.robot
+
+Suite Setup         Prepare Test Suite
+Suite Teardown      Log Out And Close Connection
+
+
+*** Test Cases ***
+CBO001.101 Custom Boot Order (EDK2)
+    [Documentation]    Check if customization of Boot Order persists and
+    ...    correct OS boots.
+    Depends On    ${TESTS_IN_FIRMWARE_SUPPORT}
+
+    Power Cycle Into Firmware Setup
+    Set Selected OS As First In Boot Order Via EDK2    ${ENV_ID_UBUNTU}
+    Verify Selected OS As First In Boot Order Via EDK2    ${ENV_ID_UBUNTU}
+
+    Power Cycle Into Firmware Setup
+    Set Selected OS As First In Boot Order Via EDK2    ${ENV_ID_WINDOWS}
+    Verify Selected OS As First In Boot Order Via EDK2    ${ENV_ID_WINDOWS}

--- a/dasharo-performance/fast-boot.robot
+++ b/dasharo-performance/fast-boot.robot
@@ -2,6 +2,7 @@
 Library             Telnet    timeout=20 seconds    connection_timeout=120 seconds
 Library             SSHLibrary    timeout=90 seconds
 Resource            ../lib/platform/boot.robot
+Resource            ../lib/cbmem.robot
 
 Suite Setup         Initialize Fast Boot Suite
 Suite Teardown      Log Out And Close Connection
@@ -85,7 +86,8 @@ Measure FW Boot Time On Linux
     Log To Console    \n
 
     FOR    ${index}    IN RANGE    0    ${iterations}
-        Power Cycle On
+        Execute Reboot Command    linux    ${True}
+        Sleep    5s
         Login To Linux
         Switch To Root User
         ${boot_time}=    Get FW Boot Time From Systemd-analyze

--- a/dasharo-performance/fast-boot.robot
+++ b/dasharo-performance/fast-boot.robot
@@ -1,16 +1,7 @@
 *** Settings ***
-Library             Collections
-Library             OperatingSystem
-Library             Process
-Library             String
 Library             Telnet    timeout=20 seconds    connection_timeout=120 seconds
 Library             SSHLibrary    timeout=90 seconds
-Library             RequestsLibrary
-# TODO: maybe have a single file to include if we need to include the same
-# stuff in all test cases
-Resource            ../variables.robot
-Resource            ../keywords.robot
-Resource            ../keys.robot
+Resource            ../lib/platform/boot.robot
 
 Suite Setup         Initialize Fast Boot Suite
 Suite Teardown      Log Out And Close Connection
@@ -130,27 +121,4 @@ Initialize Fast Boot Suite
     Prepare Test Suite
     Skip If    not ${FAST_AND_QUIET_BOOT_SUPPORT}    Boot performance measurement tests not supported
     Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    Boot performance measurement tests not supported
-
-    Boot System Or From Connected Disk    ${ENV_ID_UBUNTU}
-    Login To Linux
-    Switch To Root User
-
-    ${ubuntu_boot_id}=    Execute Linux Command
-    ...    efibootmgr | grep -i "ubuntu" | awk 'NR==1 {print $1}' | sed 's/Boot//g' | sed 's/*//g'
-    Should Not Be Empty    ${ubuntu_boot_id}
-
-    ${order_check}=    Execute Linux Command
-    ...    efibootmgr | grep "BootOrder: ${ubuntu_boot_id}"
-
-    IF    '${order_check}' == '${EMPTY}'
-        ${boot_order_no_ubuntu}=    Execute Linux Command
-        ...    efibootmgr | grep "BootOrder" | awk '{print $2}' | sed -e 's/,${ubuntu_boot_id}//g'
-        Should Not Be Empty    ${boot_order_no_ubuntu}
-
-        ${set_order_cmd}=    Set Variable    efibootmgr -o
-        ${set_order_cmd}=    Catenate    ${set_order_cmd}
-        ...    ${ubuntu_boot_id},${boot_order_no_ubuntu}
-
-        ${out}=    Execute Linux Command    ${set_order_cmd}
-        Should Contain    ${out}    BootOrder: ${ubuntu_boot_id}
-    END
+    Set Selected OS As First In Boot Order Via Efibootmgr    ${ENV_ID_UBUNTU}

--- a/keys.robot
+++ b/keys.robot
@@ -23,3 +23,4 @@ ${ENTER}=           \x0d
 ${BACKSPACE}=       \x08
 ${KEY_SPACE}=       \x20
 ${DELETE}=          \x1b\x5b\x33\x7e
+${KEY_PLUS}=        \x2b

--- a/keywords.robot
+++ b/keywords.robot
@@ -762,11 +762,11 @@ Execute Poweroff Command
 
 Execute Reboot Command
     [Documentation]    Executes reboot command in given os
-    [Arguments]    ${os}=linux
+    [Arguments]    ${os}=linux    ${assume_correct_boot}=${False}
     IF    '${os}' == 'linux'
         # if the OS cannot be chosen from the bootmanager and rebooting
         # always boots the default one
-        IF    '${OPTIONS_LIB}' == 'options-lib_dcu'
+        IF    '${OPTIONS_LIB}' == 'options-lib_dcu' and ${assume_correct_boot} == ${False}
             Set Nextboot    ${BOOTED_OS_ID}
             Import Variables    ${CURDIR}/os-config/${BOOTED_OS_ID}-credentials.py
             Set Suite Variable    ${BOOTED_OS_ID}    ${BOOTED_OS_ID}

--- a/lib/platform/boot.robot
+++ b/lib/platform/boot.robot
@@ -1,0 +1,167 @@
+*** Settings ***
+Documentation       Common header for OSFV boot management
+
+Library             Collections
+Library             OperatingSystem
+Library             Process
+Library             String
+Library             RequestsLibrary
+Library             SSHLibrary
+Resource            ../../variables.robot
+Resource            ../../keywords.robot
+Resource            ../../keys.robot
+
+
+*** Keywords ***
+Set Selected OS As First In Boot Order Via EDK2
+    [Documentation]    Uses EDK2 menu to select given OS as first in
+    ...    boot menu.
+    ...
+    ...    === Requirements ===
+    ...    - Serial port connection has to be supported by the platform
+    ...    - Must be within Dasharo's main UEFI firmware setup
+    ...
+    ...    === Arguments ===
+    ...    - ``${os}``: ``string`` - ENV_ID of the OS we want to boot
+    ...
+    ...    === Return Value ===
+    ...    - None
+    ...
+    ...    === Effects ===
+    ...    - OS specified by ENV_ID will be priority during subsequent boots
+    ...    - Resets the DUT via EDK2 reset
+    [Arguments]    ${os}
+    ${system_name}=    Get From Dictionary    ${ENV_ID_OS_BOOTMENU_NAMES}    ${os}
+
+    # When ESP scanning feature is there, boot entries are named differently than
+    # they used to
+    IF    ${ESP_SCANNING_SUPPORT} == ${TRUE}
+        IF    "${system_name}" == "ubuntu"
+            ${system_name}=    Set Variable    Ubuntu
+        ELSE IF    "${system_name}" == "fedora"
+            ${system_name}=    Set Variable    Fedora
+        ELSE IF    "${system_name}" == "trenchboot" and "${MANUFACTURER}" == "QEMU"
+            ${system_name}=    Set Variable    QEMU HARDDISK
+        END
+    END
+
+    ${menu}=    Get Setup Menu Construction
+    ${menu}=    Enter Submenu From Snapshot And Return Construction
+    ...    ${menu}
+    ...    Boot Maintenance Manager
+    ${menu}=    Enter Submenu From Snapshot And Return Construction
+    ...    ${menu}
+    ...    Boot Options
+    ${menu}=    Enter Submenu From Snapshot And Return Construction
+    ...    ${menu}
+    ...    Change Boot Order
+    Press Enter
+    ${os_list_raw}=    Read From Terminal Until    ---/
+    ${os_list}=    Extract Strings From Frame    ${os_list_raw}
+    ${first_item}=    Set Variable    ${os_list}[0]
+    ${is_first}=    Run Keyword And Return Status    Should Contain    ${first_item}    ${system_name}
+
+    IF    '${is_first}' == 'False'
+        ${index}=    Set Variable    -1
+        FOR    ${i}    ${item}    IN ENUMERATE    @{os_list}
+            ${item_lower}=    Convert To Lowercase    ${item}
+            ${system_lower}=    Convert To Lowercase    ${system_name}
+            ${found}=    Run Keyword And Return Status    Should Contain    ${item_lower}    ${system_lower}
+            IF    '${found}' == 'True'
+                ${index}=    Set Variable    ${i}
+                BREAK
+            END
+        END
+
+        Should Not Be Equal As Integers    ${index}    -1
+        ...    System name '${system_name}' not found in boot menu list
+
+        Press Key N Times    ${index}    ${ARROW_DOWN}
+        Press Key N Times    ${index}    ${KEY_PLUS}
+        Press Enter
+        Write Bare Into Terminal    ${F10}
+        Sleep    1s
+        Write Bare Into Terminal    y
+        # Return to main menu
+        Press Key N Times    3    ${ESC}
+        Sleep    1s
+        # Issue reset in the menu
+        Press Key N Times    2    ${ARROW_DOWN}
+        Press Enter
+    END
+
+Set Selected OS As First In Boot Order Via Efibootmgr
+    [Documentation]    Uses Ubuntu and efibootmgr to select boot prioroty
+    ...
+    ...    === Requirements ===
+    ...    - Connection to DUT must be established.
+    ...    - Platform must boot Ubuntu to access efibootmgr
+    ...
+    ...    === Arguments ===
+    ...    - ``${os}``: ``string`` - ENV_ID of the OS we want to boot
+    ...
+    ...    === Return Value ===
+    ...    - None
+    ...
+    ...    === Effects ===
+    ...    - OS specified by ENV_ID will be priority during subsequent
+    [Arguments]    ${os}
+    ${system_name}=    Get From Dictionary    ${ENV_ID_OS_BOOTMENU_NAMES}    ${os}
+
+    Boot System Or From Connected Disk    ${ENV_ID_UBUNTU}
+    Login To Linux
+    Switch To Root User
+
+    ${os_boot_id}=    Execute Linux Command
+    ...    efibootmgr | grep -i "${system_name}" | awk 'NR==1 {print $1}' | sed 's/Boot//g' | sed 's/*//g'
+    Should Not Be Empty    ${os_boot_id}
+
+    ${order_check}=    Execute Linux Command
+    ...    efibootmgr | grep "BootOrder: ${os_boot_id}"
+
+    # Trim the boot list to exclude target OS
+    IF    '${order_check}' == '${EMPTY}'
+        ${boot_order_trimmed}=    Execute Linux Command
+        ...    efibootmgr | grep "BootOrder" | awk '{print $2}' | sed -e 's/,${os_boot_id}//g'
+        Should Not Be Empty    ${boot_order_trimmed}
+
+        ${set_order_cmd}=    Set Variable    efibootmgr -o
+        ${set_order_cmd}=    Catenate    ${set_order_cmd}
+        ...    ${os_boot_id},${boot_order_trimmed}
+
+        ${out}=    Execute Linux Command    ${set_order_cmd}
+        Should Contain    ${out}    BootOrder: ${os_boot_id}
+    END
+
+Verify Selected OS As First In Boot Order Via EDK2
+    [Documentation]    Uses dasharo edk2 boot menu to check first OS
+    ...    in the boot order
+    ...    === Requirements ===
+    ...    - Must be run in quick succession after Powering On
+    ...
+    ...    === Arguments ===
+    ...    - ``${os}``: ``string`` - ENV_ID of the OS we want to check
+    ...
+    ...    === Return Value ===
+    ...    - None
+    ...
+    ...    === Effects ===
+    ...    - Fails if specified OS is not first boot entry
+    [Arguments]    ${os}
+    ${system_name}=    Get From Dictionary    ${ENV_ID_OS_BOOTMENU_NAMES}    ${os}
+
+    # When ESP scanning feature is there, boot entries are named differently than
+    # they used to
+    IF    ${ESP_SCANNING_SUPPORT} == ${TRUE}
+        IF    "${system_name}" == "ubuntu"
+            ${system_name}=    Set Variable    Ubuntu
+        ELSE IF    "${system_name}" == "fedora"
+            ${system_name}=    Set Variable    Fedora
+        ELSE IF    "${system_name}" == "trenchboot" and "${MANUFACTURER}" == "QEMU"
+            ${system_name}=    Set Variable    QEMU HARDDISK
+        END
+    END
+
+    ${boot_menu}=    Enter Boot Menu Tianocore And Return Construction
+    ${top_os}=    Get From List    ${boot_menu}    0
+    Should Contain    ${top_os}    ${system_name}


### PR DESCRIPTION
Additionally, create new lib entry for boot order mgmt keywords.

[custom-boot-order_2025_04_28_17_00_13.zip](https://github.com/user-attachments/files/19942345/custom-boot-order_2025_04_28_17_00_13.zip)


Commit 3ab27c45ec7af8697ed353aa14c6b98b7d4c3111 breaks Fast Boot tests, so a workaround was introduced in 39f2c94856dea2acff9f01faa3ac54c11f300583


[fast-boot_2025_04_28_16_49_53.zip](https://github.com/user-attachments/files/19942228/fast-boot_2025_04_28_16_49_53.zip)
(Test failed due to unrelated error with SnipeIT parsing)
