### PR TITLE
scripts/stats.py: Handle newly added modules

### DIFF
--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -22,7 +22,13 @@ class TestCasesFinder(SuiteVisitor):
 
 def get_test_cases_from_dir(directory):
     builder = TestSuiteBuilder()
-    testsuite = builder.build(directory)
+    try:
+        testsuite = builder.build(directory)
+    except Exception as e:
+        print(
+            f"Error building test suite from {directory}: {e}. Assuming no test cases."
+        )
+        return 0, []
     finder = TestCasesFinder()
     testsuite.visit(finder)
 

--- a/scripts/stats.py
+++ b/scripts/stats.py
@@ -158,6 +158,8 @@ def generate_stats(text=True, graphs=True, compare_against=None):
                 difference_per_module,
                 filename="test_counts_difference.png",
                 title="Difference in Number of Tests in Modules",
+                show_graph=True,
+                save_graph=True,
             )
     else:
         if text:


### PR DESCRIPTION
Otherwise builder raises an exception and everything breaks when the historic revision does not have a module, which exists now.

The script is fully usable for my needs now.