### PR TITLE
Self tests separate stress tests

### DIFF
--- a/.github/workflows/qemu-stress-tests.yml
+++ b/.github/workflows/qemu-stress-tests.yml
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2024 3mdeb <contact@3mdeb.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Keywords self-tests with QEMU
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Every day at midnight
+
+jobs:
+  qemu:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository and submodules
+      uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+
+    - name: Set up QEMU
+      run: |
+         sudo apt-get update
+         sudo apt-get install qemu-system-x86-64 swtpm
+
+    # Based on: https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
+    # It mentiones enteprise large-runners, let's see if it works
+    # on regular public runners as well
+    - name: Enable KVM group perms
+      run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+    - name: Start QEMU in background
+      run: |
+        ./scripts/ci/qemu-run.sh nographic firmware &
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Start keywords self-tests with QEMU
+      run: |
+        ./scripts/ci/qemu-stress-tests.sh
+
+    - name: Save artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: "qemu-logs"
+        path: |
+           ./logs/
+        retention-days: 30

--- a/scripts/ci/qemu-run.sh
+++ b/scripts/ci/qemu-run.sh
@@ -153,8 +153,8 @@ QEMU_PARAMS_OS="-device ich9-intel-hda \
   -audiodev pa,id=hda,server=${PULSE_SERVER},out.frequency=44100 \
   -object rng-random,id=rng0,filename=/dev/urandom \
   -device virtio-rng-pci,max-bytes=1024,period=1000 \
+  -netdev bridge,id=vmnic,br=br0 \
   -device virtio-net,netdev=vmnic \
-  -netdev user,id=vmnic,hostfwd=tcp::5222-:22 \
   -drive file=${HDD_PATH},if=ide"
 
 if [[ -f ${HDD2_PATH} ]]; then

--- a/scripts/ci/qemu-self-test.sh
+++ b/scripts/ci/qemu-self-test.sh
@@ -6,12 +6,12 @@
 
 # Define an array of commands
 commands=(
-  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/setup-and-boot-menus -v snipeit:no self-tests/setup-and-boot-menus.robot"
-  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/dasharo-system-features-menus -v snipeit:no self-tests/dasharo-system-features-menus.robot"
-  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/boolean-options -v snipeit:no self-tests/boolean-options.robot"
-  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/numerical-options -v snipeit:no self-tests/numerical-options.robot"
-  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/list-options -v snipeit:no self-tests/list-options.robot"
-  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/self-tests -v snipeit:no self-tests/terminal.robot"
+  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/setup-and-boot-menus -v snipeit:no --exclude stress-test self-tests/setup-and-boot-menus.robot"
+  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/dasharo-system-features-menus -v snipeit:no --exclude stress-test self-tests/dasharo-system-features-menus.robot"
+  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/boolean-options -v snipeit:no --exclude stress-test self-tests/boolean-options.robot"
+  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/numerical-options -v snipeit:no --exclude stress-test self-tests/numerical-options.robot"
+  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/list-options -v snipeit:no --exclude stress-test self-tests/list-options.robot"
+  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/self-tests -v snipeit:no --exclude stress-test self-tests/terminal.robot"
 )
 
 # Initialize a variable to track overall success

--- a/scripts/ci/qemu-stress-tests.sh
+++ b/scripts/ci/qemu-stress-tests.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2024 3mdeb <contact@3mdeb.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Define an array of commands
+
+commands=(
+  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/setup-and-boot-menus -v snipeit:no --include stress-test self-tests/setup-and-boot-menus.robot"
+  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/dasharo-system-features-menus -v snipeit:no --include stress-test self-tests/dasharo-system-features-menus.robot"
+  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/boolean-options -v snipeit:no --include stress-test self-tests/boolean-options.robot"
+  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/numerical-options -v snipeit:no --include stress-test self-tests/numerical-options.robot"
+  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/list-options -v snipeit:no --include stress-test self-tests/list-options.robot"
+  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/self-tests -v snipeit:no --include stress-test self-tests/terminal.robot"
+)
+
+# Initialize a variable to track overall success
+overall_success=0
+
+# Execute each command and capture the exit codes
+for cmd in "${commands[@]}"; do
+  eval $cmd
+  exit_code=$?
+  if [ $exit_code -ne 0 ]; then
+    overall_success=1
+  fi
+done
+
+# Exit with the appropriate status
+exit $overall_success

--- a/self-tests/os-boot.robot
+++ b/self-tests/os-boot.robot
@@ -28,6 +28,7 @@ Suite Teardown      Run Keyword
 *** Test Cases ***
 BOT001.001 Boot To Ubuntu Multiple Times
     [Documentation]    This test verifies if the DUT can boot to Ubuntu multiple times in a row.
+    [Tags]    stress-test
     Depends On    ${TESTS_IN_UBUNTU_SUPPORT}
     FOR    ${i}    IN RANGE    5
         ${index}=    Evaluate    ${i} + 1
@@ -40,6 +41,7 @@ BOT001.001 Boot To Ubuntu Multiple Times
 
 BOT002.001 Boot To Windows Multiple Times
     [Documentation]    This test verifies if the DUT can boot to Windows multiple times in a row.
+    [Tags]    stress-test
     Depends On    ${TESTS_IN_WINDOWS_SUPPORT}
     FOR    ${i}    IN RANGE    5
         ${index}=    Evaluate    ${i} + 1
@@ -51,6 +53,7 @@ BOT002.001 Boot To Windows Multiple Times
 
 BOT003.001 Boot To Ubuntu Then Boot To Windows
     [Documentation]    This test verifies if the DUT can boot to multiple OS one after another multiple times.
+    [Tags]    stress-test
     Depends On    ${TESTS_IN_UBUNTU_SUPPORT}
     Depends On    ${TESTS_IN_WINDOWS_SUPPORT}
     FOR    ${i}    IN RANGE    5

--- a/self-tests/setup-and-boot-menus.robot
+++ b/self-tests/setup-and-boot-menus.robot
@@ -181,6 +181,7 @@ Test TianoCore Reset System
 
 Test Exit From Current Menu
     [Documentation]    Test Exit From Current Menu kwd
+    [Tags]    stress-test
     Power On
     ${setup_menu}=    Enter Setup Menu Tianocore And Return Construction
     Enter Submenu From Snapshot    ${setup_menu}    Device Manager
@@ -196,6 +197,7 @@ Test Exit From Current Menu
 
 Test Reenter Menu
     [Documentation]    Test Reenter Menu kwd
+    [Tags]    stress-test
     Power On
     ${setup_menu}=    Enter Setup Menu Tianocore And Return Construction
     Enter Submenu From Snapshot    ${setup_menu}    Device Manager
@@ -206,6 +208,7 @@ Test Reenter Menu
     END
 
 Get Menu Construction Stress Test
+    [Tags]    stress-test
     Set Test Variable    ${MENU_TEST}    Device manager
     Set Test Variable    ${DEVICE_MGR_MENU_TEST}    Secure Boot Configuration
     Set Test Variable    ${SB_MENU_TEST}    Current Secure Boot State


### PR DESCRIPTION
The stress tests which take more than half of the total self-tests time were separated into a new workflow, that runs every day on midnight instead of on every PR/push to save a whole lot of time, as stress-testing on every change shouldn't be necessary