### PR TITLE
scripts/ci/qemu-run.sh: Add support for VirtIO drive interface

### DIFF
--- a/lib/QemuMonitor.py
+++ b/lib/QemuMonitor.py
@@ -41,6 +41,7 @@ class QemuMonitor:
         self._open()
         logger.trace(self._send("qmp_capabilities"))
         response = self._send(command, **args)
+        logger.trace(response)
         self._close()
         if "error" in response:
             logger.error(f"Command '{command}' failed with error: {response['error']}")
@@ -89,115 +90,114 @@ class QemuMonitor:
         return self._send_cmd("quit")
 
     @keyword("Add HDD To Qemu")
-    def blockdev_add(self, img_name):
-        contains_mydisk = self._check_if_block_node_exists("mydisk")
-        logger.trace(f"contains_mydisk: {contains_mydisk}")
-
-        if contains_mydisk:
-            blockdev_del_params = {"node-name": "mydisk"}
-            self._send_cmd("blockdev-del", **blockdev_del_params)
+    def blockdev_add(self, img_path, name="unnamed"):
+        self.hdd_del(name)
 
         blockdev_add_params = {
-            "node-name": "mydisk",
-            "driver": "file",
-            "filename": img_name,
-            "aio": "threads",
-            "cache": {"direct": True, "no-flush": False},
+            "node-name": self._hdd_nodename(name),
+            "driver": "raw",
+            "file": {
+                "driver": "file",
+                "filename": img_path,
+            },
             "read-only": True,
         }
         logger.trace(self._send_cmd("blockdev-add", **blockdev_add_params))
 
         device_add_params = {
             "driver": "scsi-hd",
-            "drive": "mydisk",
+            "drive": self._hdd_nodename(name),
+            "id": self._hdd_devid(name),
             "bus": "scsi.0",
-            "id": "myhdd",
         }
         return self._send_cmd("device_add", **device_add_params)
 
     @keyword("Remove Drive From Qemu")
-    def device_del(self, nodename):
-        contains_node = self._check_if_block_node_exists(nodename)
-        logger.trace(f"contains_{nodename}: {contains_node}")
+    def hdd_del(self, name="unnamed"):
+        contains_node = self._check_if_block_node_exists(self._hdd_nodename(name))
+        logger.trace(f"contains_{self._hdd_nodename(name)}: {contains_node}")
 
         if contains_node:
-            blockdevs = self._send_cmd("query-block")["return"]
-            for dev in blockdevs:
-                print(dev.keys())
-                if "inserted" in dev.keys():
-                    print(dev["inserted"]["node-name"])
-
-            node_id = [
-                dev["qdev"]
-                for dev in blockdevs
-                if "inserted" in dev.keys() and dev["inserted"]["node-name"] == nodename
-            ]
-            print(node_id)
-            if len(node_id) != 1:
-                print("device not found")
-                print(node_id)
-                raise "TODO!@# Device not found"
-            node_id = node_id[0]
-
-            device_del_params = {"id": node_id}
-            return self._send_cmd("device_del", **device_del_params)
-
-            # blockdev_del_params = {
-            #     "node-name": nodename
-            # }
-            # return self._send_cmd("blockdev-del", **blockdev_del_params)
-
-    @keyword("Add USB To Qemu")
-    def usb_add(self, img_name):
-        contains_file_iso = self._check_if_block_node_exists("file_iso")
-        logger.trace(f"contains_file_iso: {contains_file_iso}")
-
-        if contains_file_iso:
             try:
-                logger.trace(self._send_cmd("device_del", id="usbdisk"))
-            except Exception:
+                self._send_cmd("device_del", **{"id": self._hdd_devid(name)})
+            except:
                 pass
             time.sleep(2)
-
-            blockdev__del_params = {
-                "node-name": "drive-iso",
-            }
             try:
-                logger.trace(self._send_cmd("blockdev-del", **blockdev_del_params))
+                self._send_cmd(
+                    "blockdev-del", **{"node-name": self._hdd_nodename(name)}
+                )
+            except:
+                pass
+
+    @keyword("Add USB To Qemu")
+    def usb_add(self, img_path, name="unnamed"):
+        contains_file_node = self._check_if_block_node_exists(
+            self._usb_file_nodename(name)
+        )
+        logger.trace(f"contains file node: {contains_file_node}")
+
+        if contains_file_node:
+            try:
+                self._send_cmd("device_del", id=self._usb_devid(name))
             except Exception:
                 pass
             time.sleep(2)
 
             blockdev_del_params = {
-                "node-name": "file_iso",
+                "node-name": self._usb_nodename(name),
             }
-            logger.trace(self._send_cmd("blockdev-del", **blockdev_del_params))
+            try:
+                self._send_cmd("blockdev-del", **blockdev_del_params)
+            except Exception:
+                pass
+            time.sleep(2)
+
+            blockdev_del_params = {
+                "node-name": self._usb_file_nodename(name),
+            }
+            self._send_cmd("blockdev-del", **blockdev_del_params)
             time.sleep(2)
 
         blockdev_params = {
-            "node-name": "file_iso",
+            "node-name": self._usb_file_nodename(name),  # "file_iso"
             "driver": "file",
-            "filename": img_name,
+            "filename": img_path,
             "auto-read-only": True,
             "discard": "unmap",
         }
-        logger.trace(self._send_cmd("blockdev-add", **blockdev_params))
+        self._send_cmd("blockdev-add", **blockdev_params)
 
         drive_params = {
             "driver": "raw",
-            "file": "file_iso",
-            "node-name": "drive-iso",
+            "file": self._usb_file_nodename(name),
+            "node-name": self._usb_nodename(name),  # "drive-iso",
             "read-only": True,
             "discard": "unmap",
         }
-        logger.trace(self._send_cmd("blockdev-add", **drive_params))
+        self._send_cmd("blockdev-add", **drive_params)
 
         usb_storage_params = {
             "driver": "usb-storage",
-            "id": "usbdisk",
-            "drive": "drive-iso",
+            "id": self._usb_devid(name),  # "usbdisk",
+            "drive": self._usb_nodename(name),
         }
-        logger.trace(self._send_cmd("device_add", **usb_storage_params))
+        self._send_cmd("device_add", **usb_storage_params)
+
+    def _usb_file_nodename(self, name):
+        return "usb_file_node_" + name
+
+    def _usb_nodename(self, name):
+        return "usb_node_" + name
+
+    def _usb_devid(self, name):
+        return "usb_devid_" + name
+
+    def _hdd_nodename(self, name):
+        return "hdd_node_" + name
+
+    def _hdd_devid(self, name):
+        return "hdd_devid_" + name
 
     def __del__(self):
         self._close()

--- a/lib/QemuMonitor.py
+++ b/lib/QemuMonitor.py
@@ -44,7 +44,9 @@ class QemuMonitor:
         self._close()
         if "error" in response:
             logger.error(f"Command '{command}' failed with error: {response['error']}")
-            raise RuntimeError(f"QEMU monitor error response: {response['error']['desc']}")
+            raise RuntimeError(
+                f"QEMU monitor error response: {response['error']['desc']}"
+            )
         return response
 
     def _send(self, command, **args):
@@ -92,9 +94,7 @@ class QemuMonitor:
         logger.trace(f"contains_mydisk: {contains_mydisk}")
 
         if contains_mydisk:
-            blockdev_del_params = {
-                "node-name": "mydisk"
-            } 
+            blockdev_del_params = {"node-name": "mydisk"}
             self._send_cmd("blockdev-del", **blockdev_del_params)
 
         blockdev_add_params = {
@@ -103,7 +103,7 @@ class QemuMonitor:
             "filename": img_name,
             "aio": "threads",
             "cache": {"direct": True, "no-flush": False},
-            "read-only": True
+            "read-only": True,
         }
         logger.trace(self._send_cmd("blockdev-add", **blockdev_add_params))
 
@@ -116,15 +116,36 @@ class QemuMonitor:
         return self._send_cmd("device_add", **device_add_params)
 
     @keyword("Remove Drive From Qemu")
-    def device_del(self):
-        contains_mydisk = self._check_if_block_node_exists("file_iso")
-        logger.trace(f"contains_mydisk: {contains_mydisk}")
+    def device_del(self, nodename):
+        contains_node = self._check_if_block_node_exists(nodename)
+        logger.trace(f"contains_{nodename}: {contains_node}")
 
-        if contains_mydisk:
-            blockdev_del_params = {
-                "node-name": "mydisk"
-            } 
-            return self._send_cmd("blockdev-del", **blockdev_del_params)
+        if contains_node:
+            blockdevs = self._send_cmd("query-block")["return"]
+            for dev in blockdevs:
+                print(dev.keys())
+                if "inserted" in dev.keys():
+                    print(dev["inserted"]["node-name"])
+
+            node_id = [
+                dev["qdev"]
+                for dev in blockdevs
+                if "inserted" in dev.keys() and dev["inserted"]["node-name"] == nodename
+            ]
+            print(node_id)
+            if len(node_id) != 1:
+                print("device not found")
+                print(node_id)
+                raise "TODO!@# Device not found"
+            node_id = node_id[0]
+
+            device_del_params = {"id": node_id}
+            return self._send_cmd("device_del", **device_del_params)
+
+            # blockdev_del_params = {
+            #     "node-name": nodename
+            # }
+            # return self._send_cmd("blockdev-del", **blockdev_del_params)
 
     @keyword("Add USB To Qemu")
     def usb_add(self, img_name):

--- a/lib/QemuMonitor.py
+++ b/lib/QemuMonitor.py
@@ -61,6 +61,15 @@ class QemuMonitor:
         else:
             return json_objects[0]
 
+    def _check_if_block_node_exists(self, block_node):
+        block_nodes = self._send_cmd("query-named-block-nodes")
+
+        contains_node = any(
+            block.get("node-name") == block_node
+            for block in block_nodes.get("return", [])
+        )
+        return contains_node
+
     @keyword
     def qmp_capabilities(self):
         return self._send_cmd("qmp_capabilities")
@@ -79,14 +88,24 @@ class QemuMonitor:
 
     @keyword("Add HDD To Qemu")
     def blockdev_add(self, img_name):
+        contains_mydisk = self._check_if_block_node_exists("mydisk")
+        logger.trace(f"contains_mydisk: {contains_mydisk}")
+
+        if contains_mydisk:
+            blockdev_del_params = {
+                "node-name": "mydisk"
+            } 
+            self._send_cmd("blockdev-del", **blockdev_del_params)
+
         blockdev_add_params = {
             "node-name": "mydisk",
             "driver": "file",
             "filename": img_name,
             "aio": "threads",
             "cache": {"direct": True, "no-flush": False},
+            "read-only": True
         }
-        print(self._send_cmd("blockdev-add", **blockdev_add_params))
+        logger.trace(self._send_cmd("blockdev-add", **blockdev_add_params))
 
         device_add_params = {
             "driver": "scsi-hd",
@@ -98,23 +117,41 @@ class QemuMonitor:
 
     @keyword("Remove Drive From Qemu")
     def device_del(self):
-        return self._send_cmd("device_del", id="myhdd")
+        contains_mydisk = self._check_if_block_node_exists("file_iso")
+        logger.trace(f"contains_mydisk: {contains_mydisk}")
+
+        if contains_mydisk:
+            blockdev_del_params = {
+                "node-name": "mydisk"
+            } 
+            return self._send_cmd("blockdev-del", **blockdev_del_params)
 
     @keyword("Add USB To Qemu")
     def usb_add(self, img_name):
-        # first make sure to get rid of any previous instance
-        print(self._send_cmd("device_del", id="usbdisk"))
-        time.sleep(2)
-        blockdev_params = {
-            "node-name": "drive-iso",
-        }
-        print(self._send_cmd("blockdev-del", **blockdev_params))
-        time.sleep(2)
-        blockdev_params = {
-            "node-name": "file_iso",
-        }
-        print(self._send_cmd("blockdev-del", **blockdev_params))
-        time.sleep(2)
+        contains_file_iso = self._check_if_block_node_exists("file_iso")
+        logger.trace(f"contains_file_iso: {contains_file_iso}")
+
+        if contains_file_iso:
+            try:
+                logger.trace(self._send_cmd("device_del", id="usbdisk"))
+            except Exception:
+                pass
+            time.sleep(2)
+
+            blockdev__del_params = {
+                "node-name": "drive-iso",
+            }
+            try:
+                logger.trace(self._send_cmd("blockdev-del", **blockdev_del_params))
+            except Exception:
+                pass
+            time.sleep(2)
+
+            blockdev_del_params = {
+                "node-name": "file_iso",
+            }
+            logger.trace(self._send_cmd("blockdev-del", **blockdev_del_params))
+            time.sleep(2)
 
         blockdev_params = {
             "node-name": "file_iso",
@@ -123,7 +160,7 @@ class QemuMonitor:
             "auto-read-only": True,
             "discard": "unmap",
         }
-        print(self._send_cmd("blockdev-add", **blockdev_params))
+        logger.trace(self._send_cmd("blockdev-add", **blockdev_params))
 
         drive_params = {
             "driver": "raw",
@@ -132,14 +169,14 @@ class QemuMonitor:
             "read-only": True,
             "discard": "unmap",
         }
-        print(self._send_cmd("blockdev-add", **drive_params))
+        logger.trace(self._send_cmd("blockdev-add", **drive_params))
 
         usb_storage_params = {
             "driver": "usb-storage",
             "id": "usbdisk",
             "drive": "drive-iso",
         }
-        print(self._send_cmd("device_add", **usb_storage_params))
+        logger.trace(self._send_cmd("device_add", **usb_storage_params))
 
     def __del__(self):
         self._close()

--- a/lib/QemuMonitor.py
+++ b/lib/QemuMonitor.py
@@ -42,6 +42,9 @@ class QemuMonitor:
         logger.trace(self._send("qmp_capabilities"))
         response = self._send(command, **args)
         self._close()
+        if "error" in response:
+            logger.error(f"Command '{command}' failed with error: {response['error']}")
+            raise RuntimeError(f"QEMU monitor error response: {response['error']['desc']}")
         return response
 
     def _send(self, command, **args):

--- a/lib/QemuMonitor.py
+++ b/lib/QemuMonitor.py
@@ -54,7 +54,7 @@ class QemuMonitor:
         msg = {"execute": command, "arguments": args}
         logger.trace(f"QemuMonitor command: {msg}")
         self.sock.sendall(json.dumps(msg).encode())
-        response = self.sock.recv(4096).decode()
+        response = self.sock.recv(8192).decode()
         logger.trace(f"QemuMonitor response: {response}")
         json_objects = [
             json.loads(line) for line in response.splitlines() if line.strip()
@@ -183,6 +183,11 @@ class QemuMonitor:
             "drive": self._usb_nodename(name),
         }
         self._send_cmd("device_add", **usb_storage_params)
+
+        contains_file_node = self._check_if_block_node_exists(
+            self._usb_file_nodename(name)
+        )
+        logger.trace(f"contains file node: {contains_file_node}")
 
     def _usb_file_nodename(self, name):
         return "usb_file_node_" + name

--- a/lib/esp-scanning-lib.robot
+++ b/lib/esp-scanning-lib.robot
@@ -30,7 +30,8 @@ Prepare EFI Partition With System Files
 
     Power On
     IF    "${MANUFACTURER}" == "QEMU"
-        Add HDD To Qemu    img_name=${TEST_DATA_DIR}/esp-scanning/esp-scanning-disk.img
+        Add HDD To Qemu    img_path=${TEST_DATA_DIR}/esp-scanning/esp-scanning-disk.img
+        # Add HDD To Qemu    img_path=esp-scanning-disk.img
     ELSE
         Boot System Or From Connected Disk    ${ENV_ID_UBUNTU}
         Login To Linux

--- a/lib/esp-scanning-lib.robot
+++ b/lib/esp-scanning-lib.robot
@@ -31,7 +31,6 @@ Prepare EFI Partition With System Files
     Power On
     IF    "${MANUFACTURER}" == "QEMU"
         Add HDD To Qemu    img_name=${TEST_DATA_DIR}/esp-scanning/esp-scanning-disk.img
-        # Add HDD To Qemu    img_name=esp-scanning-disk.img
     ELSE
         Boot System Or From Connected Disk    ${ENV_ID_UBUNTU}
         Login To Linux
@@ -54,7 +53,7 @@ Clear Out EFI Partition
     Power On
 
     IF    "${MANUFACTURER}" == "QEMU"
-        Remove Drive From Qemu    mydisk
+        Remove Drive From Qemu
     ELSE
         Boot System Or From Connected Disk    ${ENV_ID_UBUNTU}
         Login To Linux

--- a/lib/esp-scanning-lib.robot
+++ b/lib/esp-scanning-lib.robot
@@ -54,7 +54,7 @@ Clear Out EFI Partition
     Power On
 
     IF    "${MANUFACTURER}" == "QEMU"
-        Remove Drive From Qemu
+        Remove Drive From Qemu    mydisk
     ELSE
         Boot System Or From Connected Disk    ${ENV_ID_UBUNTU}
         Login To Linux

--- a/lib/esp-scanning-lib.robot
+++ b/lib/esp-scanning-lib.robot
@@ -31,6 +31,7 @@ Prepare EFI Partition With System Files
     Power On
     IF    "${MANUFACTURER}" == "QEMU"
         Add HDD To Qemu    img_name=${TEST_DATA_DIR}/esp-scanning/esp-scanning-disk.img
+        # Add HDD To Qemu    img_name=esp-scanning-disk.img
     ELSE
         Boot System Or From Connected Disk    ${ENV_ID_UBUNTU}
         Login To Linux

--- a/lib/usb-hid-msc-lib.robot
+++ b/lib/usb-hid-msc-lib.robot
@@ -34,7 +34,6 @@ Mount USB Disk Image
         ${img_dir}    ${img_name}=    Split Path    ${img_source}
 
         IF    "${MANUFACTURER}" == "QEMU"
-            Remove Drive From Qemu
             Add USB To Qemu    img_name=${img_source}
         ELSE IF    "${DUT_CONNECTION_METHOD}" == "pikvm"
             Upload Image To PiKVM    ${img_source}    ${img_name}    ${upload_type}

--- a/lib/usb-hid-msc-lib.robot
+++ b/lib/usb-hid-msc-lib.robot
@@ -31,13 +31,13 @@ Mount USB Disk Image
 
     # TODO:: Move to interface approach, not IF/ELSE tree
     IF    "${upload_type}" == "file"
-        ${img_dir}    ${img_name}=    Split Path    ${img_source}
+        ${img_dir}    ${img_path}=    Split Path    ${img_source}
 
         IF    "${MANUFACTURER}" == "QEMU"
-            Add USB To Qemu    img_name=${img_source}
+            Add USB To Qemu    img_path=${img_source}
         ELSE IF    "${DUT_CONNECTION_METHOD}" == "pikvm"
-            Upload Image To PiKVM    ${img_source}    ${img_name}    ${upload_type}
-            Mount Image On PiKVM    ${img_name}
+            Upload Image To PiKVM    ${img_source}    ${img_path}    ${upload_type}
+            Mount Image On PiKVM    ${img_path}
         ELSE
             # For setups with no real ability to mount USB Disk, we may decide whether we assume that certain USB Disk is prepared beforehand, or we skip the test.
             Log To Console    Mounting USB Disk Image at runtime is not supported on this platform.

--- a/scripts/ci/qemu-run.sh
+++ b/scripts/ci/qemu-run.sh
@@ -155,11 +155,11 @@ QEMU_PARAMS_OS="-device ich9-intel-hda \
   -device virtio-rng-pci,max-bytes=1024,period=1000 \
   -device virtio-net,netdev=vmnic \
   -netdev user,id=vmnic,hostfwd=tcp::5222-:22 \
-  -drive file=${HDD_PATH},if=ide"
+  -drive file=${HDD_PATH},if=virtio"
 
 if [[ -f ${HDD2_PATH} ]]; then
   QEMU_PARAMS_OS+=" \
-  -drive file=${HDD2_PATH},if=ide"
+  -drive file=${HDD2_PATH},if=virtio"
 
   echo "Using ${HDD2_PATH} as the second drive"
 fi


### PR DESCRIPTION
Use `if=virtio` instead of `if=ide` in QEMU commandline for improved performance with edk2 bundling VirtIO drivers.

See https://github.com/Dasharo/dasharo-issues/issues/901#issuecomment-3005462400 for context.