### PR TITLE
Fix nightly stress tests fails

### DIFF
--- a/.github/workflows/qemu-self-test.yml
+++ b/.github/workflows/qemu-self-test.yml
@@ -1,10 +1,15 @@
-# SPDX-FileCopyrightText: 2024 3mdeb <contact@3mdeb.com>
+# SPDX-FileCopyrightText: 2025 3mdeb <contact@3mdeb.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 
 name: Keywords self-tests with QEMU
 
-on: [push, pull_request]
+on:
+  schedule:
+    - cron: '0 0 * * *' # Every day at midnight
+  workflow_dispatch:
+  pull_request:
+
 
 jobs:
   qemu:

--- a/.github/workflows/qemu-stress-tests.yml
+++ b/.github/workflows/qemu-stress-tests.yml
@@ -1,12 +1,15 @@
-# SPDX-FileCopyrightText: 2024 3mdeb <contact@3mdeb.com>
+# SPDX-FileCopyrightText: 2025 3mdeb <contact@3mdeb.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: Keywords self-tests with QEMU
+name: Keywords stress-tests with QEMU
 
 on:
   schedule:
     - cron: '0 0 * * *' # Every day at midnight
+  workflow_dispatch:
+  pull_request:
+
 
 jobs:
   qemu:

--- a/scripts/ci/qemu-self-test.sh
+++ b/scripts/ci/qemu-self-test.sh
@@ -1,30 +1,20 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2024 3mdeb <contact@3mdeb.com>
+# SPDX-FileCopyrightText: 2025 3mdeb <contact@3mdeb.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Define an array of commands
-commands=(
-  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/setup-and-boot-menus -v snipeit:no --exclude stress-test self-tests/setup-and-boot-menus.robot"
-  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/dasharo-system-features-menus -v snipeit:no --exclude stress-test self-tests/dasharo-system-features-menus.robot"
-  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/boolean-options -v snipeit:no --exclude stress-test self-tests/boolean-options.robot"
-  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/numerical-options -v snipeit:no --exclude stress-test self-tests/numerical-options.robot"
-  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/list-options -v snipeit:no --exclude stress-test self-tests/list-options.robot"
-  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/self-tests -v snipeit:no --exclude stress-test self-tests/terminal.robot"
+export RTE_IP=127.0.0.1
+export CONFIG=qemu-selftests
+export SNIPEIT_NO=1
+
+suites=(
+  "self-tests/setup-and-boot-menus.robot"
+  "self-tests/dasharo-system-features.robot"
+  "self-tests/boolean-options.robot"
+  "self-tests/numerical-options.robot"
+  "self-tests/list-options.robot"
+  "self-tests/terminal.robot"
 )
 
-# Initialize a variable to track overall success
-overall_success=0
-
-# Execute each command and capture the exit codes
-for cmd in "${commands[@]}"; do
-  eval $cmd
-  exit_code=$?
-  if [ $exit_code -ne 0 ]; then
-    overall_success=1
-  fi
-done
-
-# Exit with the appropriate status
-exit $overall_success
+./scripts/run.sh "${suites[@]}" -- --exclude stress-test

--- a/scripts/ci/qemu-stress-tests.sh
+++ b/scripts/ci/qemu-stress-tests.sh
@@ -1,31 +1,16 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2024 3mdeb <contact@3mdeb.com>
+# SPDX-FileCopyrightText: 2025 3mdeb <contact@3mdeb.com>
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Define an array of commands
+export RTE_IP=127.0.0.1
+export CONFIG=qemu-selftests
+export SNIPEIT_NO=1
 
-commands=(
-  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/setup-and-boot-menus -v snipeit:no --include stress-test self-tests/setup-and-boot-menus.robot"
-  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/dasharo-system-features-menus -v snipeit:no --include stress-test self-tests/dasharo-system-features-menus.robot"
-  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/boolean-options -v snipeit:no --include stress-test self-tests/boolean-options.robot"
-  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/numerical-options -v snipeit:no --include stress-test self-tests/numerical-options.robot"
-  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/list-options -v snipeit:no --include stress-test self-tests/list-options.robot"
-  "robot -L TRACE -v config:qemu-selftests -v rte_ip:127.0.0.1 -d ./logs/$(date +%Y.%m.%d_%H.%M.%S)/self-tests -v snipeit:no --include stress-test self-tests/terminal.robot"
+
+suites=(
+  "self-tests/setup-and-boot-menus.robot"
 )
 
-# Initialize a variable to track overall success
-overall_success=0
-
-# Execute each command and capture the exit codes
-for cmd in "${commands[@]}"; do
-  eval $cmd
-  exit_code=$?
-  if [ $exit_code -ne 0 ]; then
-    overall_success=1
-  fi
-done
-
-# Exit with the appropriate status
-exit $overall_success
+./scripts/run.sh "${suites[@]}" -- --include stress-test

--- a/self-tests/os-boot.robot
+++ b/self-tests/os-boot.robot
@@ -1,3 +1,7 @@
+*** Comments ***
+# robocop: off=could-be-test-tags
+
+
 *** Settings ***
 Documentation       This suite verifies the correct operation of keywords
 ...                 getting and setting state of boolean options.
@@ -24,12 +28,11 @@ Suite Setup         Run Keyword
 Suite Teardown      Run Keyword
 ...                     Log Out And Close Connection
 
-Test Tags           stress-test
-
 
 *** Test Cases ***
 BOT001.001 Boot To Ubuntu Multiple Times
     [Documentation]    This test verifies if the DUT can boot to Ubuntu multiple times in a row.
+    [Tags]    stress-test
     Depends On    ${TESTS_IN_UBUNTU_SUPPORT}
     FOR    ${i}    IN RANGE    5
         ${index}=    Evaluate    ${i} + 1
@@ -42,6 +45,7 @@ BOT001.001 Boot To Ubuntu Multiple Times
 
 BOT002.001 Boot To Windows Multiple Times
     [Documentation]    This test verifies if the DUT can boot to Windows multiple times in a row.
+    [Tags]    stress-test
     Depends On    ${TESTS_IN_WINDOWS_SUPPORT}
     FOR    ${i}    IN RANGE    5
         ${index}=    Evaluate    ${i} + 1
@@ -53,6 +57,7 @@ BOT002.001 Boot To Windows Multiple Times
 
 BOT003.001 Boot To Ubuntu Then Boot To Windows
     [Documentation]    This test verifies if the DUT can boot to multiple OS one after another multiple times.
+    [Tags]    stress-test
     Depends On    ${TESTS_IN_UBUNTU_SUPPORT}
     Depends On    ${TESTS_IN_WINDOWS_SUPPORT}
     FOR    ${i}    IN RANGE    5


### PR DESCRIPTION
The tests were failing because robot was run on single files instead of the whole module, so it produced an error if no `stress-test` tag was found in the selected file. Using the `run.sh` wrapper the results will be closer to what a tester would experience and the self tests scripts can be simplified because they were doing pretty much the same thing as run.sh.

The qemu-self-tests.sh script was updated too to work the same way.