### PR TITLE
keywords.robot: Import platform configs default.robot

### DIFF
--- a/keywords.robot
+++ b/keywords.robot
@@ -16,6 +16,7 @@ Resource    lib/framework.robot
 Resource    lib/me.robot
 Resource    lib/network.robot
 Resource    lib/bsd.robot
+Resource    platform-configs/include/default.robot
 
 
 *** Keywords ***


### PR DESCRIPTION
Importing the default platform configs in keywords.robot will fix language servers spamming warnings of undefined variables all over the place. The platform config defined in the ${CONFIG} variable is imported dynamically after all of the static imports, and takes precedence over them.

The documentation is confusing on this:
- not explicitly mentioned how it works: https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#variable-priorities-and-scopes
- https://robotframework.org/robotframework/latest/libraries/BuiltIn.html#Import%20Resource says that `Resources imported with this keyword are set into the test suite scope similarly when importing them in the Setting table using the Resource setting.`. This suggests, that the first imported resource should take precedence.

It is experimentally proven, to not be the case in a little test:
[resource-precedence_log.zip](https://github.com/user-attachments/files/21504717/resource-precedence_log.zip)


