### PR TITLE
Ci on hw fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -133,3 +133,14 @@ repos:
         entry: ./scripts/ci/test_ids/check_sort.py
         args: ["--fix"]
         files: 'test_cases.json'
+
+      - id: check-platform-config-vars
+        name: Check Platform Config Variables
+        description: Check if platform config file define variables not present in include/default.robot
+        language: python
+        additional_dependencies:
+          - robotframework
+        entry: ./scripts/ci/check_platform_configs_vars.py
+        args: []
+        files: '^.*\.robot$'
+        pass_filenames: false

--- a/dasharo-compatibility/check-ethernet-ports-order.robot
+++ b/dasharo-compatibility/check-ethernet-ports-order.robot
@@ -23,7 +23,7 @@ Default Tags        automated
 SPS001.001 Ethernet ports are in order
     [Documentation]    This test automates the verification of port order based
     ...    on PCIe bus numbers and checks PCIe switching.
-    Skip If    '''${ETH_PORTS}''' == ''    not supported
+    Depends On    '${ETH_PORTS}' != '@{EMPTY}'    not supported
     Power On
     Boot System Or From Connected Disk    ${ENV_ID_UBUNTU}
     Login To Linux

--- a/dasharo-compatibility/network-speed.robot
+++ b/dasharo-compatibility/network-speed.robot
@@ -29,8 +29,8 @@ ETHPERF001.201 Check Performance of 2.5G Wired Network Interface (Ubuntu)
     ...
     ...    Previous IDs: ETHPERF001.001
     [Tags]    semiauto
-    Depends On    ${ETH_PERF_PAIR_2_G}
-    Depends On    ${ETH_PORTS}
+    Depends On    '${ETH_PERF_PAIR_2_G}' != '@{EMPTY}'
+    Depends On    '${ETH_PORTS}' != '@{EMPTY}'
 
     ${eth_ports_number}=    Get Length    ${ETH_PORTS}
     IF    '${eth_ports_number}' == '2'
@@ -81,7 +81,7 @@ ETHPERF002.201 Check Performance of 10G Wired Network Interface (Ubuntu)
     ...
     ...    Previous IDs: ETHPERF002.001
     [Tags]    automated
-    Depends On    ${ETH_PERF_PAIR_10_G}
+    Depends On    '${ETH_PERF_PAIR_10_G}' != '@{EMPTY}'
     Power On
     Boot System Or From Connected Disk    ${ENV_ID_UBUNTU}
     Login To Linux

--- a/lib/framework.robot
+++ b/lib/framework.robot
@@ -8,10 +8,11 @@ Depends On Variable
 Depends On
     [Documentation]    Skips test if ``condition`` is not met. Test identifier
     ...    (first word of its name) and optional ``reason`` is set
-    ...    to the test as per ```Skip`` keyword.
+    ...    to the test as per ``Skip`` keyword.
     [Arguments]    ${condition}    ${reason}=${NONE}
     ${line}=    Set Variable    ${TEST_NAME.split()}[0] not supported
-    IF    """${reason}""" != """${NONE}"""
+    IF    "${reason}" != "${NONE}"
         ${line}=    Set Variable    ${line}: ${reason}
     END
-    Skip If    not ${condition}    ${line}
+    ${should_skip}=    Evaluate    not bool(${condition})
+    Skip If    ${should_skip}    ${line}

--- a/platform-configs/include/default.robot
+++ b/platform-configs/include/default.robot
@@ -296,6 +296,12 @@ ${USE_ANSIBLE}=                                     ${TRUE}
 ${TESTS_IN_XCP_NG_SUPPORT}=                         ${FALSE}
 ${TESTS_IN_ESXI_SUPPORT}=                           ${FALSE}
 
+@{ETH_PERF_PAIR_10_G}=                              @{EMPTY}
+@{ETH_PERF_PAIR_1_G}=                               @{EMPTY}
+@{ETH_PERF_PAIR_2_G}=                               @{EMPTY}
+@{ETH_PORTS}=                                       @{EMPTY}
+@{ETH_SFP_PORTS}=                                   @{EMPTY}
+
 # These were missing in default.robot and have been automatically
 # identified and added via: ./scripts/ci/check_platform_configs_vars.py
 
@@ -384,11 +390,6 @@ ${WIN_SEQ_WRITE_QUEUED}=                            ${TBD}
 ${ZIP_MULTI_COMPRESSION}=                           ${TBD}
 ${ZIP_MULTI_DECOMPRESSION}=                         ${TBD}
 ${FAN_RPM_MEASUREMENT_SENSOR_MODULE}=               ${TBD}
-@{ETH_PERF_PAIR_10_G}=                              ${TBD}
-@{ETH_PERF_PAIR_1_G}=                               ${TBD}
-@{ETH_PERF_PAIR_2_G}=                               ${TBD}
-@{ETH_PORTS}=                                       ${TBD}
-@{ETH_SFP_PORTS}=                                   ${TBD}
 
 
 *** Keywords ***

--- a/platform-configs/include/default.robot
+++ b/platform-configs/include/default.robot
@@ -296,6 +296,7 @@ ${BOOTED_OS_ID}=                                    ${DEFAULT_BOOT_OS_ID}
 
 ${USE_ANSIBLE}=                                     ${TRUE}
 ${TESTS_IN_XCP_NG_SUPPORT}=                         ${FALSE}
+${TESTS_IN_ESXI_SUPPORT}=                           ${FALSE}
 
 
 *** Keywords ***

--- a/platform-configs/include/default.robot
+++ b/platform-configs/include/default.robot
@@ -5,7 +5,7 @@ Variables       ../../os-config/environment-test-ids.py
 
 *** Variables ***
 ${TBD}=
-...                                                 TBD_variable_not_set_03626549a59abf648ee59163b3b8acbf66c36513cb1e76d6e277bc044c926e30
+...                                                 TBD_variable_not_set_and_should_be_defined_in_platform_config_if_needed
 ${INITIAL_DUT_CONNECTION_METHOD}=                   ${TBD}
 ${DUT_CONNECTION_METHOD}=                           ${TBD}
 ${PAYLOAD}=                                         tianocore
@@ -81,6 +81,7 @@ ${TESTS_IN_DEBIAN_SUPPORT}=                         ${FALSE}
 ${TESTS_IN_WINDOWS_SUPPORT}=                        ${FALSE}
 ${TESTS_IN_METATB_SUPPORT}=                         ${FALSE}
 ${TESTS_IN_HEADS_SUPPORT}=                          ${FALSE}
+${TESTS_IN_FEDORA_SUPPORT}=                         ${FALSE}
 
 # Regression test flags
 ${DASHARO_SECURITY_MENU_SUPPORT}=                   ${FALSE}
@@ -94,6 +95,7 @@ ${DASHARO_PCIE_REBAR_SUPPORT}=                      ${FALSE}
 ${DASHARO_MEMORY_MENU_SUPPORT}=                     ${FALSE}
 ${DASHARO_SERIAL_PORT_MENU_SUPPORT}=                ${TRUE}
 # Test module: dasharo-compatibility
+${ACPI_DRIVER_SUPPORT}=                             ${FALSE}
 ${BASE_PORT_ALLOCATOR_V4_SUPPORT}=                  ${FALSE}
 ${CUSTOM_BOOT_MENU_KEY_SUPPORT}=                    ${FALSE}
 ${CUSTOM_SETUP_MENU_KEY_SUPPORT}=                   ${FALSE}
@@ -213,9 +215,6 @@ ${DGPU_ONLY_SUPPORT}=                               ${FALSE}
 # measuring temperatures, fans etc.
 ${SENSORS_CONFIG_FILE}=                             include/sensors/default-sensors-config.yaml
 ${CUSTOM_FAN_CURVE_FILE}=                           ${TBD}
-${ETH_PERF_PAIR_1_G}=                               ${FALSE}
-${ETH_PERF_PAIR_2_G}=                               ${FALSE}
-${ETH_PERF_PAIR_10_G}=                              ${FALSE}
 ${DISK_IO_PERFORMANCE_TESTS}=                       ${FALSE}
 ${CPU_PERFORMANCE_TESTS_SUPPORT}=                   ${FALSE}
 ${GPU_PERFORMANCE_TESTS_SUPPORT}=                   ${FALSE}
@@ -287,7 +286,6 @@ ${STABILITY_DETECTION_WARMBOOT_ITERATIONS}=         2
 ${STABILITY_DETECTION_REBOOT_ITERATIONS}=           5
 ${STABILITY_DETECTION_SUSPEND_ITERATIONS}=          5
 ${DCU_SUPPORTED_BOOLEAN_SMMSTORE_VARIABLE}=         NetworkBoot
-${ETH_PORTS}=                                       ${EMPTY}
 ${WINDOWS_SHUTDOWN_AWAITING_SECONDS}=               120
 
 @{TESTED_LINUX_DISTROS}=                            ${ENV_ID_UBUNTU}
@@ -297,6 +295,100 @@ ${BOOTED_OS_ID}=                                    ${DEFAULT_BOOT_OS_ID}
 ${USE_ANSIBLE}=                                     ${TRUE}
 ${TESTS_IN_XCP_NG_SUPPORT}=                         ${FALSE}
 ${TESTS_IN_ESXI_SUPPORT}=                           ${FALSE}
+
+# These were missing in default.robot and have been automatically
+# identified and added via: ./scripts/ci/check_platform_configs_vars.py
+
+${AUTO_BOOT_TIME_OUT_DEFAULT_VALUE}=                ${TBD}
+${BLAKE2_TEST_SCORE}=                               ${TBD}
+${BLUETOOTH_CARD_UBUNTU}=                           ${TBD}
+${CACHEBENCH_TEST_SCORE}=                           ${TBD}
+${CLEVO_BATTERY_CAPACITY}=                          ${TBD}
+${CLEVO_DISK}=                                      ${TBD}
+${CLEVO_USB_C_HUB}=                                 ${TBD}
+${COREMARK_SINGLE}=                                 ${TBD}
+${CPU_E_CORES_MAX}=                                 ${TBD}
+${CPU_MAX_FREQUENCY}=                               ${TBD}
+${CPU_MIN_FREQUENCY}=                               ${TBD}
+${CPU_P_CORES_MAX}=                                 ${TBD}
+${CPU_TEMPERATURE_MEASUREMENT_METHOD}=              ${TBD}
+${CRAFTY_TEST_SCORE}=                               ${TBD}
+${CRAY_1080_P_RENDER}=                              ${TBD}
+${CRAY_4_K_RENDER}=                                 ${TBD}
+${CRAY_5_K_RENDER}=                                 ${TBD}
+${CUSTOM_FAN_CURVE_COOLDOWN_SECONDS}=               ${TBD}
+${DEF_CORES_PER_SOCKET}=                            ${TBD}
+${DEF_CORES}=                                       ${TBD}
+${DEF_CPU}=                                         ${TBD}
+${DEF_ONLINE_CPU}=                                  ${TBD}
+${DEF_SOCKETS}=                                     ${TBD}
+${DEF_THREADS_PER_CORE}=                            ${TBD}
+${DEF_THREADS_TOTAL}=                               ${TBD}
+${DEF_THREADS}=                                     ${TBD}
+${DEVICE_AUDIO1_WIN}=                               ${TBD}
+${DEVICE_AUDIO1}=                                   ${TBD}
+${DEVICE_AUDIO2}=                                   ${TBD}
+${DEVICE_USB_PASSWORD}=                             ${TBD}
+${DEVICE_USB_PROMPT}=                               ${TBD}
+${DEVICE_USB_ROOT_PROMPT}=                          ${TBD}
+${DEVICE_USB_USERNAME}=                             ${TBD}
+${DRAM_SIZE}=                                       ${TBD}
+${EC_NO_SYNC_DOWNLOAD_LINK}=                        ${TBD}
+${EC_NO_SYNC_VERSION}=                              ${TBD}
+${ETHERNET_ID}=                                     ${TBD}
+${EXTERNAL_HEADSET}=                                ${TBD}
+${E_MMC_NAME}=                                      ${TBD}
+${FAN_PWM_MEASUREMENT_HWMON_PATH}=                  ${TBD}
+${FAN_PWM_MEASUREMENT_METHOD}=                      ${TBD}
+${FAN_RPM_MEASUREMENT_METHOD}=                      ${TBD}
+${FAN_RPM_MEASUREMENT_SENSOR}=                      ${TBD}
+${FLASH_VERIFY_OPTION}=                             ${TBD}
+${FW_NO_EC_SYNC_DOWNLOAD_LINK}=                     ${TBD}
+${FW_NO_EC_SYNC_VERSION}=                           ${TBD}
+${HAS_E_CORES}=                                     ${TBD}
+${HIBERNATION_ITERATIONS_NUMBER}=                   ${TBD}
+${INITIAL_CPU_FREQUENCY}=                           ${TBD}
+${ITERATIONS}=                                      ${TBD}
+${LTE_CARD}=                                        ${TBD}
+${MAX_CPU_TEMP_THRESHOLD}=                          ${TBD}
+${ONLY_FLASH_BIOS}=                                 ${TBD}
+${OPEN_BMC_PASSWORD}=                               ${TBD}
+${OPEN_BMC_ROOT_PROMPT}=                            ${TBD}
+${OPEN_BMC_USERNAME}=                               ${TBD}
+${OS_DUT_CONNECTION_METHOD}=                        ${TBD}
+${PLATFORM_CPU_SPEED}=                              ${TBD}
+${PLATFORM_RAM_SIZE}=                               ${TBD}
+${PLATFORM_RAM_SPEED}=                              ${TBD}
+${SD_WIRES_CONNECTED}=                              ${TBD}
+${SD_WIRE_SERIAL1}=                                 ${TBD}
+${SMALLPT_TEST_SCORE}=                              ${TBD}
+${UBU_RAND_READ_NONQUE}=                            ${TBD}
+${UBU_RAND_READ_QUEUED}=                            ${TBD}
+${UBU_RAND_WRITE_NONQUE}=                           ${TBD}
+${UBU_RAND_WRITE_QUEUED}=                           ${TBD}
+${UBU_SEQ_READ_NONQUE}=                             ${TBD}
+${UBU_SEQ_READ_QUEUED}=                             ${TBD}
+${UBU_SEQ_WRITE_NONQUE}=                            ${TBD}
+${UBU_SEQ_WRITE_QUEUED}=                            ${TBD}
+${UNIGINE_SUPERPOSITION_RESULT_AC}=                 ${TBD}
+${UNIGINE_SUPERPOSITION_RESULT_BAT}=                ${TBD}
+${WEBCAM_UBUNTU}=                                   ${TBD}
+${WIN_RAND_READ_NONQUE}=                            ${TBD}
+${WIN_RAND_READ_QUEUED}=                            ${TBD}
+${WIN_RAND_WRITE_NONQUE}=                           ${TBD}
+${WIN_RAND_WRITE_QUEUED}=                           ${TBD}
+${WIN_SEQ_READ_NONQUE}=                             ${TBD}
+${WIN_SEQ_READ_QUEUED}=                             ${TBD}
+${WIN_SEQ_WRITE_NONQUE}=                            ${TBD}
+${WIN_SEQ_WRITE_QUEUED}=                            ${TBD}
+${ZIP_MULTI_COMPRESSION}=                           ${TBD}
+${ZIP_MULTI_DECOMPRESSION}=                         ${TBD}
+${FAN_RPM_MEASUREMENT_SENSOR_MODULE}=               ${TBD}
+@{ETH_PERF_PAIR_10_G}=                              ${TBD}
+@{ETH_PERF_PAIR_1_G}=                               ${TBD}
+@{ETH_PERF_PAIR_2_G}=                               ${TBD}
+@{ETH_PORTS}=                                       ${TBD}
+@{ETH_SFP_PORTS}=                                   ${TBD}
 
 
 *** Keywords ***

--- a/platform-configs/odroid-h4-plus.robot
+++ b/platform-configs/odroid-h4-plus.robot
@@ -34,7 +34,6 @@ ${DCU_UUID_SUPPORT}=                            ${TRUE}
 ${DCU_SERIAL_SUPPORT}=                          ${TRUE}
 ${CUSTOM_LOGO_SUPPORT}=                         ${TRUE}
 ${DCU_SUPPORTED_BOOLEAN_SMMSTORE_VARIABLE}=     ${EMPTY}
-${ETH_PORTS}=                                   ${EMPTY}
 ${USB_DISKS_DETECTION_SUPPORT}=                 ${TRUE}
 ${USB_KEYBOARD_DETECTION_SUPPORT}=              ${TRUE}
 ${NVME_DISK_SUPPORT}=                           ${TRUE}

--- a/platform-configs/raptor-cs_talos2.robot
+++ b/platform-configs/raptor-cs_talos2.robot
@@ -209,7 +209,7 @@ ${FAN_RPM_MEASUREMENT_SENSOR}=                      w83795g-i2c-1-2f
 # the sensor. Dictionary keys:
 # - module - name of the kernel module
 # - force_id - optional force_id arg for modprobe
-&{FAN_RPM_MEASUREMENT_SENSOR_MODULE}=               module=w83795
+${FAN_RPM_MEASUREMENT_SENSOR_MODULE}=               module=w83795
 
 
 *** Keywords ***

--- a/scripts/ci/check_platform_configs_vars.py
+++ b/scripts/ci/check_platform_configs_vars.py
@@ -11,6 +11,7 @@ import sys
 
 from robot.api import get_model
 from robot.api.parsing import Variable, VariableSection
+from robot.running import ResourceFileBuilder
 
 # Define paths
 BASE_DIR = "platform-configs"  # Adjust this if needed
@@ -20,15 +21,8 @@ DEFAULT_ROBOT = os.path.join(INCLUDE_DIR, "default.robot")
 
 def get_defined_variables(file_path):
     """Extract variable names from a Robot Framework file using RF parser."""
-    with open(file_path, encoding="utf-8") as f:
-        model = get_model(f.read())
-
-    variables = set()
-    for section in model.sections:
-        if isinstance(section, VariableSection):
-            for var in section.body:
-                if isinstance(var, Variable):
-                    variables.add(var.name)
+    variables = ResourceFileBuilder().build(file_path).variables
+    variables = set([var.name for var in variables])
     return variables
 
 

--- a/scripts/ci/check_platform_configs_vars.py
+++ b/scripts/ci/check_platform_configs_vars.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2024 3mdeb <contact@3mdeb.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Default value for autofix flag
+
+import os
+import sys
+
+from robot.api import get_model
+from robot.api.parsing import Variable, VariableSection
+
+# Define paths
+BASE_DIR = "platform-configs"  # Adjust this if needed
+INCLUDE_DIR = os.path.join(BASE_DIR, "include")
+DEFAULT_ROBOT = os.path.join(INCLUDE_DIR, "default.robot")
+
+
+def get_defined_variables(file_path):
+    """Extract variable names from a Robot Framework file using RF parser."""
+    with open(file_path, encoding="utf-8") as f:
+        model = get_model(f.read())
+
+    variables = set()
+    for section in model.sections:
+        if isinstance(section, VariableSection):
+            for var in section.body:
+                if isinstance(var, Variable):
+                    variables.add(var.name)
+    return variables
+
+
+# Step 1: Load default.robot variables
+default_variables = get_defined_variables(DEFAULT_ROBOT)
+
+# Step 2: Walk all .robot files and extract additional variable definitions
+undefined_variables = {}
+all_undefined_vars = set()
+
+for root, _, files in os.walk(BASE_DIR):
+    for file in files:
+        if not file.endswith(".robot"):
+            continue
+        path = os.path.join(root, file)
+        if path == DEFAULT_ROBOT:
+            continue
+
+        file_vars = get_defined_variables(path)
+        new_vars = file_vars - default_variables
+        if new_vars:
+            undefined_variables[path] = new_vars
+            all_undefined_vars.update(new_vars)
+
+# Step 3: Print per-file report
+if undefined_variables:
+    print("⚠️ Variables defined in files but missing in include/default.robot:\n")
+    for path, vars in sorted(undefined_variables.items()):
+        print(f"{path}:")
+        for var in sorted(vars):
+            print(f"  {var}")
+
+    if all_undefined_vars:
+        print("\n📌 Unique variables to consider adding to include/default.robot:\n")
+        print("*** Variables ***\n")
+        for var in sorted(all_undefined_vars):
+            print(f"{var}=                           ${{TBD}}")
+    sys.exit(1)
+else:
+    print("✅ All variables are defined in include/default.robot.")


### PR DESCRIPTION
Missing flags on some platforms is a common failure during regression testing.

The goal here is to have a pre-commit which checks if the newly added flags are defined in default.robot.

That was the script execution result here:  https://paste.dasharo.com/?bea619207b960492#8Kr1hUr4D37CXoaC5KpPZpy5UFaZ4Ujqy9W7cyeKgxfp