### PR TITLE
Osfv ci tests scope determining

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/other_changes.md
+++ b/.github/PULL_REQUEST_TEMPLATE/other_changes.md
@@ -1,0 +1,10 @@
+<!--
+SPDX-FileCopyrightText: 2024 3mdeb <contact@3mdeb.com>
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<!-- markdownlint-disable MD041 -->
+## Short description
+
+## Related Issue(s)

--- a/.github/PULL_REQUEST_TEMPLATE/tests.md
+++ b/.github/PULL_REQUEST_TEMPLATE/tests.md
@@ -1,0 +1,23 @@
+<!--
+SPDX-FileCopyrightText: 2024 3mdeb <contact@3mdeb.com>
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<!-- markdownlint-disable MD041 -->
+## Short description
+
+## Related Issue(s)
+
+## Checklist
+
+- [ ] When modifying `platform-configs/`, the minimal regression passes on all
+      of the affected devices.
+      (`scripts/regression.sh` -- -i minimal-regression`)
+    + [ ] <logs_device_1.zip>
+    + [ ] <logs_device_2.zip>
+
+- [ ] All of the changes in test case IDs, including adding new ones, were
+      propagated to the OSFV Dashboard
+    + [ ] <TEST_ID_1>
+    + [ ] <TEST_ID_2>

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ dbbot-sqlalchemy==0.2
 distlib==0.3.8
 Faker==24.11.0
 filelock==3.13.4
+fire==0.7.0
 fonttools==4.56.0
 git-cliff==2.6.1
 greenlet==3.1.1

--- a/scripts/ci/regression-scope/lib/parser_manager.py
+++ b/scripts/ci/regression-scope/lib/parser_manager.py
@@ -3,29 +3,106 @@
 # SPDX-FileCopyrightText: 2025 3mdeb <contact@3mdeb.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-
-import json
-import os
-import subprocess
-import sys
-
-import fire
+from collections import defaultdict
 
 from lib.rules_parser import RuleParser
 
 
 class ParserManager:
-    def __init__(self, rules_file, changed_files):
-        self.rules_file = rules_file
+    """
+    Runs rule parsers on the rules file and presents the parsing results.
+    """
+
+    def __init__(self, rules, changed_files):
+        self.rules = rules
         self.changed_files = changed_files
+        self.runs_data = None
+        self.parse()
+
+    def _assemble_robot_command(self, files, robot_args=[]):
+        """
+        Assembles the command to run given test suites with given args.
+        """
+        command = ["scripts/run.sh"]
+        command += sorted(files)
+        if len(robot_args) > 0:
+            command.append("--")
+            command += robot_args
+        return command
+
+    def _assemble_commands_from_runs_data(self, runs_data):
+        """
+        Assembles all the commands for the rules file
+        """
+        commands = []
+        for data in runs_data:
+            if len(data["env"]) > 0:
+                commands.append(data["env"])
+            if len(data["files"]) > 0:
+                commands.append(
+                    self._assemble_robot_command(data["files"], data["args"])
+                )
+            else:
+                commands.append(data["command"])
+        return commands
+
+    def _uniqeuify_runs_data(self, parser_runs_data, by=["env", "args"]):
+        """
+        Group the runs_data by `by` parameter.
+        For every unique `by` gathers unique tests to be performed.
+        Makes sure that a test is repeated for every unique combination of `by`
+            fields, but no more.
+        Important when multiple rules would result in running one test suite
+            with the exact same env variables and robot args.
+        """
+        unique_scenarios = defaultdict(list)
+        for data in parser_runs_data:
+            key = tuple([tuple(data[key]) for key in by])
+            unique_scenarios[key].append(data)
+        uniqueified_runs_data = []
+        for key, runs in unique_scenarios.items():
+            joined = defaultdict(list)
+            for i in range(len(by)):
+                joined[by[i]] = list(key[i])  # copy keys
+            for data in runs:
+                joined["files"] += data["files"]
+                joined["command"] += data["command"]
+            joined["files"] = list(set(joined["files"]))
+            uniqueified_runs_data.append(joined)
+        return uniqueified_runs_data
+
+    def files(self):
+        """
+        Return a list of unique filenames matched by rules
+        """
+        files = []
+        for data in self.runs_data:
+            files += data["files"]
+        return sorted(list(set(files)))
+
+    def commands(self):
+        """
+        Return a list of lines of commands for the parsed rules.
+        Each line is one command.
+        """
+        uniquified = self._uniqeuify_runs_data(self.runs_data, ["env", "args"])
+        return self._assemble_commands_from_runs_data(uniquified)
+
+    def wrapper_args(self):
+        """
+        Return a list of lines containing args to `run.sh` according to the
+            parsed rules.
+        One line is one run.sh call
+        """
+        uniquified = self._uniqeuify_runs_data(self.runs_data, ["args"])
+        return [" ".join(data["files"]) + " ".join(data["args"]) for data in uniquified]
 
     def parse(self):
-        parser_commands = []
-        parser_files = []
-        parser_args = []
+        """
+        Parse the rules file. Call before any other method
+        """
+        self.runs_data = []
         for rule in self.rules:
             parser = RuleParser(rule, self.changed_files)
             parser.match_rule()
-            parser_commands.append(parser.commands)
-            parser_files.append(parser.test_files)
-            parser_args.append(parser.robot_args)
+            self.runs_data += parser.runs_data

--- a/scripts/ci/regression-scope/lib/parser_manager.py
+++ b/scripts/ci/regression-scope/lib/parser_manager.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2025 3mdeb <contact@3mdeb.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+import subprocess
+import sys
+
+import fire
+
+from lib.rules_parser import RuleParser
+
+
+class ParserManager:
+    def __init__(self, rules_file, changed_files):
+        self.rules_file = rules_file
+        self.changed_files = changed_files
+
+    def parse(self):
+        parser_commands = []
+        parser_files = []
+        parser_args = []
+        for rule in self.rules:
+            parser = RuleParser(rule, self.changed_files)
+            parser.match_rule()
+            parser_commands.append(parser.commands)
+            parser_files.append(parser.test_files)
+            parser_args.append(parser.robot_args)

--- a/scripts/ci/regression-scope/lib/rules_parser.py
+++ b/scripts/ci/regression-scope/lib/rules_parser.py
@@ -25,7 +25,7 @@ class RuleParser:
         self.matched_files = []
         self.matched_paths = []
         self.commands = []
-        self.tests = []
+        self.test_files = []
         self.env = os.environ.copy()
 
     def init_devices_command(self):
@@ -42,8 +42,10 @@ class RuleParser:
         Returns an `env` dictionary representing the bash environment
         with the variables defined in the `env_vars` section of the rule set.
         """
-        vars_dict = self.rule["run"]["env_vars"]
         env = os.environ.copy()
+        if "env_vars" not in self.rule["run"]:
+            return env
+        vars_dict = self.rule["run"]["env_vars"]
         for k in vars_dict.keys():
             env[k] = vars_dict[k]
         if self.rule["run"]["device"] == "qemu":
@@ -56,6 +58,8 @@ class RuleParser:
         according to the `env_vars` section of the rule.
         """
         commands = []
+        if "env_vars" not in self.rule["run"]:
+            return commands
         vars_dict = self.rule["run"]["env_vars"]
         for k in vars_dict.keys():
             commands.append(f"export {k}={vars_dict[k]}")
@@ -119,15 +123,16 @@ class RuleParser:
         Returns a robot command to run the tests.
         """
         run_dict = self.rule["run"]
-        self.tests = self.get_files_choice(run_dict["files"])
+        if "files" in run_dict:
+            self.test_files = self.get_files_choice(run_dict["files"])
 
         if "custom_command" in run_dict:
             return run_dict["custom_command"].split(" ")
 
         robot_args = []
-        if run_dict["snipeit"] == "no":
+        if "snipeit" in run_dict and run_dict["snipeit"] == "no":
             robot_args += ["-v", "snipeit:no"]
-        return self.assemble_robot_command(self.tests, robot_args=robot_args)
+        return self.assemble_robot_command(self.test_files, robot_args=robot_args)
 
     def match_rule(self):
         """
@@ -153,6 +158,8 @@ class RuleParser:
         if len(self.matched_files) < 1:
             return False
 
-        self.commands.append(self.get_env_modification_commands())
+        env_cmd = self.get_env_modification_commands()
+        if len(env_cmd) > 0:
+            self.commands.append(env_cmd)
         self.commands.append(self.parse_run())
         return True

--- a/scripts/ci/regression-scope/lib/rules_parser.py
+++ b/scripts/ci/regression-scope/lib/rules_parser.py
@@ -128,8 +128,9 @@ class RuleParser:
 
         if "custom_command" in run_dict:
             return run_dict["custom_command"].split(" ")
-
         robot_args = []
+        if "robot_args" in run_dict:
+            robot_args.extend(run_dict["robot_args"].split(" "))
         if "snipeit" in run_dict and run_dict["snipeit"] == "no":
             robot_args += ["-v", "snipeit:no"]
         return self.assemble_robot_command(self.test_files, robot_args=robot_args)

--- a/scripts/ci/regression-scope/lib/rules_parser.py
+++ b/scripts/ci/regression-scope/lib/rules_parser.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2025 3mdeb <contact@3mdeb.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import re
+
+RULES_TAG_MATCHED_FILENAME = "${MATCHED_FILENAME}"
+RULES_TAG_FULL_MATCH = "${FULL_MATCH}"
+RULES_TAG_CONTAINING_FILENAME = "${CONTAINING_MATCHES}"
+RULES_TAG_CONTAINS_REGEX = "${CONTENT_MATCH_REGEX}"
+
+
+class RuleParser:
+    """
+    Class for parsing the rules file in order to create a list of commands
+    that need to be executed to ensure the changes in OSFV didn't break anything
+    """
+
+    def __init__(self, rule, changed_files):
+        self.rule = rule
+        self.changed_files = changed_files
+        self.matched_files = []
+        self.matched_paths = []
+        self.commands = []
+        self.tests = []
+        self.env = os.environ.copy()
+
+    def init_devices_command(self):
+        """
+        Returns a list of commands to initialize devices
+        """
+        if self.rule["run"]["device"] == "qemu":
+            cmd = ["scripts/ci/qemu-run.sh", "graphic", "os"]
+            return cmd
+        return []
+
+    def get_modified_env(self):
+        """
+        Returns an `env` dictionary representing the bash environment
+        with the variables defined in the `env_vars` section of the rule set.
+        """
+        vars_dict = self.rule["run"]["env_vars"]
+        env = os.environ.copy()
+        for k in vars_dict.keys():
+            env[k] = vars_dict[k]
+        if self.rule["run"]["device"] == "qemu":
+            env["DIR"] = "scripts/ci/"
+        return env
+
+    def get_env_modification_commands(self):
+        """
+        Returns a list of commands to set environment variables
+        according to the `env_vars` section of the rule.
+        """
+        commands = []
+        vars_dict = self.rule["run"]["env_vars"]
+        for k in vars_dict.keys():
+            commands.append(f"export {k}={vars_dict[k]}")
+        return commands
+
+    def get_test_files_in_dirs(self, search_in):
+        """
+        Helper function to get all test files in the given list of directories.
+        """
+        test_files = []
+        for module in search_in:
+            for root, _, files in os.walk(module):
+                for file in files:
+                    if file.split(".")[-1] == "robot":
+                        path = os.path.join(root, file)
+                        test_files.append(path)
+        return test_files
+
+    def get_files_choice(self, files_choice):
+        """
+        Returns a list of test files to run according to the `files` section
+        """
+        if files_choice["mode"] == RULES_TAG_MATCHED_FILENAME:
+            return self.matched_files
+        elif files_choice["mode"] == RULES_TAG_FULL_MATCH:
+            return self.matched_paths
+        elif files_choice["mode"] == RULES_TAG_CONTAINING_FILENAME:
+            test_files = self.get_test_files_in_dirs(files_choice["search_in"])
+            changes_in_deps = []
+            for file in test_files:
+                with open(file, "r") as f:
+                    for lib in self.matched_files:
+                        if lib in f.read():
+                            changes_in_deps.append(file)
+            return changes_in_deps
+        elif files_choice["mode"] == RULES_TAG_CONTAINS_REGEX:
+            test_files = self.get_test_files_in_dirs(files_choice["search_in"])
+            regex = re.compile(files_choice["regex"])
+            matching = []
+            for file in test_files:
+                with open(file, "r") as f:
+                    if regex.search(f.read()) is not None:
+                        matching.append(file)
+            return matching
+
+    def assemble_robot_command(self, files, robot_args=[]):
+        """
+        Assembles the command to run given test suites with given args.
+        """
+        command = ["scripts/run.sh"]
+        command += files
+        if len(robot_args) > 0:
+            command.append("--")
+            command += robot_args
+        return command
+
+    def parse_run(self):
+        """
+        Parses the `run` section of the rule which means running robot on
+        the files.
+        Returns a robot command to run the tests.
+        """
+        run_dict = self.rule["run"]
+        self.tests = self.get_files_choice(run_dict["files"])
+
+        if "custom_command" in run_dict:
+            return run_dict["custom_command"].split(" ")
+
+        robot_args = []
+        if run_dict["snipeit"] == "no":
+            robot_args += ["-v", "snipeit:no"]
+        return self.assemble_robot_command(self.tests, robot_args=robot_args)
+
+    def match_rule(self):
+        """
+        Matches one rule in rules.json.
+        Finds matching files and returns a list of commands to run
+        According to the rule.
+        """
+        reg = re.compile(self.rule["on-changed"])
+        self.matched_files = []
+        self.matched_paths = []
+
+        if self.rule["run"] is None:
+            print("No `run` section in the rule")
+            return False
+
+        for line in self.changed_files:
+            match = reg.match(line)
+            if match is None:
+                continue
+            self.matched_paths.append(match.group(0))
+            self.matched_files.append(match.group(1))
+
+        if len(self.matched_files) < 1:
+            return False
+
+        self.commands.append(self.get_env_modification_commands())
+        self.commands.append(self.parse_run())
+        return True

--- a/scripts/ci/regression-scope/lib/rules_parser.py
+++ b/scripts/ci/regression-scope/lib/rules_parser.py
@@ -7,10 +7,10 @@
 import os
 import re
 
-RULES_TAG_MATCHED_FILENAME = "${MATCHED_FILENAME}"
-RULES_TAG_FULL_MATCH = "${FULL_MATCH}"
-RULES_TAG_CONTAINING_FILENAME = "${CONTAINING_MATCHES}"
-RULES_TAG_CONTAINS_REGEX = "${CONTENT_MATCH_REGEX}"
+RULES_TAG_MATCHED_FILENAME = "${FILENAME_MATCH}"
+RULES_TAG_FULL_MATCH = "${FULL_FILENAME_MATCH}"
+RULES_TAG_CONTAINING_FILENAME = "${FILE_CONTAINS_MATCH}"
+RULES_TAG_CONTAINS_REGEX = "${FILE_CONTAINS_REGEX}"
 
 
 class RuleParser:
@@ -29,39 +29,15 @@ class RuleParser:
         self.robot_args = []
         self.env = os.environ.copy()
 
-    def init_devices_command(self):
-        """
-        Returns a list of commands to initialize devices
-        """
-        if self.rule["run"]["device"] == "qemu":
-            cmd = ["scripts/ci/qemu-run.sh", "graphic", "os"]
-            return cmd
-        return []
-
-    def get_modified_env(self):
-        """
-        Returns an `env` dictionary representing the bash environment
-        with the variables defined in the `env_vars` section of the rule set.
-        """
-        env = os.environ.copy()
-        if "env_vars" not in self.rule["run"]:
-            return env
-        vars_dict = self.rule["run"]["env_vars"]
-        for k in vars_dict.keys():
-            env[k] = vars_dict[k]
-        if self.rule["run"]["device"] == "qemu":
-            env["DIR"] = "scripts/ci/"
-        return env
-
-    def get_env_modification_commands(self):
+    def get_env_modification_commands(self, run):
         """
         Returns a list of commands to set environment variables
-        according to the `env_vars` section of the rule.
+        according to the `env_vars` section of the given "run" of a rule.
         """
         commands = []
-        if "env_vars" not in self.rule["run"]:
+        if "env_vars" not in run:
             return commands
-        vars_dict = self.rule["run"]["env_vars"]
+        vars_dict = run["env_vars"]
         for k in vars_dict.keys():
             commands.append(f"export {k}={vars_dict[k]}")
         return commands
@@ -124,17 +100,24 @@ class RuleParser:
         Returns a robot command to run the tests.
         """
         run_dict = self.rule["run"]
-        if "files" in run_dict:
-            self.test_files = self.get_files_choice(run_dict["files"])
-
-        if "custom_command" in run_dict:
-            return run_dict["custom_command"].split(" ")
-        self.robot_args = []
-        if "robot_args" in run_dict:
-            self.robot_args.extend(run_dict["robot_args"].split(" "))
-        if "snipeit" in run_dict and run_dict["snipeit"] == "no":
-            self.robot_args += ["-v", "snipeit:no"]
-        return self.assemble_robot_command(self.test_files, robot_args=self.robot_args)
+        commands = []
+        for run in run_dict:
+            if "env_vars" in run:
+                commands.append(self.get_env_modification_commands(run))
+            if "files" in run:
+                self.test_files = self.get_files_choice(run["files"])
+            if "custom_command" in run:
+                commands.append(run["custom_command"].split(" "))
+                continue
+            self.robot_args = []
+            if "robot_args" in run:
+                self.robot_args.extend(run["robot_args"].split(" "))
+            if "snipeit" in run and run["snipeit"] == "no":
+                self.robot_args += ["-v", "snipeit:no"]
+            commands.append(
+                self.assemble_robot_command(self.test_files, robot_args=self.robot_args)
+            )
+        return commands
 
     def match_rule(self):
         """
@@ -160,8 +143,5 @@ class RuleParser:
         if len(self.matched_files) < 1:
             return False
 
-        env_cmd = self.get_env_modification_commands()
-        if len(env_cmd) > 0:
-            self.commands.append(env_cmd)
-        self.commands.append(self.parse_run())
+        self.commands += self.parse_run()
         return True

--- a/scripts/ci/regression-scope/lib/rules_parser.py
+++ b/scripts/ci/regression-scope/lib/rules_parser.py
@@ -26,6 +26,7 @@ class RuleParser:
         self.matched_paths = []
         self.commands = []
         self.test_files = []
+        self.robot_args = []
         self.env = os.environ.copy()
 
     def init_devices_command(self):
@@ -128,12 +129,12 @@ class RuleParser:
 
         if "custom_command" in run_dict:
             return run_dict["custom_command"].split(" ")
-        robot_args = []
+        self.robot_args = []
         if "robot_args" in run_dict:
-            robot_args.extend(run_dict["robot_args"].split(" "))
+            self.robot_args.extend(run_dict["robot_args"].split(" "))
         if "snipeit" in run_dict and run_dict["snipeit"] == "no":
-            robot_args += ["-v", "snipeit:no"]
-        return self.assemble_robot_command(self.test_files, robot_args=robot_args)
+            self.robot_args += ["-v", "snipeit:no"]
+        return self.assemble_robot_command(self.test_files, robot_args=self.robot_args)
 
     def match_rule(self):
         """

--- a/scripts/ci/regression-scope/lib/rules_parser.py
+++ b/scripts/ci/regression-scope/lib/rules_parser.py
@@ -6,6 +6,7 @@
 
 import os
 import re
+from collections import defaultdict
 
 RULES_TAG_MATCHED_FILENAME = "${FILENAME_MATCH}"
 RULES_TAG_FULL_MATCH = "${FULL_FILENAME_MATCH}"
@@ -24,10 +25,7 @@ class RuleParser:
         self.changed_files = changed_files
         self.matched_files = []
         self.matched_paths = []
-        self.commands = []
-        self.test_files = []
-        self.robot_args = []
-        self.env = os.environ.copy()
+        self.runs_data = []
 
     def get_env_modification_commands(self, run):
         """
@@ -39,7 +37,7 @@ class RuleParser:
             return commands
         vars_dict = run["env_vars"]
         for k in vars_dict.keys():
-            commands.append(f"export {k}={vars_dict[k]}")
+            commands += ["export", f"{k}={vars_dict[k]}"]
         return commands
 
     def get_test_files_in_dirs(self, search_in):
@@ -82,48 +80,48 @@ class RuleParser:
                         matching.append(file)
             return matching
 
-    def assemble_robot_command(self, files, robot_args=[]):
-        """
-        Assembles the command to run given test suites with given args.
-        """
-        command = ["scripts/run.sh"]
-        command += files
-        if len(robot_args) > 0:
-            command.append("--")
-            command += robot_args
-        return command
-
     def parse_run(self):
         """
         Parses the `run` section of the rule which means running robot on
         the files.
-        Returns a robot command to run the tests.
+        Returns a dict:
+        {
+            "env": export_env_vars_commands, might be None,
+            "files": list of test suite filenames
+            "command": optional ovevrride command, might be None,
+            "args": optional additional robot args list
+        }
         """
         run_dict = self.rule["run"]
-        commands = []
+        self.runs_data = []
         for run in run_dict:
+            run_data = {
+                "env": [],
+                "files": [],
+                "command": [],
+                "args": [],
+            }
             if "env_vars" in run:
-                commands.append(self.get_env_modification_commands(run))
+                run_data["env"] = self.get_env_modification_commands(run)
             if "files" in run:
-                self.test_files = self.get_files_choice(run["files"])
+                run_data["files"] = self.get_files_choice(run["files"])
             if "custom_command" in run:
-                commands.append(run["custom_command"].split(" "))
+                run_data["command"] = run["custom_command"].split(" ")
+                self.runs_data.append(run_data)
                 continue
-            self.robot_args = []
             if "robot_args" in run:
-                self.robot_args.extend(run["robot_args"].split(" "))
+                run_data["args"] = run["robot_args"].split(" ")
             if "snipeit" in run and run["snipeit"] == "no":
-                self.robot_args += ["-v", "snipeit:no"]
-            commands.append(
-                self.assemble_robot_command(self.test_files, robot_args=self.robot_args)
-            )
-        return commands
+                run_data["args"] += ["-v", "snipeit:no"]
+
+            self.runs_data.append(run_data)
+        return self.runs_data
 
     def match_rule(self):
         """
         Matches one rule in rules.json.
         Finds matching files and returns a list of commands to run
-        According to the rule.
+        According to the rule.runs_data
         """
         reg = re.compile(self.rule["on-changed"])
         self.matched_files = []
@@ -142,6 +140,11 @@ class RuleParser:
 
         if len(self.matched_files) < 1:
             return False
-
-        self.commands += self.parse_run()
+        self.runs_data = self.parse_run()
         return True
+
+    def commands(self):
+        return self.assemble_commands_from_runs_data(self.runs_data)
+
+    def files(self):
+        return self.get_files_from_runs_data(self.runs_data)

--- a/scripts/ci/regression-scope/osfv_regression_scope.py
+++ b/scripts/ci/regression-scope/osfv_regression_scope.py
@@ -83,6 +83,26 @@ class CLI:
                 subprocess.run(cmd, env=parser.env, stdout=sys.stdout)
 
 
+def robot_wrapper_args(
+    self, rules_file="scripts/ci/regression-scope/rules.json", compare_to="HEAD"
+):
+    """
+    Print the commands that should be executed to test the changes
+    """
+    with open(rules_file) as rules_file:
+        self.rules = json.load(rules_file)["rules"]
+    self.changed_files = get_changed_files(compare_to)
+    for rule in self.rules:
+        parser = RuleParser(rule, self.changed_files)
+        parser.match_rule()
+        out = ""
+        if len(parser.test_files) > 0:
+            out += " ".join(parser.test_files)
+            if len(parser.robot_args) > 0:
+                out += " -- " + " ".join(parser.robot_args)
+            print(out)
+
+
 if __name__ == "__main__":
     if "--help" in sys.argv or "-h" in sys.argv:
         # remove all arguments except the script name to print

--- a/scripts/ci/regression-scope/osfv_regression_scope.py
+++ b/scripts/ci/regression-scope/osfv_regression_scope.py
@@ -8,9 +8,11 @@ import json
 import os
 import subprocess
 import sys
+from pprint import pprint
 
 import fire
 
+from lib.parser_manager import ParserManager
 from lib.rules_parser import RuleParser
 
 
@@ -40,16 +42,14 @@ class CLI:
         self, rules_file="scripts/ci/regression-scope/rules.json", compare_to="HEAD"
     ):
         """
-        Print the filenames of test suites to be tested
+        Print the filenames of test suites that are affected by the changes
         """
         with open(rules_file) as rules_file:
             self.rules = json.load(rules_file)["rules"]
         self.changed_files = get_changed_files(compare_to)
-        for rule in self.rules:
-            parser = RuleParser(rule, self.changed_files)
-            parser.match_rule()
-            if len(parser.test_files) > 0:
-                print(" ".join(parser.test_files))
+        parser = ParserManager(self.rules, self.changed_files)
+        parser.parse()
+        print(" ".join(parser.files()))
 
     def commands(
         self, rules_file="scripts/ci/regression-scope/rules.json", compare_to="HEAD"
@@ -60,31 +60,23 @@ class CLI:
         with open(rules_file) as rules_file:
             self.rules = json.load(rules_file)["rules"]
         self.changed_files = get_changed_files(compare_to)
-        for rule in self.rules:
-            parser = RuleParser(rule, self.changed_files)
-            parser.match_rule()
-            if len(parser.commands) > 0:
-                for cmd in parser.commands:
-                    print(" ".join(cmd))
+        parser = ParserManager(self.rules, self.changed_files)
+        parser.parse()
+        print(" ".join(parser.commands()))
 
-    def robot_wrapper_args(
+    def robot_args(
         self, rules_file="scripts/ci/regression-scope/rules.json", compare_to="HEAD"
     ):
         """
-        Print the commands that should be executed to test the changes
+        Print the parameters that should be passed to the run.sh robot wrapper to
+        test the changes. Does not
         """
         with open(rules_file) as rules_file:
             self.rules = json.load(rules_file)["rules"]
         self.changed_files = get_changed_files(compare_to)
-        for rule in self.rules:
-            parser = RuleParser(rule, self.changed_files)
-            parser.match_rule()
-            out = ""
-            if len(parser.test_files) > 0:
-                out += " ".join(parser.test_files)
-                if len(parser.robot_args) > 0:
-                    out += " -- " + " ".join(parser.robot_args)
-                print(out)
+        parser = ParserManager(self.rules, self.changed_files)
+        parser.parse()
+        print(" ".join(parser.wrapper_args()))
 
 
 if __name__ == "__main__":

--- a/scripts/ci/regression-scope/osfv_regression_scope.py
+++ b/scripts/ci/regression-scope/osfv_regression_scope.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2025 3mdeb <contact@3mdeb.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+import subprocess
+import sys
+
+import fire
+
+from lib.rules_parser import RuleParser
+
+
+def run_command(cmd, env=os.environ.copy()):
+    """
+    Wrapper for subprocess.run to not repeat decoding the output too much
+    """
+    out = subprocess.run(cmd, capture_output=True, env=env)
+    out = out.stdout.decode("utf-8").splitlines()
+    return out
+
+
+def get_changed_files(compare_to):
+    """
+    Returns a list of filenames tracked by git that are modified
+    """
+    cmd_dirty = ["git", "diff", compare_to, "--name-only"]
+    cmd_cached = ["git", "diff", compare_to, "--name-only", "--cached"]
+    files_dirty = run_command(cmd_dirty)
+    files_cached = run_command(cmd_cached)
+    files = files_dirty + files_cached
+    return files
+
+
+class CLI:
+    def filenames(
+        self, rules_file="scripts/ci/regression-scope/rules.json", compare_to="HEAD"
+    ):
+        """
+        Print the filenames of test suites to be tested
+        """
+        with open(rules_file) as rules_file:
+            self.rules = json.load(rules_file)["rules"]
+        self.changed_files = get_changed_files(compare_to)
+        for rule in self.rules:
+            parser = RuleParser(rule, self.changed_files)
+            parser.match_rule()
+            if len(parser.test_files) > 0:
+                print(" ".join(parser.test_files))
+
+    def commands(
+        self, rules_file="scripts/ci/regression-scope/rules.json", compare_to="HEAD"
+    ):
+        """
+        Print the commands that should be executed to test the changes
+        """
+        with open(rules_file) as rules_file:
+            self.rules = json.load(rules_file)["rules"]
+        self.changed_files = get_changed_files(compare_to)
+        for rule in self.rules:
+            parser = RuleParser(rule, self.changed_files)
+            parser.match_rule()
+            if len(parser.commands) > 0:
+                for cmd in parser.commands:
+                    print(" ".join(cmd))
+
+    def execute(
+        self, rules_file="scripts/ci/regression-scope/rules.json", compare_to="HEAD"
+    ):
+        """
+        Run the test suites to be tested for the current changes
+        """
+        with open(self) as rules_file:
+            self.rules = json.load(rules_file)["rules"]
+        self.changed_files = get_changed_files(compare_to)
+        for rule in self.rules:
+            parser = RuleParser(rule, self.changed_files)
+            parser.match_rule()
+            for cmd in parser.commands:
+                subprocess.run(cmd, env=parser.env, stdout=sys.stdout)
+
+
+if __name__ == "__main__":
+    if "--help" in sys.argv or "-h" in sys.argv:
+        # remove all arguments except the script name to print
+        # fire generated help message
+        sys.argv = sys.argv[:1]
+    fire.Fire(CLI)

--- a/scripts/ci/regression-scope/osfv_regression_scope.py
+++ b/scripts/ci/regression-scope/osfv_regression_scope.py
@@ -67,40 +67,24 @@ class CLI:
                 for cmd in parser.commands:
                     print(" ".join(cmd))
 
-    def execute(
+    def robot_wrapper_args(
         self, rules_file="scripts/ci/regression-scope/rules.json", compare_to="HEAD"
     ):
         """
-        Run the test suites to be tested for the current changes
+        Print the commands that should be executed to test the changes
         """
-        with open(self) as rules_file:
+        with open(rules_file) as rules_file:
             self.rules = json.load(rules_file)["rules"]
         self.changed_files = get_changed_files(compare_to)
         for rule in self.rules:
             parser = RuleParser(rule, self.changed_files)
             parser.match_rule()
-            for cmd in parser.commands:
-                subprocess.run(cmd, env=parser.env, stdout=sys.stdout)
-
-
-def robot_wrapper_args(
-    self, rules_file="scripts/ci/regression-scope/rules.json", compare_to="HEAD"
-):
-    """
-    Print the commands that should be executed to test the changes
-    """
-    with open(rules_file) as rules_file:
-        self.rules = json.load(rules_file)["rules"]
-    self.changed_files = get_changed_files(compare_to)
-    for rule in self.rules:
-        parser = RuleParser(rule, self.changed_files)
-        parser.match_rule()
-        out = ""
-        if len(parser.test_files) > 0:
-            out += " ".join(parser.test_files)
-            if len(parser.robot_args) > 0:
-                out += " -- " + " ".join(parser.robot_args)
-            print(out)
+            out = ""
+            if len(parser.test_files) > 0:
+                out += " ".join(parser.test_files)
+                if len(parser.robot_args) > 0:
+                    out += " -- " + " ".join(parser.robot_args)
+                print(out)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/regression-scope/regression_scope_selftests.py
+++ b/scripts/ci/regression-scope/regression_scope_selftests.py
@@ -19,9 +19,9 @@ class TestMiscellaneous(unittest.TestCase):
                     {
                         "name": "Single match",
                         "on-changed": "(important-file.robot)",
-                        "run": {
+                        "run": [{
                             "custom_command": "echo hello"
-                        }
+                        }]
                     }
                 ]
             }"""
@@ -47,12 +47,12 @@ class TestMiscellaneous(unittest.TestCase):
                     {
                         "name": "Single match",
                         "on-changed": "(important-file.robot)",
-                        "run": {
+                        "run": [{
                             "files": {
-                                "mode": "${FULL_MATCH}"
+                                "mode": "${FULL_FILENAME_MATCH}"
                             },
                             "robot_args": "-i minimal-regression"
-                        }
+                        }]
                     }
                 ]
             }"""
@@ -78,6 +78,60 @@ class TestMiscellaneous(unittest.TestCase):
                 ],
             )
 
+    def test_mutliple_runs_one_rule(self):
+        rules = json.loads(
+            """
+            {
+                "rules": [
+                    {
+                        "name": "Single match",
+                        "on-changed": "(important-file.robot)",
+                        "run": [
+                            {
+                                "files": {
+                                    "mode": "${FULL_FILENAME_MATCH}"
+                                },
+                                "robot_args": "-i minimal-regression"
+                            },
+                            {
+                                "files": {
+                                    "mode": "${FULL_FILENAME_MATCH}"
+                                },
+                                "robot_args": "-i some_other:tag"
+                            }
+                        ]
+                    }
+                ]
+            }"""
+        )["rules"]
+        changed_files = [
+            "important-file.robot",
+            "dasharo-performance/boot-time-measure.robot",
+        ]
+        for rule in rules:
+            parser = RuleParser(rule, changed_files)
+            parser.match_rule()
+            self.assertEqual(parser.test_files, ["important-file.robot"])
+            self.assertEqual(
+                parser.commands,
+                [
+                    [
+                        "scripts/run.sh",
+                        "important-file.robot",
+                        "--",
+                        "-i",
+                        "minimal-regression",
+                    ],
+                    [
+                        "scripts/run.sh",
+                        "important-file.robot",
+                        "--",
+                        "-i",
+                        "some_other:tag",
+                    ],
+                ],
+            )
+
 
 class TestModulesRules(unittest.TestCase):
     rules = json.loads(
@@ -87,17 +141,17 @@ class TestModulesRules(unittest.TestCase):
                     {
                         "name": "Run changed test suites",
                         "on-changed": "dasharo-compatibility/(.*)",
-                        "run": {
+                        "run": [{
                             "env_vars": {
                                 "RTE_IP": "127.0.0.1",
                                 "FW_FILE": "scripts/ci/qemu_q35.rom",
                                 "CONFIG": "qemu"
                             },
                             "files": {
-                                "mode": "${FULL_MATCH}"
+                                "mode": "${FULL_FILENAME_MATCH}"
                             },
                             "snipeit": "no"
-                        }
+                        }]
                     }
                 ]
             }"""
@@ -180,13 +234,13 @@ class TestLibsRules(unittest.TestCase):
                 {
                     "name": "Run suites that use a modified lib",
                     "on-changed": "lib/(.*)",
-                    "run": {
+                    "run": [{
                         "files": {
-                            "mode": "${CONTAINING_MATCHES}",
+                            "mode": "${FILE_CONTAINS_MATCH}",
                             "search_in": ["dasharo-compatibility", "dasharo-security", "dasharo-performance", "dasharo-stability"]
                         },
                         "snipeit": "no"
-                    }
+                    }]
                 }
             ]
         }
@@ -303,24 +357,24 @@ class TestLibsMultipleRules(unittest.TestCase):
                 {
                     "name": "Run suites that use a modified lib",
                     "on-changed": "lib/(tpm.robot)",
-                    "run": {
+                    "run": [{
                         "files": {
-                            "mode": "${CONTAINING_MATCHES}",
+                            "mode": "${FILE_CONTAINS_MATCH}",
                             "search_in": ["dasharo-compatibility", "dasharo-security", "dasharo-performance", "dasharo-stability"]
                         },
                         "snipeit": "no"
-                    }
+                    }]
                 },
                 {
                     "name": "Run suites that use a modified lib",
                     "on-changed": "lib/(tpm2.robot)",
-                    "run": {
+                    "run": [{
                         "files": {
-                            "mode": "${CONTAINING_MATCHES}",
+                            "mode": "${FILE_CONTAINS_MATCH}",
                             "search_in": ["dasharo-compatibility", "dasharo-security", "dasharo-performance", "dasharo-stability"]
                         },
                         "snipeit": "no"
-                    }
+                    }]
                 }
             ]
         }

--- a/scripts/ci/regression-scope/regression_scope_selftests.py
+++ b/scripts/ci/regression-scope/regression_scope_selftests.py
@@ -7,8 +7,8 @@
 import json
 import unittest
 
-from lib.rules_parser import RuleParser
 from lib.parser_manager import ParserManager
+
 
 class TestMiscellaneous(unittest.TestCase):
     def test_no_matches(self):
@@ -30,14 +30,13 @@ class TestMiscellaneous(unittest.TestCase):
             "important-file.robot",
             "dasharo-performance/boot-time-measure.robot",
         ]
-        for rule in rules:
-            parser = RuleParser(rule, changed_files)
-            parser.match_rule()
-            self.assertEqual(parser.test_files, [])
-            self.assertEqual(
-                parser.commands,
-                [["echo", "hello"]],
-            )
+        parser = ParserManager(rules, changed_files)
+        parser.parse()
+        self.assertEqual(parser.files(), [])
+        self.assertEqual(
+            parser.commands(),
+            [["echo", "hello"]],
+        )
 
     def test_additional_robot_args(self):
         rules = json.loads(
@@ -61,22 +60,21 @@ class TestMiscellaneous(unittest.TestCase):
             "important-file.robot",
             "dasharo-performance/boot-time-measure.robot",
         ]
-        for rule in rules:
-            parser = RuleParser(rule, changed_files)
-            parser.match_rule()
-            self.assertEqual(parser.test_files, ["important-file.robot"])
-            self.assertEqual(
-                parser.commands,
+        parser = ParserManager(rules, changed_files)
+        parser.parse()
+        self.assertEqual(parser.files(), ["important-file.robot"])
+        self.assertEqual(
+            parser.commands(),
+            [
                 [
-                    [
-                        "scripts/run.sh",
-                        "important-file.robot",
-                        "--",
-                        "-i",
-                        "minimal-regression",
-                    ]
-                ],
-            )
+                    "scripts/run.sh",
+                    "important-file.robot",
+                    "--",
+                    "-i",
+                    "minimal-regression",
+                ]
+            ],
+        )
 
     def test_mutliple_runs_one_rule(self):
         rules = json.loads(
@@ -108,29 +106,28 @@ class TestMiscellaneous(unittest.TestCase):
             "important-file.robot",
             "dasharo-performance/boot-time-measure.robot",
         ]
-        for rule in rules:
-            parser = RuleParser(rule, changed_files)
-            parser.match_rule()
-            self.assertEqual(parser.test_files, ["important-file.robot"])
-            self.assertEqual(
-                parser.commands,
+        parser = ParserManager(rules, changed_files)
+        parser.parse()
+        self.assertEqual(parser.files(), ["important-file.robot"])
+        self.assertEqual(
+            parser.commands(),
+            [
                 [
-                    [
-                        "scripts/run.sh",
-                        "important-file.robot",
-                        "--",
-                        "-i",
-                        "minimal-regression",
-                    ],
-                    [
-                        "scripts/run.sh",
-                        "important-file.robot",
-                        "--",
-                        "-i",
-                        "some_other:tag",
-                    ],
+                    "scripts/run.sh",
+                    "important-file.robot",
+                    "--",
+                    "-i",
+                    "minimal-regression",
                 ],
-            )
+                [
+                    "scripts/run.sh",
+                    "important-file.robot",
+                    "--",
+                    "-i",
+                    "some_other:tag",
+                ],
+            ],
+        )
 
 
 class TestModulesRules(unittest.TestCase):
@@ -164,29 +161,31 @@ class TestModulesRules(unittest.TestCase):
             "lib/linux.robot",
             "platform-configs/include/msi-common.robot",
         ]
-        for rule in TestModulesRules.rules:
-            parser = RuleParser(rule, changed_files)
-            parser.match_rule()
-            self.assertEqual(
-                parser.test_files, ["dasharo-compatibility/audio-subsystem.robot"]
-            )
-            self.assertEqual(
-                parser.commands,
+        parser = ParserManager(TestModulesRules.rules, changed_files)
+        parser.parse()
+        self.assertEqual(
+            parser.files(), ["dasharo-compatibility/audio-subsystem.robot"]
+        )
+        self.assertEqual(
+            parser.commands(),
+            [
                 [
-                    [
-                        "export RTE_IP=127.0.0.1",
-                        "export FW_FILE=scripts/ci/qemu_q35.rom",
-                        "export CONFIG=qemu",
-                    ],
-                    [
-                        "scripts/run.sh",
-                        "dasharo-compatibility/audio-subsystem.robot",
-                        "--",
-                        "-v",
-                        "snipeit:no",
-                    ],
+                    "export",
+                    "RTE_IP=127.0.0.1",
+                    "export",
+                    "FW_FILE=scripts/ci/qemu_q35.rom",
+                    "export",
+                    "CONFIG=qemu",
                 ],
-            )
+                [
+                    "scripts/run.sh",
+                    "dasharo-compatibility/audio-subsystem.robot",
+                    "--",
+                    "-v",
+                    "snipeit:no",
+                ],
+            ],
+        )
 
     def test_single_module_multiple_changes(self):
         changed_files = [
@@ -196,34 +195,36 @@ class TestModulesRules(unittest.TestCase):
             "lib/linux.robot",
             "platform-configs/include/msi-common.robot",
         ]
-        for rule in TestModulesRules.rules:
-            parser = RuleParser(rule, changed_files)
-            parser.match_rule()
-            self.assertEqual(
-                parser.test_files,
+        parser = ParserManager(TestModulesRules.rules, changed_files)
+        parser.parse()
+        self.assertEqual(
+            parser.files(),
+            [
+                "dasharo-compatibility/audio-subsystem.robot",
+                "dasharo-compatibility/cpu-status.robot",
+            ],
+        )
+        self.assertEqual(
+            parser.commands(),
+            [
                 [
+                    "export",
+                    "RTE_IP=127.0.0.1",
+                    "export",
+                    "FW_FILE=scripts/ci/qemu_q35.rom",
+                    "export",
+                    "CONFIG=qemu",
+                ],
+                [
+                    "scripts/run.sh",
                     "dasharo-compatibility/audio-subsystem.robot",
                     "dasharo-compatibility/cpu-status.robot",
+                    "--",
+                    "-v",
+                    "snipeit:no",
                 ],
-            )
-            self.assertEqual(
-                parser.commands,
-                [
-                    [
-                        "export RTE_IP=127.0.0.1",
-                        "export FW_FILE=scripts/ci/qemu_q35.rom",
-                        "export CONFIG=qemu",
-                    ],
-                    [
-                        "scripts/run.sh",
-                        "dasharo-compatibility/audio-subsystem.robot",
-                        "dasharo-compatibility/cpu-status.robot",
-                        "--",
-                        "-v",
-                        "snipeit:no",
-                    ],
-                ],
-            )
+            ],
+        )
 
 
 class TestLibsRules(unittest.TestCase):
@@ -254,27 +255,26 @@ class TestLibsRules(unittest.TestCase):
             "lib/performance/gpu.robot",
             "platform-configs/include/msi-common.robot",
         ]
-        for rule in TestLibsRules.rules:
-            parser = RuleParser(rule, changed_files)
-            parser.match_rule()
-            self.assertEqual(
-                parser.test_files,
+        parser = ParserManager(TestLibsRules.rules, changed_files)
+        parser.parse()
+        self.assertEqual(
+            parser.files(),
+            [
+                "dasharo-performance/gpu-performance.robot",
+            ],
+        )
+        self.assertEqual(
+            parser.commands(),
+            [
                 [
+                    "scripts/run.sh",
                     "dasharo-performance/gpu-performance.robot",
+                    "--",
+                    "-v",
+                    "snipeit:no",
                 ],
-            )
-            self.assertEqual(
-                parser.commands,
-                [
-                    [
-                        "scripts/run.sh",
-                        "dasharo-performance/gpu-performance.robot",
-                        "--",
-                        "-v",
-                        "snipeit:no",
-                    ],
-                ],
-            )
+            ],
+        )
 
     def test_single_lib_multiple_module(self):
         changed_files = [
@@ -283,29 +283,28 @@ class TestLibsRules(unittest.TestCase):
             "lib/linux.robot",
             "platform-configs/include/msi-common.robot",
         ]
-        for rule in TestLibsRules.rules:
-            parser = RuleParser(rule, changed_files)
-            parser.match_rule()
-            self.assertEqual(
-                parser.test_files,
+        parser = ParserManager(TestLibsRules.rules, changed_files)
+        parser.parse()
+        self.assertEqual(
+            parser.files(),
+            [
+                "dasharo-compatibility/apu-configuration-menu.robot",
+                "dasharo-performance/platform-stability.robot",
+            ],
+        )
+        self.assertEqual(
+            parser.commands(),
+            [
                 [
+                    "scripts/run.sh",
                     "dasharo-compatibility/apu-configuration-menu.robot",
                     "dasharo-performance/platform-stability.robot",
+                    "--",
+                    "-v",
+                    "snipeit:no",
                 ],
-            )
-            self.assertEqual(
-                parser.commands,
-                [
-                    [
-                        "scripts/run.sh",
-                        "dasharo-compatibility/apu-configuration-menu.robot",
-                        "dasharo-performance/platform-stability.robot",
-                        "--",
-                        "-v",
-                        "snipeit:no",
-                    ],
-                ],
-            )
+            ],
+        )
 
     def test_multiple_lib_multiple_module_overlap(self):
         changed_files = [
@@ -314,31 +313,30 @@ class TestLibsRules(unittest.TestCase):
             "lib/tpm.robot",
             "lib/tpm2.robot" "platform-configs/include/msi-common.robot",
         ]
-        for rule in TestLibsRules.rules:
-            parser = RuleParser(rule, changed_files)
-            parser.match_rule()
-            self.assertEqual(
-                parser.test_files,
+        parser = ParserManager(TestLibsRules.rules, changed_files)
+        parser.parse()
+        self.assertEqual(
+            parser.files(),
+            [
+                "dasharo-security/measured-boot.robot",  # tpm.robot only
+                "dasharo-security/tpm-support.robot",  # tpm.robot & tpm2.robot
+                "dasharo-security/tpm2-commands.robot",  # tpm.robot & tpm2.robot
+            ],
+        )
+        self.assertEqual(
+            parser.commands(),
+            [
                 [
-                    "dasharo-security/tpm2-commands.robot",  # tpm.robot & tpm2.robot
-                    "dasharo-security/measured-boot.robot",  # tpm.robot only
-                    "dasharo-security/tpm-support.robot",  # tpm.robot & tpm2.robot
+                    "scripts/run.sh",
+                    "dasharo-security/measured-boot.robot",
+                    "dasharo-security/tpm-support.robot",
+                    "dasharo-security/tpm2-commands.robot",
+                    "--",
+                    "-v",
+                    "snipeit:no",
                 ],
-            )
-            self.assertEqual(
-                parser.commands,
-                [
-                    [
-                        "scripts/run.sh",
-                        "dasharo-security/tpm2-commands.robot",
-                        "dasharo-security/measured-boot.robot",
-                        "dasharo-security/tpm-support.robot",
-                        "--",
-                        "-v",
-                        "snipeit:no",
-                    ],
-                ],
-            )
+            ],
+        )
 
 
 class TestLibsMultipleRules(unittest.TestCase):
@@ -384,47 +382,21 @@ class TestLibsMultipleRules(unittest.TestCase):
         parser = ParserManager(rules, TestLibsMultipleRules.changed_files)
         parser.parse()
         self.assertEqual(
-            parser.test_files,
+            parser.files(),
             [
-                "dasharo-security/tpm2-commands.robot",  # tpm.robot & tpm2.robot
                 "dasharo-security/measured-boot.robot",  # tpm.robot only
                 "dasharo-security/tpm-support.robot",  # tpm.robot & tpm2.robot
+                "dasharo-security/tpm2-commands.robot",  # tpm.robot & tpm2.robot
             ],
         )
         self.assertEqual(
-            parser.commands,
+            parser.commands(),
             [
                 [
                     "scripts/run.sh",
-                    "dasharo-security/tpm2-commands.robot",
                     "dasharo-security/measured-boot.robot",
                     "dasharo-security/tpm-support.robot",
-                    "--",
-                    "-v",
-                    "snipeit:no",
-                ],
-            ],
-        )
-
-    def test_multiple_lib_multiple_rules_overlap_2(self):
-        parser = RuleParser(
-            TestLibsMultipleRules.rules[1], TestLibsMultipleRules.changed_files
-        )
-        parser.match_rule()
-        self.assertEqual(
-            parser.test_files,
-            [
-                "dasharo-security/tpm2-commands.robot",  # tpm.robot & tpm2.robot
-                "dasharo-security/tpm-support.robot",  # tpm.robot & tpm2.robot
-            ],
-        )
-        self.assertEqual(
-            parser.commands,
-            [
-                [
-                    "scripts/run.sh",
                     "dasharo-security/tpm2-commands.robot",
-                    "dasharo-security/tpm-support.robot",
                     "--",
                     "-v",
                     "snipeit:no",

--- a/scripts/ci/regression-scope/regression_scope_selftests.py
+++ b/scripts/ci/regression-scope/regression_scope_selftests.py
@@ -5,181 +5,447 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-
-import fire
+import unittest
 
 from lib.rules_parser import RuleParser
+from lib.parser_manager import ParserManager
+
+class TestMiscellaneous(unittest.TestCase):
+    def test_no_matches(self):
+        rules = json.loads(
+            """
+            {
+                "rules": [
+                    {
+                        "name": "Single match",
+                        "on-changed": "(important-file.robot)",
+                        "run": {
+                            "custom_command": "echo hello"
+                        }
+                    }
+                ]
+            }"""
+        )["rules"]
+        changed_files = [
+            "important-file.robot",
+            "dasharo-performance/boot-time-measure.robot",
+        ]
+        for rule in rules:
+            parser = RuleParser(rule, changed_files)
+            parser.match_rule()
+            self.assertEqual(parser.test_files, [])
+            self.assertEqual(
+                parser.commands,
+                [["echo", "hello"]],
+            )
+
+    def test_additional_robot_args(self):
+        rules = json.loads(
+            """
+            {
+                "rules": [
+                    {
+                        "name": "Single match",
+                        "on-changed": "(important-file.robot)",
+                        "run": {
+                            "files": {
+                                "mode": "${FULL_MATCH}"
+                            },
+                            "robot_args": "-i minimal-regression"
+                        }
+                    }
+                ]
+            }"""
+        )["rules"]
+        changed_files = [
+            "important-file.robot",
+            "dasharo-performance/boot-time-measure.robot",
+        ]
+        for rule in rules:
+            parser = RuleParser(rule, changed_files)
+            parser.match_rule()
+            self.assertEqual(parser.test_files, ["important-file.robot"])
+            self.assertEqual(
+                parser.commands,
+                [
+                    [
+                        "scripts/run.sh",
+                        "important-file.robot",
+                        "--",
+                        "-i",
+                        "minimal-regression",
+                    ]
+                ],
+            )
 
 
-def test_suites():
+class TestModulesRules(unittest.TestCase):
     rules = json.loads(
         """
-    {
-        "rules": [
             {
-                "name": "Run changed test suites",
-                "on-changed": "dasharo-compatibility/(.*)",
-                "run": {
-                    "env_vars": {
-                        "RTE_IP": "127.0.0.1",
-                        "FW_FILE": "scripts/ci/qemu_q35.rom",
-                        "CONFIG": "qemu"
-                    },
-                    "files": {
-                        "mode": "${FULL_MATCH}"
-                    },
-                    "snipeit": "no"
-                }
-            }
-        ]
-    }"""
+                "rules": [
+                    {
+                        "name": "Run changed test suites",
+                        "on-changed": "dasharo-compatibility/(.*)",
+                        "run": {
+                            "env_vars": {
+                                "RTE_IP": "127.0.0.1",
+                                "FW_FILE": "scripts/ci/qemu_q35.rom",
+                                "CONFIG": "qemu"
+                            },
+                            "files": {
+                                "mode": "${FULL_MATCH}"
+                            },
+                            "snipeit": "no"
+                        }
+                    }
+                ]
+            }"""
     )["rules"]
-    changed_files = [
-        "dasharo-compatibility/audio-subsystem.robot",
-        "dasharo-performance/platform-stability.robot",
-        "lib/linux.robot",
-        "platform-configs/include/msi-common.robot",
-    ]
-    for rule in rules:
-        parser = RuleParser(rule, changed_files)
-        parser.match_rule()
-        assert parser.tests == ["dasharo-compatibility/audio-subsystem.robot"]
-        assert parser.commands == [
-            [
-                "export RTE_IP=127.0.0.1",
-                "export FW_FILE=scripts/ci/qemu_q35.rom",
-                "export CONFIG=qemu",
-            ],
-            [
-                "scripts/run.sh",
-                "dasharo-compatibility/audio-subsystem.robot",
-                "--",
-                "-v",
-                "snipeit:no",
-            ],
-        ]
 
-
-def test_libs():
-    rules = json.loads(
-        """
-    {
-        "rules": [
-            {
-                "name": "Run suites that use a modified lib",
-                "on-changed": "lib/(.*)",
-                "run": {
-                    "env_vars": {
-                        "RTE_IP": "127.0.0.1",
-                        "FW_FILE": "scripts/ci/qemu_q35.rom",
-                        "CONFIG": "qemu"
-                    },
-                    "files": {
-                        "mode": "${CONTAINING_MATCHES}",
-                        "search_in": ["dasharo-compatibility", "dasharo-security", "dasharo-performance", "dasharo-stability"]
-                    },
-                    "snipeit": "no"
-                }
-            }
-        ]
-    }
-    """
-    )["rules"]
-    changed_files = [
-        "dasharo-compatibility/audio-subsystem.robot",
-        "dasharo-performance/platform-stability.robot",
-        "lib/linux.robot",
-        "platform-configs/include/msi-common.robot",
-    ]
-    for rule in rules:
-        parser = RuleParser(rule, changed_files)
-        parser.match_rule()
-        assert parser.tests == [
-            "dasharo-compatibility/apu-configuration-menu.robot",
+    def test_single_module_single_change(self):
+        changed_files = [
+            "dasharo-compatibility/audio-subsystem.robot",
             "dasharo-performance/platform-stability.robot",
+            "lib/linux.robot",
+            "platform-configs/include/msi-common.robot",
         ]
-        assert parser.commands == [
-            [
-                "export RTE_IP=127.0.0.1",
-                "export FW_FILE=scripts/ci/qemu_q35.rom",
-                "export CONFIG=qemu",
-            ],
-            [
-                "scripts/run.sh",
-                "dasharo-compatibility/apu-configuration-menu.robot",
-                "dasharo-performance/platform-stability.robot",
-                "--",
-                "-v",
-                "snipeit:no",
-            ],
+        for rule in TestModulesRules.rules:
+            parser = RuleParser(rule, changed_files)
+            parser.match_rule()
+            self.assertEqual(
+                parser.test_files, ["dasharo-compatibility/audio-subsystem.robot"]
+            )
+            self.assertEqual(
+                parser.commands,
+                [
+                    [
+                        "export RTE_IP=127.0.0.1",
+                        "export FW_FILE=scripts/ci/qemu_q35.rom",
+                        "export CONFIG=qemu",
+                    ],
+                    [
+                        "scripts/run.sh",
+                        "dasharo-compatibility/audio-subsystem.robot",
+                        "--",
+                        "-v",
+                        "snipeit:no",
+                    ],
+                ],
+            )
+
+    def test_single_module_multiple_changes(self):
+        changed_files = [
+            "dasharo-compatibility/audio-subsystem.robot",
+            "dasharo-compatibility/cpu-status.robot",
+            "dasharo-performance/platform-stability.robot",
+            "lib/linux.robot",
+            "platform-configs/include/msi-common.robot",
         ]
+        for rule in TestModulesRules.rules:
+            parser = RuleParser(rule, changed_files)
+            parser.match_rule()
+            self.assertEqual(
+                parser.test_files,
+                [
+                    "dasharo-compatibility/audio-subsystem.robot",
+                    "dasharo-compatibility/cpu-status.robot",
+                ],
+            )
+            self.assertEqual(
+                parser.commands,
+                [
+                    [
+                        "export RTE_IP=127.0.0.1",
+                        "export FW_FILE=scripts/ci/qemu_q35.rom",
+                        "export CONFIG=qemu",
+                    ],
+                    [
+                        "scripts/run.sh",
+                        "dasharo-compatibility/audio-subsystem.robot",
+                        "dasharo-compatibility/cpu-status.robot",
+                        "--",
+                        "-v",
+                        "snipeit:no",
+                    ],
+                ],
+            )
 
 
-def test_platform_configs():
+class TestLibsRules(unittest.TestCase):
     rules = json.loads(
         """
-    {
-        "rules": [
-            {
-                "name": "Minimal regression for MSI common",
-                "on-changed": "(platform-configs/include/msi-common.robot)",
-                "run": {
-                    "env_vars": {
-                        "RTE_IP": "1.2.3.4",
-                        "FW_FILE": "msi-firmware.rom",
-                        "CONFIG": "msi-pro-z790-p-ddr5",
-                        "CAPSULE_FW_FILE": "msi-pro-z790-p-ddr5.cap"
-                    },
-                    "files": {
-                        "mode": "${CONTENT_MATCH_REGEX}",
-                        "search_in": ["dasharo-compatibility", "dasharo-security", "dasharo-performance", "dasharo-stability"],
-                        "regex": ".*minimal-regression.*"
-                    },
-                    "custom_command": "scripts/regression.sh -- -i minimal-regression"
+        {
+            "rules": [
+                {
+                    "name": "Run suites that use a modified lib",
+                    "on-changed": "lib/(.*)",
+                    "run": {
+                        "files": {
+                            "mode": "${CONTAINING_MATCHES}",
+                            "search_in": ["dasharo-compatibility", "dasharo-security", "dasharo-performance", "dasharo-stability"]
+                        },
+                        "snipeit": "no"
+                    }
                 }
-            }
-        ]
-    }
-    """
+            ]
+        }
+        """
     )["rules"]
+
+    def test_single_lib_single_module(self):
+        changed_files = [
+            "dasharo-compatibility/audio-subsystem.robot",
+            "dasharo-performance/platform-stability.robot",
+            "lib/performance/gpu.robot",
+            "platform-configs/include/msi-common.robot",
+        ]
+        for rule in TestLibsRules.rules:
+            parser = RuleParser(rule, changed_files)
+            parser.match_rule()
+            self.assertEqual(
+                parser.test_files,
+                [
+                    "dasharo-performance/gpu-performance.robot",
+                ],
+            )
+            self.assertEqual(
+                parser.commands,
+                [
+                    [
+                        "scripts/run.sh",
+                        "dasharo-performance/gpu-performance.robot",
+                        "--",
+                        "-v",
+                        "snipeit:no",
+                    ],
+                ],
+            )
+
+    def test_single_lib_multiple_module(self):
+        changed_files = [
+            "dasharo-compatibility/audio-subsystem.robot",
+            "dasharo-performance/platform-stability.robot",
+            "lib/linux.robot",
+            "platform-configs/include/msi-common.robot",
+        ]
+        for rule in TestLibsRules.rules:
+            parser = RuleParser(rule, changed_files)
+            parser.match_rule()
+            self.assertEqual(
+                parser.test_files,
+                [
+                    "dasharo-compatibility/apu-configuration-menu.robot",
+                    "dasharo-performance/platform-stability.robot",
+                ],
+            )
+            self.assertEqual(
+                parser.commands,
+                [
+                    [
+                        "scripts/run.sh",
+                        "dasharo-compatibility/apu-configuration-menu.robot",
+                        "dasharo-performance/platform-stability.robot",
+                        "--",
+                        "-v",
+                        "snipeit:no",
+                    ],
+                ],
+            )
+
+    def test_multiple_lib_multiple_module_overlap(self):
+        changed_files = [
+            "dasharo-compatibility/audio-subsystem.robot",
+            "dasharo-performance/platform-stability.robot",
+            "lib/tpm.robot",
+            "lib/tpm2.robot" "platform-configs/include/msi-common.robot",
+        ]
+        for rule in TestLibsRules.rules:
+            parser = RuleParser(rule, changed_files)
+            parser.match_rule()
+            self.assertEqual(
+                parser.test_files,
+                [
+                    "dasharo-security/tpm2-commands.robot",  # tpm.robot & tpm2.robot
+                    "dasharo-security/measured-boot.robot",  # tpm.robot only
+                    "dasharo-security/tpm-support.robot",  # tpm.robot & tpm2.robot
+                ],
+            )
+            self.assertEqual(
+                parser.commands,
+                [
+                    [
+                        "scripts/run.sh",
+                        "dasharo-security/tpm2-commands.robot",
+                        "dasharo-security/measured-boot.robot",
+                        "dasharo-security/tpm-support.robot",
+                        "--",
+                        "-v",
+                        "snipeit:no",
+                    ],
+                ],
+            )
+
+
+class TestLibsMultipleRules(unittest.TestCase):
     changed_files = [
         "dasharo-compatibility/audio-subsystem.robot",
         "dasharo-performance/platform-stability.robot",
-        "lib/linux.robot",
-        "platform-configs/include/msi-common.robot",
+        "lib/tpm.robot",
+        "lib/tpm2.robot" "platform-configs/include/msi-common.robot",
     ]
-    for rule in rules:
-        parser = RuleParser(rule, changed_files)
-        parser.match_rule()
-        assert parser.tests == [
-            "dasharo-compatibility/network-boot.robot",
-            "dasharo-compatibility/auto-boot-time-out.robot",
-            "dasharo-compatibility/dmidecode.robot",
-            "dasharo-compatibility/usb-hid-and-msc-support.robot",
-            "dasharo-compatibility/wifi-bluetooth-support.robot",
-            "dasharo-security/tpm-support.robot",
-            "dasharo-performance/platform-stability.robot",
-        ]
-        assert parser.commands == [
+
+    def test_multiple_lib_multiple_rules_overlap(self):
+        rules = json.loads(
+            """
+        {
+            "rules": [
+                {
+                    "name": "Run suites that use a modified lib",
+                    "on-changed": "lib/(tpm.robot)",
+                    "run": {
+                        "files": {
+                            "mode": "${CONTAINING_MATCHES}",
+                            "search_in": ["dasharo-compatibility", "dasharo-security", "dasharo-performance", "dasharo-stability"]
+                        },
+                        "snipeit": "no"
+                    }
+                },
+                {
+                    "name": "Run suites that use a modified lib",
+                    "on-changed": "lib/(tpm2.robot)",
+                    "run": {
+                        "files": {
+                            "mode": "${CONTAINING_MATCHES}",
+                            "search_in": ["dasharo-compatibility", "dasharo-security", "dasharo-performance", "dasharo-stability"]
+                        },
+                        "snipeit": "no"
+                    }
+                }
+            ]
+        }
+        """
+        )["rules"]
+
+        parser = ParserManager(rules, TestLibsMultipleRules.changed_files)
+        parser.parse()
+        self.assertEqual(
+            parser.test_files,
             [
-                "export RTE_IP=1.2.3.4",
-                "export FW_FILE=msi-firmware.rom",
-                "export CONFIG=msi-pro-z790-p-ddr5",
-                "export CAPSULE_FW_FILE=msi-pro-z790-p-ddr5.cap",
+                "dasharo-security/tpm2-commands.robot",  # tpm.robot & tpm2.robot
+                "dasharo-security/measured-boot.robot",  # tpm.robot only
+                "dasharo-security/tpm-support.robot",  # tpm.robot & tpm2.robot
             ],
-            ["scripts/regression.sh", "--", "-i", "minimal-regression"],
-        ]
+        )
+        self.assertEqual(
+            parser.commands,
+            [
+                [
+                    "scripts/run.sh",
+                    "dasharo-security/tpm2-commands.robot",
+                    "dasharo-security/measured-boot.robot",
+                    "dasharo-security/tpm-support.robot",
+                    "--",
+                    "-v",
+                    "snipeit:no",
+                ],
+            ],
+        )
 
+    def test_multiple_lib_multiple_rules_overlap_2(self):
+        parser = RuleParser(
+            TestLibsMultipleRules.rules[1], TestLibsMultipleRules.changed_files
+        )
+        parser.match_rule()
+        self.assertEqual(
+            parser.test_files,
+            [
+                "dasharo-security/tpm2-commands.robot",  # tpm.robot & tpm2.robot
+                "dasharo-security/tpm-support.robot",  # tpm.robot & tpm2.robot
+            ],
+        )
+        self.assertEqual(
+            parser.commands,
+            [
+                [
+                    "scripts/run.sh",
+                    "dasharo-security/tpm2-commands.robot",
+                    "dasharo-security/tpm-support.robot",
+                    "--",
+                    "-v",
+                    "snipeit:no",
+                ],
+            ],
+        )
 
-def tests():
-    """
-    CLI for running regression scope selftests.
-    Returns 0 on success
-    """
-    test_suites()
-    test_libs()
-    test_platform_configs()
+    def test_multiple_lib_multiple_rules_overlap_no_repeats(self):
+        rules = json.loads(
+            """
+        {
+            "rules": [
+                {
+                    "name": "Run suites that use a modified lib",
+                    "on-changed": "lib/(tpm.robot)",
+                    "run": [{
+                        "files": {
+                            "mode": "${FILE_CONTAINS_MATCH}",
+                            "search_in": ["dasharo-compatibility", "dasharo-security", "dasharo-performance", "dasharo-stability"]
+                        },
+                        "snipeit": "no"
+                    }]
+                },
+                {
+                    "name": "Run suites that use a modified lib",
+                    "on-changed": "lib/(tpm2.robot)",
+                    "run": [{
+                        "files": {
+                            "mode": "${FILE_CONTAINS_MATCH}",
+                            "search_in": ["dasharo-compatibility", "dasharo-security", "dasharo-performance", "dasharo-stability"]
+                        },
+                        "robot_args": "-i some_other:tag",
+                        "snipeit": "no"
+                    }]
+                }
+            ]
+        }
+        """
+        )["rules"]
+
+        parser = ParserManager(rules, TestLibsMultipleRules.changed_files)
+        parser.parse()
+        self.assertEqual(
+            parser.files(),
+            [
+                "dasharo-security/measured-boot.robot",  # tpm.robot only
+                "dasharo-security/tpm-support.robot",  # tpm.robot & tpm2.robot
+                "dasharo-security/tpm2-commands.robot",  # tpm.robot & tpm2.robot
+            ],
+        )
+        self.assertEqual(
+            parser.commands(),
+            [
+                [
+                    "scripts/run.sh",
+                    "dasharo-security/measured-boot.robot",
+                    "dasharo-security/tpm-support.robot",
+                    "dasharo-security/tpm2-commands.robot",
+                    "--",
+                    "-v",
+                    "snipeit:no",
+                ],
+                [
+                    "scripts/run.sh",
+                    "dasharo-security/tpm-support.robot",
+                    "dasharo-security/tpm2-commands.robot",
+                    "--",
+                    "-i",
+                    "some_other:tag",
+                    "-v",
+                    "snipeit:no",
+                ],
+            ],
+        )
 
 
 if __name__ == "__main__":
-    fire.Fire(tests)
+    unittest.main()

--- a/scripts/ci/regression-scope/regression_scope_selftests.py
+++ b/scripts/ci/regression-scope/regression_scope_selftests.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2025 3mdeb <contact@3mdeb.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import fire
+
+from lib.rules_parser import RuleParser
+
+
+def test_suites():
+    rules = json.loads(
+        """
+    {
+        "rules": [
+            {
+                "name": "Run changed test suites",
+                "on-changed": "dasharo-compatibility/(.*)",
+                "run": {
+                    "env_vars": {
+                        "RTE_IP": "127.0.0.1",
+                        "FW_FILE": "scripts/ci/qemu_q35.rom",
+                        "CONFIG": "qemu"
+                    },
+                    "files": {
+                        "mode": "${FULL_MATCH}"
+                    },
+                    "snipeit": "no"
+                }
+            }
+        ]
+    }"""
+    )["rules"]
+    changed_files = [
+        "dasharo-compatibility/audio-subsystem.robot",
+        "dasharo-performance/platform-stability.robot",
+        "lib/linux.robot",
+        "platform-configs/include/msi-common.robot",
+    ]
+    for rule in rules:
+        parser = RuleParser(rule, changed_files)
+        parser.match_rule()
+        assert parser.tests == ["dasharo-compatibility/audio-subsystem.robot"]
+        assert parser.commands == [
+            [
+                "export RTE_IP=127.0.0.1",
+                "export FW_FILE=scripts/ci/qemu_q35.rom",
+                "export CONFIG=qemu",
+            ],
+            [
+                "scripts/run.sh",
+                "dasharo-compatibility/audio-subsystem.robot",
+                "--",
+                "-v",
+                "snipeit:no",
+            ],
+        ]
+
+
+def test_libs():
+    rules = json.loads(
+        """
+    {
+        "rules": [
+            {
+                "name": "Run suites that use a modified lib",
+                "on-changed": "lib/(.*)",
+                "run": {
+                    "env_vars": {
+                        "RTE_IP": "127.0.0.1",
+                        "FW_FILE": "scripts/ci/qemu_q35.rom",
+                        "CONFIG": "qemu"
+                    },
+                    "files": {
+                        "mode": "${CONTAINING_MATCHES}",
+                        "search_in": ["dasharo-compatibility", "dasharo-security", "dasharo-performance", "dasharo-stability"]
+                    },
+                    "snipeit": "no"
+                }
+            }
+        ]
+    }
+    """
+    )["rules"]
+    changed_files = [
+        "dasharo-compatibility/audio-subsystem.robot",
+        "dasharo-performance/platform-stability.robot",
+        "lib/linux.robot",
+        "platform-configs/include/msi-common.robot",
+    ]
+    for rule in rules:
+        parser = RuleParser(rule, changed_files)
+        parser.match_rule()
+        assert parser.tests == [
+            "dasharo-compatibility/apu-configuration-menu.robot",
+            "dasharo-performance/platform-stability.robot",
+        ]
+        assert parser.commands == [
+            [
+                "export RTE_IP=127.0.0.1",
+                "export FW_FILE=scripts/ci/qemu_q35.rom",
+                "export CONFIG=qemu",
+            ],
+            [
+                "scripts/run.sh",
+                "dasharo-compatibility/apu-configuration-menu.robot",
+                "dasharo-performance/platform-stability.robot",
+                "--",
+                "-v",
+                "snipeit:no",
+            ],
+        ]
+
+
+def test_platform_configs():
+    rules = json.loads(
+        """
+    {
+        "rules": [
+            {
+                "name": "Minimal regression for MSI common",
+                "on-changed": "(platform-configs/include/msi-common.robot)",
+                "run": {
+                    "env_vars": {
+                        "RTE_IP": "1.2.3.4",
+                        "FW_FILE": "msi-firmware.rom",
+                        "CONFIG": "msi-pro-z790-p-ddr5",
+                        "CAPSULE_FW_FILE": "msi-pro-z790-p-ddr5.cap"
+                    },
+                    "files": {
+                        "mode": "${CONTENT_MATCH_REGEX}",
+                        "search_in": ["dasharo-compatibility", "dasharo-security", "dasharo-performance", "dasharo-stability"],
+                        "regex": ".*minimal-regression.*"
+                    },
+                    "custom_command": "scripts/regression.sh -- -i minimal-regression"
+                }
+            }
+        ]
+    }
+    """
+    )["rules"]
+    changed_files = [
+        "dasharo-compatibility/audio-subsystem.robot",
+        "dasharo-performance/platform-stability.robot",
+        "lib/linux.robot",
+        "platform-configs/include/msi-common.robot",
+    ]
+    for rule in rules:
+        parser = RuleParser(rule, changed_files)
+        parser.match_rule()
+        assert parser.tests == [
+            "dasharo-compatibility/network-boot.robot",
+            "dasharo-compatibility/auto-boot-time-out.robot",
+            "dasharo-compatibility/dmidecode.robot",
+            "dasharo-compatibility/usb-hid-and-msc-support.robot",
+            "dasharo-compatibility/wifi-bluetooth-support.robot",
+            "dasharo-security/tpm-support.robot",
+            "dasharo-performance/platform-stability.robot",
+        ]
+        assert parser.commands == [
+            [
+                "export RTE_IP=1.2.3.4",
+                "export FW_FILE=msi-firmware.rom",
+                "export CONFIG=msi-pro-z790-p-ddr5",
+                "export CAPSULE_FW_FILE=msi-pro-z790-p-ddr5.cap",
+            ],
+            ["scripts/regression.sh", "--", "-i", "minimal-regression"],
+        ]
+
+
+def tests():
+    """
+    CLI for running regression scope selftests.
+    Returns 0 on success
+    """
+    test_suites()
+    test_libs()
+    test_platform_configs()
+
+
+if __name__ == "__main__":
+    fire.Fire(tests)

--- a/scripts/ci/regression-scope/rules.json
+++ b/scripts/ci/regression-scope/rules.json
@@ -21,14 +21,34 @@
             "name": "Run suites that use a modified lib",
             "on-changed": "lib/(.*)",
             "run": {
-                "device": "qemu",
                 "env_vars": {
                     "RTE_IP": "127.0.0.1",
-                    "FW_FILE": "scripts/ci/qemu_q35.rom"
+                    "FW_FILE": "scripts/ci/qemu_q35.rom",
+                    "CONFIG": "qemu"
                 },
-                "files": "${CONTAINING_MATCHES}",
-                "files_search_in": ["dasharo-compatibility", "dasharo-security", "dasharo-performance", "dasharo-stability"],
+                "files": {
+                    "mode": "${CONTAINING_MATCHES}",
+                    "search_in": ["dasharo-compatibility", "dasharo-security", "dasharo-performance", "dasharo-stability"]
+                },
                 "snipeit": "no"
+            }
+        },
+        {
+            "name": "Minimal regression for MSI common",
+            "on-changed": "platform-configs/include/msi-common.robot",
+            "run": {
+                "env_vars": {
+                        "RTE_IP": "1.2.3.4",
+                        "FW_FILE": "msi-firmware.rom",
+                        "CONFIG": "msi-pro-z790-p-ddr5",
+                        "CAPSULE_FW_FILE": "msi-pro-z790-p-ddr5.cap"
+                },
+                "command": "scripts/regression.sh -- -i minimal-regression",
+                "files": {
+                    "mode": "${CONTENT_MATCH_REGEX}",
+                    "search_in": ["dasharo-compatibility", "dasharo-security", "dasharo-performance", "dasharo-stability"],
+                    "regex": "minimal-regression"
+                }
             }
         }
     ]

--- a/scripts/ci/regression-scope/rules.json
+++ b/scripts/ci/regression-scope/rules.json
@@ -20,18 +20,20 @@
         {
             "name": "Run suites that use a modified lib",
             "on-changed": "lib/(.*)",
-            "run": {
-                "env_vars": {
-                    "RTE_IP": "127.0.0.1",
-                    "FW_FILE": "scripts/ci/qemu_q35.rom",
-                    "CONFIG": "qemu"
-                },
-                "files": {
-                    "mode": "${CONTAINING_MATCHES}",
-                    "search_in": ["dasharo-compatibility", "dasharo-security", "dasharo-performance", "dasharo-stability"]
-                },
-                "snipeit": "no"
-            }
+            "run": [
+                {
+                    "env_vars": {
+                        "RTE_IP": "127.0.0.1",
+                        "FW_FILE": "scripts/ci/qemu_q35.rom",
+                        "CONFIG": "qemu"
+                    },
+                    "files": {
+                        "mode": "${FILE_CONTAINS_MATCH}",
+                        "search_in": ["dasharo-compatibility", "dasharo-security", "dasharo-performance", "dasharo-stability"]
+                    },
+                    "snipeit": "no"
+                }
+            ]
         }
     ]
 }

--- a/scripts/ci/regression-scope/rules.json
+++ b/scripts/ci/regression-scope/rules.json
@@ -1,0 +1,35 @@
+{
+    "rules": [
+        {
+            "name": "Run changed test suites",
+            "on-changed": "dasharo-[a-z]{,15}/(.*)",
+            "run": [
+                {
+                    "env_vars": {
+                        "RTE_IP": "127.0.0.1",
+                        "FW_FILE": "scripts/ci/qemu_q35.rom",
+                        "CONFIG": "qemu"
+                    },
+                    "files": {
+                        "mode": "${FULL_FILENAME_MATCH}"
+                    },
+                    "snipeit": "no"
+                }
+            ]
+        },
+        {
+            "name": "Run suites that use a modified lib",
+            "on-changed": "lib/(.*)",
+            "run": {
+                "device": "qemu",
+                "env_vars": {
+                    "RTE_IP": "127.0.0.1",
+                    "FW_FILE": "scripts/ci/qemu_q35.rom"
+                },
+                "files": "${CONTAINING_MATCHES}",
+                "files_search_in": ["dasharo-compatibility", "dasharo-security", "dasharo-performance", "dasharo-stability"],
+                "snipeit": "no"
+            }
+        }
+    ]
+}

--- a/scripts/ci/regression-scope/rules.json
+++ b/scripts/ci/regression-scope/rules.json
@@ -32,24 +32,6 @@
                 },
                 "snipeit": "no"
             }
-        },
-        {
-            "name": "Minimal regression for MSI common",
-            "on-changed": "platform-configs/include/msi-common.robot",
-            "run": {
-                "env_vars": {
-                        "RTE_IP": "1.2.3.4",
-                        "FW_FILE": "msi-firmware.rom",
-                        "CONFIG": "msi-pro-z790-p-ddr5",
-                        "CAPSULE_FW_FILE": "msi-pro-z790-p-ddr5.cap"
-                },
-                "command": "scripts/regression.sh -- -i minimal-regression",
-                "files": {
-                    "mode": "${CONTENT_MATCH_REGEX}",
-                    "search_in": ["dasharo-compatibility", "dasharo-security", "dasharo-performance", "dasharo-stability"],
-                    "regex": "minimal-regression"
-                }
-            }
         }
     ]
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 3mdeb <contact@3mdeb.com>

SPDX-License-Identifier: Apache-2.0
-->

<!-- markdownlint-disable MD041 -->
## Short description
The script is supposed to help determine which tests should be run in order to verify if the changes performed to OSFV are breaking anything.
The script's functionality is tested using `scripts/ci/regression-scope/regression_scope_selftests.py`, which also serves a purpose of demonstrating how the rules files can be created.
## Related Issue(s)