### PR TITLE
scripts/ci/qemu-run.sh: Add support for VirtIO drive interface

### DIFF
--- a/scripts/ci/qemu-run.sh
+++ b/scripts/ci/qemu-run.sh
@@ -155,11 +155,11 @@ QEMU_PARAMS_OS="-device ich9-intel-hda \
   -device virtio-rng-pci,max-bytes=1024,period=1000 \
   -device virtio-net,netdev=vmnic \
   -netdev user,id=vmnic,hostfwd=tcp::5222-:22 \
-  -drive file=${HDD_PATH},if=ide"
+  -drive file=${HDD_PATH},if=virtio"
 
 if [[ -f ${HDD2_PATH} ]]; then
   QEMU_PARAMS_OS+=" \
-  -drive file=${HDD2_PATH},if=ide"
+  -drive file=${HDD2_PATH},if=virtio"
 
   echo "Using ${HDD2_PATH} as the second drive"
 fi


### PR DESCRIPTION
Use `if=virtio` instead of `if=ide` in QEMU commandline for improved performance with edk2 bundling VirtIO drivers.

See https://github.com/Dasharo/dasharo-issues/issues/901#issuecomment-3005462400 for context. This PR is for merging into the `develop` branch, [as requested](https://github.com/Dasharo/open-source-firmware-validation/pull/905#issuecomment-3068451172). [Here](https://github.com/aronowski/coreboot/actions/runs/16277409813/job/45960352691)'s an example coreboot test suite run, which proves, that this works (the esp-scanning.robot suite added as per https://github.com/Dasharo/coreboot/pull/712).
