### PR TITLE
setup-and-boot-menus: Mount a bootable drive instead of UEFI shell

### DIFF
--- a/.github/workflows/qemu-self-test.yml
+++ b/.github/workflows/qemu-self-test.yml
@@ -11,10 +11,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repository and submodules
+    - name: Checkout repository
       uses: actions/checkout@v2
-      with:
-        submodules: 'recursive'
+
+    - name: Chceckout submodules
+      run: |
+        git submodule update --init --checkout --recursive
 
     - name: Set up QEMU
       run: |
@@ -43,6 +45,18 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+
+    - name: Set up git-annex
+      uses: jstritch/setup-git-annex@v1
+
+    - name: Set up osfv-test-data
+      working-directory: osfv-test-data
+      run: |
+        set +e
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+        git annex pull
+        ./setup.sh
 
     - name: Start keywords self-tests with QEMU
       run: |

--- a/self-tests/dasharo-system-features-menus.robot
+++ b/self-tests/dasharo-system-features-menus.robot
@@ -124,7 +124,7 @@ Parse Power Management Options
     Skip If    not ${DASHARO_POWER_MGMT_MENU_SUPPORT}
     ${power_menu}=    Parsing Dasharo Submenu Verification    Power Management Options
     ${power_entries}=    Get Length    ${power_menu}
-    Should Be Equal As Integers    ${power_entries}    6
+    Should Be Equal As Integers    ${power_entries}    5
     Should Match Regexp    ${power_menu}[0]    ^Fan profile <.*>.*$
     Menu Construction Should Not Contain Control Text    ${power_menu}
 
@@ -181,14 +181,16 @@ Parse Serial Port Configuration
 Enter Dasharo Submenu Verification
     [Documentation]    Enters Dasharo System Features submenu as in the given
     ...    ${submenu_name}. Checks whether the menu can be entered properly.
-    [Arguments]    ${submenu_name}
+    [Arguments]    ${submenu_name}    ${skip_last_line_check}=${FALSE}
     Power On
     ${setup_menu}=    Enter Setup Menu Tianocore And Return Construction
     ${dasharo_menu}=    Enter Dasharo System Features    ${setup_menu}
     Enter Submenu From Snapshot    ${dasharo_menu}    ${submenu_name}
     ${out}=    Read From Terminal Until    Esc=Exit
     Should Contain    ${out}    ${submenu_name}
-    Should Contain    ${out}    Press ESC to exit.
+    IF    not ${skip_last_line_check}
+        Should Contain    ${out}    Press ESC to exit.
+    END
     RETURN    ${out}
 
 Parsing Dasharo Submenu Verification

--- a/self-tests/setup-and-boot-menus.robot
+++ b/self-tests/setup-and-boot-menus.robot
@@ -132,13 +132,15 @@ Enter One Time Boot Menu
 
 Parse One Time Boot Menu
     [Documentation]    Test entering into User Password Management menu
+    Add USB To Qemu    ${TEST_DATA_DIR}/dts/dts-base-image-v2.1.3.wic
     Power On
     ${setup_menu}=    Enter Setup Menu Tianocore And Return Construction
     ${otb_menu}=    Enter Submenu From Snapshot And Return Construction
     ...    ${setup_menu}
     ...    One Time Boot
-    List Should Contain Value    ${otb_menu}    UEFI Shell
+    List Should Contain Value    ${otb_menu}    QEMU QEMU USB HARDDRIVE
     Menu Construction Should Not Contain Control Text    ${otb_menu}
+    Remove Drive From Qemu
 
 Enter Boot Maintenance Manager Menu
     [Documentation]    Test entering into User Password Management menu


### PR DESCRIPTION
Fixes the test always FAILing because UEFI Shell is no longer distributed with Dasharo
[setup-and-boot-menus_log.zip](https://github.com/user-attachments/files/20589382/setup-and-boot-menus_log.zip)
