### PR TITLE
202-packages.yaml: Update ffmpeg package name

### DIFF
--- a/os-config/ansible/vars/202-packages.yaml
+++ b/os-config/ansible/vars/202-packages.yaml
@@ -16,7 +16,7 @@ package_iperf3: iperf3
 package_fwts: fwts
 package_util_linux: util-linux
 package_smartmontools: smartmontools
-package_ffmeg: ffmpeg
+package_ffmeg: ffmpeg-free
 package_usbutils: usbutils
 package_tpm2_tools: tpm2-tools
 package_ethtool: ethtool


### PR DESCRIPTION
It's now called `ffmpeg-free`. You can still install it manually using `dnf install ffmpeg`, which will result in installing `ffmpeg-free`, but when running it via ansible the old name won't work. 