### PR TITLE
regression-scope/rules.json: Fix env args order

### DIFF
--- a/scripts/ci/regression-scope/rules.json
+++ b/scripts/ci/regression-scope/rules.json
@@ -7,10 +7,10 @@
                 {
                     "env_vars": {
                         "RTE_IP": "192.168.10.199",
-                        "SONOFF_IP": "192.168.10.169",
-                        "PIKVM_IP": "192.168.10.120",
                         "SNIPEIT_NO": "true",
-                        "CONFIG": "msi-pro-z690-a-wifi-ddr4"
+                        "CONFIG": "msi-pro-z690-a-wifi-ddr4",
+                        "SONOFF_IP": "192.168.10.169",
+                        "PIKVM_IP": "192.168.10.120"
                     },
                     "files": {
                         "mode": "${FULL_FILENAME_MATCH}"
@@ -36,9 +36,9 @@
                     "env_vars": {
                         "RTE_IP": "192.168.10.199",
                         "SNIPEIT_NO": "true",
+                        "CONFIG": "msi-pro-z690-a-wifi-ddr4",
                         "SONOFF_IP": "192.168.10.169",
-                        "PIKVM_IP": "192.168.10.120",
-                        "CONFIG": "msi-pro-z690-a-wifi-ddr4"
+                        "PIKVM_IP": "192.168.10.120"
                     },
                     "files": {
                         "mode": "${FILE_CONTAINS_MATCH}",


### PR DESCRIPTION
Fixes issues with hardware regression scope determining found in https://github.com/Dasharo/open-source-firmware-validation/pull/915#issuecomment-3036761018

Hardware CI after rebasing onto sv-boot branch to cause the same tests to be run:
https://github.com/Dasharo/open-source-firmware-validation/actions/runs/16088355575/job/45402217679?pr=925
