### PR TITLE
CI: Save robot logs even if it fails

### DIFF
--- a/.github/workflows/qemu-self-test.yml
+++ b/.github/workflows/qemu-self-test.yml
@@ -49,6 +49,7 @@ jobs:
         ./scripts/ci/qemu-self-test.sh
 
     - name: Save artifacts
+      if: '!cancelled()'
       uses: actions/upload-artifact@v4
       with:
         name: "qemu-logs"


### PR DESCRIPTION
I think the logs from fails are much more important than from passes...