### PR TITLE
.pre-commit-config.yml: scripts/freebsd excluded from shellcheck

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,7 @@ repos:
     rev: v0.10.0
     hooks:
       - id: shellcheck
+        exclude: ^scripts/freebsd/
         args: ["--severity=warning"]
 
   - repo: https://github.com/pycqa/isort


### PR DESCRIPTION
I need this to avoid shellcheck failure on `local` command required by FreeBSD shell.

In scripts/freebsd/preseed_opnsense.sh line 29:
    local new_esp_label="$1" file_prefix="$2" file_to_patch="$3"
    ^-- SC3043 (warning): In POSIX sh, 'local' is undefined.
