### PR TITLE
platform-configs/include/protectli-vp32xx.robot: ME menu tests enabled.

### DIFF
--- a/platform-configs/include/protectli-vp32xx.robot
+++ b/platform-configs/include/protectli-vp32xx.robot
@@ -4,11 +4,13 @@ Resource    protectli-common.robot
 
 
 *** Variables ***
-${FLASH_SIZE}=              ${16*1024*1024}
+${FLASH_SIZE}=                          ${16*1024*1024}
 
-${MAX_CPU_TEMP}=            82
-${DEVICE_USB_KEYBOARD}=     Logitech, Inc. Keyboard K120
-${ETHERNET_ID}=             8086:125c
-@{ETH_PERF_PAIR_2_G}=       enp2s0    enp4s0
+${MAX_CPU_TEMP}=                        82
+${DEVICE_USB_KEYBOARD}=                 Logitech, Inc. Keyboard K120
+${ETHERNET_ID}=                         8086:125c
+@{ETH_PERF_PAIR_2_G}=                   enp2s0    enp4s0
 
-${SENSORS_CONFIG_FILE}=     include/sensors/default-sensors-config.yaml
+${SENSORS_CONFIG_FILE}=                 include/sensors/default-sensors-config.yaml
+
+${DASHARO_INTEL_ME_MENU_SUPPORT}=       ${TRUE}


### PR DESCRIPTION
DASHARO_INTEL_ME_MENU_SUPPORT set to TRUE for vp32xx platforms.