### PR TITLE
scripts/regression.sh: allow for execution of tests from the release …

### DIFF
--- a/scripts/lib/robot.sh
+++ b/scripts/lib/robot.sh
@@ -54,7 +54,7 @@ execute_robot() {
   # scope and additional arguments to robot which need to be separated
   # when calling robot
   for ((i=0;i<_args_len;i++)); do
-    if [[ ${_args[$i]} == *"--"* ]]; then
+    if [[ ${_args[$i]} == "--" ]]; then
       _separator_idx=$i
       break
     fi
@@ -67,6 +67,9 @@ execute_robot() {
   if [[ $_separator_idx -gt 0 ]]; then
     _separator_idx=$_separator_idx+1
     for ((i=_separator_idx;i<_args_len;i++)); do
+      if [[ ${_args[$i]} == "--" ]]; then
+        continue
+      fi
       # Some arguments may contain spaces. Bash removes quotation marks
       # from command arguments. Because we need to pass them again to
       # another command the quotation marks need to be restored or the arguments

--- a/scripts/regression.sh
+++ b/scripts/regression.sh
@@ -25,6 +25,16 @@ if [ -z "$NO_SETUP" ]; then
     execute_robot "util/basic-platform-setup.robot" "${@}"
 fi
 
-execute_robot "dasharo-compatibility" "${@}"
-execute_robot "dasharo-security" "${@}"
-execute_robot "dasharo-performance" "${@}"
+TESTS=""
+
+if [ -n "$REL_ID" ] && [ -n "$DB_URL" ]; then
+    TESTS+=" --"
+    JSON=`curl -s -k "$DB_URL/releases/$REL_ID"`
+    for t in `echo "$JSON" | jq '.test_cases | map_values(select(endswith("automated"))) | keys | map(.+"*") | .[]'`; do
+        TESTS+=" -t $t"
+    done
+fi
+
+execute_robot "dasharo-compatibility" "${@}" $TESTS
+execute_robot "dasharo-security" "${@}" $TESTS
+execute_robot "dasharo-performance" "${@}" $TESTS


### PR DESCRIPTION
…scope

Release scope can be taken directly from the release document in the database to avoid running unnecessary tests and avoid mistakes. To run the script that way, it must be started as:

    DB_URL=http://web:site@localhost:5984 \
    REL_ID=f1ce0f69153f6e229363c653aacb4aad \
    FW_FILE=... CONFIG=... DEVICE_IP=... \
    ./scripts/regression.sh

---

It was only tested by swapping `echo "$command"` and `eval "$command"` in `scripts/lib/robot.sh`, not with real regression tests. Documentation TBD.