### PR TITLE
regression.sh: Remove hardcoded `--include automated`

### DIFF
--- a/scripts/regression.sh
+++ b/scripts/regression.sh
@@ -25,6 +25,6 @@ if [ -z "$NO_SETUP" ]; then
     execute_robot "util/basic-platform-setup.robot" "${@}"
 fi
 
-execute_robot "dasharo-compatibility" -- --include automated "${@}"
-execute_robot "dasharo-security" -- --include automated "${@}"
-execute_robot "dasharo-performance" -- --include automated "${@}"
+execute_robot "dasharo-compatibility" "${@}"
+execute_robot "dasharo-security" "${@}"
+execute_robot "dasharo-performance" "${@}"


### PR DESCRIPTION
The tester can add it if they want. With the option hardcoded it would not be possible to only run manual tests without modifying the script, which could be an inconvenience. Moreover adding additional arguments, like `--include minimal-regression` would break, because when `--include` is passed two times, the two are `OR`'ed, not `AND`'ed.