### PR TITLE
linux-packages-playbook.yaml: Add packages update_cache

### DIFF
--- a/os-config/ansible/linux-packages-playbook.yaml
+++ b/os-config/ansible/linux-packages-playbook.yaml
@@ -10,6 +10,7 @@
       ansible.builtin.include_vars: "{{os_id}}-packages.yaml"
     - name: Install packages
       ansible.builtin.package:
+        update_cache: true
         name:
           - "{{package_network_manager}}"
           - "{{package_lm_sensors}}"


### PR DESCRIPTION
The latest documentation does not list this option https://docs.ansible.com/ansible/latest/collections/ansible/builtin/package_module.html

It is awailable in the more specific builtin `apt` and `dnf` though:
https://docs.ansible.com/ansible/latest/collections/ansible/builtin/dnf_module.html https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_module.html

Despite that it works in the builtin `package` .

Logs in PR
[basic-platform-setup_log.zip](https://github.com/user-attachments/files/21524778/basic-platform-setup_log.zip)

Before the installation was failing due to stale cache:
[basic-platform-setup_log.zip](https://github.com/user-attachments/files/21524808/basic-platform-setup_log.zip)
