### PR TITLE
ACPT001.201: Test for SIO serial presence in ACPI tables

### DIFF
--- a/dasharo-compatibility/acpi-tables.robot
+++ b/dasharo-compatibility/acpi-tables.robot
@@ -1,0 +1,43 @@
+*** Settings ***
+Library             Collections
+Library             OperatingSystem
+Library             Process
+Library             String
+Library             Telnet    timeout=20 seconds    connection_timeout=120 seconds
+Library             SSHLibrary    timeout=90 seconds
+Library             RequestsLibrary
+# TODO: maybe have a single file to include if we need to include the same
+# stuff in all test cases
+Resource            ../variables.robot
+Resource            ../keywords.robot
+Resource            ../keys.robot
+
+# TODO:
+# - document which setup/teardown keywords to use and what are they doing
+# - go threough them and make sure they are doing what the name suggest (not
+# exactly the case right now)
+Suite Setup         Run Keywords
+...                     Prepare Test Suite
+Suite Teardown      Run Keyword
+...                     Log Out And Close Connection
+
+
+*** Variables ***
+${SYSFS_PREFIX}=    /sys/bus/acpi/devices
+
+
+*** Test Cases ***
+ACPT001.201 SuperIO UART presence in sysfs ACPI tree (Ubuntu)
+    [Documentation]    Test verifies presence of SIO ACPI entries in sysfs.
+    ...    Platform config must contain SIO_NODE, SIO_SER_NODE, SIO_SCOPE
+    ...    and SIO_SER_SCOPE variables.
+    Power On
+    Boot System Or From Connected Disk    ${ENV_ID_UBUNTU}
+    Login To Linux
+    Switch To Root User
+    ${path_sio}=    Catenate    SEPARATOR="/"    ${SYSFS_PREFIX}    ${SIO_NODE}    path
+    ${path_sio_ser}=    Catenate    SEPARATOR="/"    ${SYSFS_PREFIX}    ${SIO_SER_NODE}    path
+    ${out_sio}=    Execute Command In Terminal    cat ${path_sio}
+    ${out_sio_ser}=    Execute Command In Terminal    cat ${path_sio_ser}
+    Should Contain    ${out_sio}    ${SIO_SCOPE}
+    Should Contain    ${out_sio_ser}    ${SIO_SER_SCOPE}

--- a/dasharo-compatibility/acpi-tables.robot
+++ b/dasharo-compatibility/acpi-tables.robot
@@ -23,14 +23,16 @@ Suite Teardown      Run Keyword
 
 
 *** Variables ***
-${SYSFS_PREFIX}=    /sys/bus/acpi/devices
+${SYSFS_PREFIX}=        /sys/bus/acpi/devices
+${SIO_NODE}=            PNP0A05:00
+${SIO_SCOPE}=           \\_SB_.PCI0.LPCB.SIO0
+${SIO_SER_NODE}=        PNP0501:00
+${SIO_SER_SCOPE}=       \\_SB_.PCI0.LPCB.SIO0.SER1
 
 
 *** Test Cases ***
 ACPT001.201 SuperIO UART presence in sysfs ACPI tree (Ubuntu)
     [Documentation]    Test verifies presence of SIO ACPI entries in sysfs.
-    ...    Platform config must contain SIO_NODE, SIO_SER_NODE, SIO_SCOPE
-    ...    and SIO_SER_SCOPE variables.
     Power On
     Boot System Or From Connected Disk    ${ENV_ID_UBUNTU}
     Login To Linux

--- a/dasharo-compatibility/acpi-tables.robot
+++ b/dasharo-compatibility/acpi-tables.robot
@@ -33,6 +33,7 @@ ${SIO_SER_SCOPE}=       \\_SB_.PCI0.LPCB.SIO0.SER1
 *** Test Cases ***
 ACPT001.201 SuperIO UART presence in sysfs ACPI tree (Ubuntu)
     [Documentation]    Test verifies presence of SIO ACPI entries in sysfs.
+    Depends On    ${HAS_SUPERIO_SERIAL}
     Power On
     Boot System Or From Connected Disk    ${ENV_ID_UBUNTU}
     Login To Linux

--- a/platform-configs/include/default.robot
+++ b/platform-configs/include/default.robot
@@ -196,6 +196,7 @@ ${WIFI_BLUETOOTH_CARD_SWITCH_SUPPORT}=              ${FALSE}
 ${CAMERA_SWITCH_SUPPORT}=                           ${FALSE}
 ${EARLY_BOOT_DMA_SUPPORT}=                          ${FALSE}
 ${UEFI_PASSWORD_SUPPORT}=                           ${FALSE}
+${HAS_SUPERIO_SERIAL}=                              ${FALSE}
 
 # Test module: dasharo-performance
 ${SERIAL_BOOT_MEASURE}=                             ${FALSE}

--- a/platform-configs/include/protectli-common.robot
+++ b/platform-configs/include/protectli-common.robot
@@ -77,6 +77,7 @@ ${DCU_SERIAL_SUPPORT}=                          ${TRUE}
 ${DCU_SUPPORTED_BOOLEAN_SMMSTORE_VARIABLE}=     UsbMassStorage
 ${HDMI_AUDIO_SUPPORT}=                          ${TRUE}
 ${SUSPEND_AND_RESUME_SUPPORT}=                  ${TRUE}
+${HAS_SUPERIO_SERIAL}=                          ${TRUE}
 
 # Test module: dasharo-security
 ${TPM_SUPPORTED_VERSION}=                       2

--- a/platform-configs/include/protectli-v1x10.robot
+++ b/platform-configs/include/protectli-v1x10.robot
@@ -34,6 +34,11 @@ ${EXTERNAL_DISPLAY_PORT_SUPPORT}=               ${FALSE}
 
 ${DCU_SUPPORTED_BOOLEAN_SMMSTORE_VARIABLE}=     ${EMPTY}
 
+${SIO_NODE}=                                    PNP0A05:00
+${SIO_SCOPE}=                                   \\_SB_.PCI0.LPCB.SIO0
+${SIO_SER_NODE}=                                PNP0501:00
+${SIO_SER_SCOPE}=                               \\_SB_.PCI0.LPCB.SIO0.SER1
+
 
 *** Keywords ***
 Flash Device Via External Programmer

--- a/platform-configs/include/protectli-v1x10.robot
+++ b/platform-configs/include/protectli-v1x10.robot
@@ -34,11 +34,6 @@ ${EXTERNAL_DISPLAY_PORT_SUPPORT}=               ${FALSE}
 
 ${DCU_SUPPORTED_BOOLEAN_SMMSTORE_VARIABLE}=     ${EMPTY}
 
-${SIO_NODE}=                                    PNP0A05:00
-${SIO_SCOPE}=                                   \\_SB_.PCI0.LPCB.SIO0
-${SIO_SER_NODE}=                                PNP0501:00
-${SIO_SER_SCOPE}=                               \\_SB_.PCI0.LPCB.SIO0.SER1
-
 
 *** Keywords ***
 Flash Device Via External Programmer

--- a/test_cases.json
+++ b/test_cases.json
@@ -15,6 +15,13 @@
   },
   {
     "doc": {
+      "_id": "ACPT001.201",
+      "name": "SuperIO UART presence in sysfs ACPI tree (Ubuntu)",
+      "module": "Dasharo Compatibility"
+    }
+  },
+  {
+    "doc": {
       "_id": "APU001.001",
       "name": "Check if apu2 watchdog option is available",
       "module": "Dasharo Compatibility"


### PR DESCRIPTION
Introducing dasharo-compatibility/acpi-yables.robot suite, requires mounted sysfs and platform config variables: ${SIO_NODE}, ${SIO_SCOPE}, ${SIO_SER_NODE}, ${SIO_SER_SCOPE}. Platform config set for Protectli V1x10 series as a referece.