### PR TITLE
Add dts profile diff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ qemu-data/
 command_log.txt
 ipxe/
 /logs
+dts/dts-gen-profiles/
+UEFI

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,6 +71,7 @@ repos:
     rev: v5.0.2
     hooks:
       - id: reuse-lint-file
+        exclude: ^dts/profiles
 
   - repo: local
     hooks:

--- a/dasharo-compatibility/dasharo-tools-suite.robot
+++ b/dasharo-compatibility/dasharo-tools-suite.robot
@@ -250,31 +250,6 @@ DTS011.001 Heads Transition by using DTS via iPXE works correctly
 
 
 *** Keywords ***
-Are DPP Keys Defined
-    ${email}=    Run Keyword And Return Status
-    ...    Variable Should Exist    $DPP_EMAIL
-    ${password}=    Run Keyword And Return Status
-    ...    Variable Should Exist    $DPP_PASSWORD
-    ${status}=    Run Keyword And Return Status    Should Be True
-    ...    ${email} and ${password}
-    RETURN    ${status}
-
-Flash FW Automatically Or Manually
-    [Documentation]    Flash firmware automatically if it's possible and
-    ...    variable with name passed in fw_var exists
-    [Arguments]    ${fw_var}    ${msg}="Flash firmware"
-    ${variable_exists}=    Run Keyword And Return Status
-    ...    Variable Should Exist    \${${fw_var}}
-    # Without POWER_CTRL Flash Firmware will try to boot into Linux which won't
-    # work
-    IF    not ${variable_exists} or '''${POWER_CTRL}''' == '''none'''
-        Execute Manual Step While Freeing Serial Connection    ${msg}
-    ELSE
-        Flash Firmware    ${${fw_var}}
-        Power On
-        Set DUT Response Timeout    5m
-    END
-
 Prepare For Initial Deployment
     [Documentation]    Prepare for deployment, from flashing up to entering
     ...    DPP keys. Returns deployment type to pass to
@@ -306,12 +281,3 @@ Prepare For Initial Deployment
         VAR    ${version}=    DCR UEFI
     END
     RETURN    ${version}
-
-Execute Manual Step While Freeing Serial Connection
-    [Documentation]    In case you need to connect to DUT via serial to do
-    ...    manual steps. Arguments are the same as for 'Execute Manual Step'
-    [Arguments]    ${msg}
-    Telnet.Close All Connections
-    Execute Manual Step
-    ...    ${msg}. Make sure to close serial connection before continuing
-    Serial Setup    ${RTE_IP}    ${RTE_S2_N_PORT}

--- a/dasharo-compatibility/dasharo-tools-suite.robot
+++ b/dasharo-compatibility/dasharo-tools-suite.robot
@@ -190,8 +190,7 @@ DTS010.001 Deploy Dasharo firmware by using DTS works correctly
     Depends On    ${TESTS_IN_FIRMWARE_SUPPORT}
     ${version}=    Prepare For Initial Deployment    seabios=${False}
     Enable DTS Log Sending
-    Go Through Initial Deployment    ${version}
-    Wait For Checkpoint    Rebooting
+    Go Through Initial Deployment    ${version}    skip_me=${TRUE}
     Restore Initial DUT Connection Method
     Set DUT Response Timeout    5m
     # Not sure how to check if Dasharo fw has serial console enabled by
@@ -212,7 +211,6 @@ DTS010.002 Deploy Dasharo SeaBios firmware by using DTS works correctly
     ${version}=    Prepare For Initial Deployment    seabios=${True}
     Enable DTS Log Sending
     Go Through Initial Deployment    ${version}
-    Wait For Checkpoint    Rebooting
     Restore Initial DUT Connection Method
     Set DUT Response Timeout    5m
     # Not sure how to check if Dasharo fw has serial console enabled by
@@ -244,8 +242,7 @@ DTS011.001 Heads Transition by using DTS via iPXE works correctly
     ${dpp_keys_defined}=    Are DPP Keys Defined
     IF    ${dpp_keys_defined} == ${TRUE}    Provide DPP Credentials
     Enable DTS Log Sending
-    Go Through Heads Transition
-    Wait For Checkpoint    Rebooting
+    Go Through Heads Transition    skip_me=${TRUE}
     Restore Initial DUT Connection Method
     Set DUT Response Timeout    5m
     Execute Manual Step While Freeing Serial Connection

--- a/docs/dts-tests.md
+++ b/docs/dts-tests.md
@@ -42,7 +42,11 @@ Control variables:
 Launching example:
 
 ```bash
-robot -b command_log.txt -v snipeit:no -L TRACE -v config:qemu -v rte_ip:127.0.0.1 -v boot_dts_from_ipxe_shell:True -v dts_ipxe_link:http://192.168.0.102:8080/ipxe -v dpp_email:'EMAIL' -v dpp_password:'PASSWORD' -v dts_config_ref:'refs/heads/develop' -t "E2E006.002*" dts/dts-e2e.robot
+robot -b command_log.txt -v snipeit:no -L TRACE -v config:qemu \
+    -v rte_ip:127.0.0.1 -v boot_dts_from_ipxe_shell:True \
+    -v dts_ipxe_link:http://192.168.0.102:8080/ipxe -v dpp_email:'EMAIL' \
+    -v dpp_password:'PASSWORD' -v dts_config_ref:'refs/heads/develop' \
+    -t "E2E006.002*" dts/dts-e2e.robot
 ```
 
 > Note: replace `EMAIL` and `PASSWORD` with appropriate credentials if required.

--- a/dts/dts-e2e-helper.robot
+++ b/dts/dts-e2e-helper.robot
@@ -48,7 +48,8 @@ Print Test Names And Exports
     Log To Console    --------------------------------------------------
     FOR    ${platform_workflows}    IN    @{workflows}
         ${workflow}    ${release}=    Set Variable    ${platform_workflows}
-        @{exports}=    Prepare Test Exports    ${workflow}    ${platform_variables}    ${DTS_CONFIG_REF}
+        @{exports}=    Prepare Test Exports    ${workflow}    ${release}
+        ...    ${platform_variables}    ${DTS_CONFIG_REF}
         Log To Console    ---------------
         Log To Console    ${platform} ${workflow} - ${release}
         Log To Console    ---------------

--- a/dts/dts-e2e.robot
+++ b/dts/dts-e2e.robot
@@ -63,84 +63,100 @@ ${platform} ${workflow} - ${release}
 
 ${platform} UEFI Update - DCR
     [Documentation]    Update workflow for Dasharo Community Release
-    Prepare E2E Test    ${platform}    UEFI Update
-    Go Through Update
-    Wait For Checkpoint    Rebooting
+    Prepare E2E Test
+    Go Through Update    skip_me=${TRUE}
+    Wait For Checkpoint And Press Enter    ${DTS_CONFIRM_CHECKPOINT}
+    Wait For Checkpoint    ${DTS_CHECKPOINT}
 
 ${platform} SeaBIOS Update - DCR
     [Documentation]    Update workflow for Dasharo Community Release
-    Prepare E2E Test    ${platform}    SeaBIOS Update
+    Prepare E2E Test
     Go Through Update
-    Wait For Checkpoint    Rebooting
+    Wait For Checkpoint And Press Enter    ${DTS_CONFIRM_CHECKPOINT}
+    Wait For Checkpoint    ${DTS_CHECKPOINT}
 
 ${platform} Initial Deployment - DCR
     [Documentation]    Initial deployment workflow for Dasharo Community Release
-    Prepare E2E Test    ${platform}    Initial Deployment
-    Go Through Initial Deployment    DCR UEFI
-    Wait For Checkpoint    Rebooting
+    Prepare E2E Test
+    Go Through Initial Deployment    DCR UEFI    skip_me=${TRUE}
+    Wait For Checkpoint And Press Enter    ${DTS_CONFIRM_CHECKPOINT}
+    Wait For Checkpoint    ${DTS_CHECKPOINT}
 
 ${platform} UEFI Update - DPP
     [Documentation]    Update workflow with DPP credentials
-    Prepare E2E Test    ${platform}    UEFI Update
+    Prepare E2E Test
     Provide DPP Credentials
-    Go Through Update
-    Wait For Checkpoint    Rebooting
+    Go Through Update    skip_me=${TRUE}
+    Wait For Checkpoint And Press Enter    ${DTS_CONFIRM_CHECKPOINT}
+    Wait For Checkpoint    ${DTS_CHECKPOINT}
 
 ${platform} SeaBIOS Update - DPP
     [Documentation]    Update workflow with DPP credentials
-    Prepare E2E Test    ${platform}    SeaBIOS Update
+    Prepare E2E Test
     Provide DPP Credentials
     Go Through Update
-    Wait For Checkpoint    Rebooting
+    Wait For Checkpoint And Press Enter    ${DTS_CONFIRM_CHECKPOINT}
+    Wait For Checkpoint    ${DTS_CHECKPOINT}
 
 ${platform} Initial Deployment - DPP
     [Documentation]    Initial deployment workflow with DPP credentials
-    Prepare E2E Test    ${platform}    Initial Deployment
+    Prepare E2E Test
     Provide DPP Credentials
-    Go Through Initial Deployment    DPP UEFI
-    Wait For Checkpoint    Rebooting
+    Go Through Initial Deployment    DPP UEFI    skip_me=${TRUE}
+    Wait For Checkpoint And Press Enter    ${DTS_CONFIRM_CHECKPOINT}
+    Wait For Checkpoint    ${DTS_CHECKPOINT}
 
 ${platform} UEFI->Heads Transition - DPP
     [Documentation]    Heads transition workflow with DPP credentials
-    Prepare E2E Test    ${platform}    UEFI->Heads Transition
+    Prepare E2E Test
     Provide DPP Credentials
-    Go Through Heads Transition
-    Wait For Checkpoint    Rebooting
+    Go Through Heads Transition    skip_me=${TRUE}
+    Wait For Checkpoint And Press Enter    ${DTS_CONFIRM_CHECKPOINT}
+    Wait For Checkpoint    ${DTS_CHECKPOINT}
 
 ${platform} SeaBIOS->UEFI Transition - DPP
     [Documentation]    Heads transition workflow with DPP credentials
-    Prepare E2E Test    ${platform}    SeaBIOS->UEFI Transition
+    Prepare E2E Test
     Provide DPP Credentials
     Go Through Transition    DPP UEFI
-    Wait For Checkpoint    Rebooting
+    Wait For Checkpoint And Press Enter    ${DTS_CONFIRM_CHECKPOINT}
+    Wait For Checkpoint    ${DTS_CHECKPOINT}
 
 ${platform} Dasharo (coreboot+UEFI) To Dasharo (Slim Bootloader+UEFI) Transition - DPP
     [Documentation]    Transition to Dasharo (Slim) workflow with DPP credentials
-    Prepare E2E Test    ${platform}    Dasharo (coreboot+UEFI) to Dasharo (Slim Bootloader+UEFI) Transition
+    Prepare E2E Test
     Provide DPP Credentials
-    Go Through Transition    DPP Slim Bootloader + UEFI
-    Wait For Checkpoint    Rebooting
+    Go Through Transition    DPP Slim Bootloader + UEFI    skip_me=${TRUE}
+    Wait For Checkpoint And Press Enter    ${DTS_CONFIRM_CHECKPOINT}
+    Wait For Checkpoint    ${DTS_CHECKPOINT}
 
 ${platform} Dasharo (Slim Bootloader+UEFI) Initial Deployment - DPP
     [Documentation]    Initial deployment workflow for Slim Bootloadere + UEFI
-    Prepare E2E Test    ${platform}    Dasharo (Slim Bootloader+UEFI) Initial Deployment
+    Prepare E2E Test
     Provide DPP Credentials
-    Go Through Initial Deployment    DPP Slim Bootloader + UEFI
+    Go Through Initial Deployment    DPP Slim Bootloader + UEFI    skip_me=${TRUE}
+    Wait For Checkpoint And Press Enter    ${DTS_CONFIRM_CHECKPOINT}
+    Wait For Checkpoint    ${DTS_CHECKPOINT}
 
 Prepare E2E Test
     [Documentation]    Prepare everything needed for platform and workflow
     ...    emulation. Keyword has to be run in shell. After keyword ends we
     ...    should be in DTS menu
-    [Arguments]    ${platform}    ${workflow}
+    ${platform}=    Evaluate    '${TEST_NAME}'.split()[1]
+    ${release}=    Evaluate    '${TEST_NAME}'.split()[-1]
+    ${workflow}=    Evaluate    ' '.join('${TEST_NAME}'.split()[2:-2])
     # Verify if DTS_CONFIG_REF is set via `-v` argument
     Variable Should Exist    ${DTS_CONFIG_REF}
     Export Shell Variables For Emulation
     ...    ${workflow}
+    ...    ${release}
     ...    ${DTS_PLATFORM_VARIABLES}[${platform}]
     ...    ${DTS_CONFIG_REF}
     # TODO: needed by 'Go Through Initial Deployment' keyword for couple of
     # NovaCustom boards
     VAR    ${DTS_TEST_BOARD_MODEL}=    ${DTS_PLATFORM_VARIABLES}[${platform}][DTS_TEST_BOARD_MODEL]    scope=TEST
+    Execute Command In Terminal
+    ...    rm -rf /etc/cloud-pass /root/.mc /*.tar.gz /root/*.tar.gz /tmp/logs/*profile /tmp/dts-temp-files
     Write Into Terminal    dts-boot
 
 Prepare DTS Test
@@ -156,7 +172,31 @@ Teardown DTS Test
     # background
     SSHLibrary.Close Connection
     Set Prompt For Terminal    bash-5.2#
-    Execute Linux Command    rm -rf /etc/cloud-pass /root/.mc /*.tar.gz /root/*.tar.gz
+    TRY
+        ${platform}=    Evaluate    '${TEST_NAME}'.split()[1]
+        ${release}=    Evaluate    '${TEST_NAME}'.split()[-1]
+        ${workflow}=    Evaluate    ' '.join('${TEST_NAME}'.split()[2:-2])
+        VAR    ${profiles}=    ${DTS_PLATFORM_VARIABLES}[${platform}][DTS_TEST_WORKFLOW_PROFILES]
+        ${verify_profile}=    Run Keyword And Return Status    List Should Contain Value
+        ...    ${profiles}    ${{ ("${workflow}", "${release}" ) }}
+        IF    ${verify_profile}
+            # strip 'E2Exxx: ' prefix from test name
+            ${profile_name}=    Evaluate    $TEST_NAME.split(":")[1].strip()
+            VAR    ${profile}=    ${CURDIR}/profiles/${profile_name}.profile
+            OperatingSystem.File Should Exist    ${profile}
+            IF    "${TEST_STATUS}" == "PASS"
+                Get File From DUT    /tmp/logs/profile    /tmp/robotframework-dts-profile
+                ${rc}    ${output}=    Run And Return Rc And Output
+                ...    diff -u1 /tmp/robotframework-dts-profile "${profile}"
+                Should Be Equal As Integers    ${rc}    0    Profiles are not identical!
+            END
+        ELSE
+            Log    Workflow isn't configured for profile verification.    WARN
+        END
+    FINALLY
+        Execute Command In Terminal
+        ...    rm -rf /etc/cloud-pass /root/.mc /*.tar.gz /root/*.tar.gz /tmp/logs /tmp/dts-temp-files
+    END
 
 Start New DTS SSH Session In QEMU
     [Documentation]    Changes connection method to ssh and logs in to DTS
@@ -183,6 +223,8 @@ Prepare DTS E2E Test Suite
     Skip If    not ${DTS_SUPPORT}
     &{dts_vars}=    Get DTS Test Variables
     VAR    ${DTS_PLATFORM_VARIABLES}=    ${dts_vars}    scope=SUITE
+    VAR    ${DEVICE_OS_USERNAME}=    root    scope=SUITE
+    VAR    ${DEVICE_OS_PASSWORD}=    ${EMPTY}    scope=SUITE
     Power On And Enter DTS Shell
     Set Prompt For Terminal    bash-5.2#
-    Execute Linux Command    systemctl start sshd
+    Execute Command In Terminal    systemctl start sshd

--- a/dts/dts-gen-profile.robot
+++ b/dts/dts-gen-profile.robot
@@ -1,0 +1,225 @@
+*** Settings ***
+Library             Collections
+Library             DateTime
+Library             Dialogs
+Library             OperatingSystem
+Library             Process
+Library             String
+Library             Telnet    timeout=20 seconds    connection_timeout=120 seconds
+Library             SSHLibrary    timeout=90 seconds
+Library             RequestsLibrary
+Resource            ../keywords.robot
+Resource            ../keys.robot
+Resource            ../variables.robot
+
+Suite Setup         Prepare DTS Gen Suite
+Suite Teardown      Run Keyword
+...                     Log Out And Close Connection
+Test Setup          DTS Gen Test Setup
+
+
+*** Test Cases ***
+DTG001.001 Generate Profile for DTS UEFI Update Workflow
+    [Documentation]
+    ...    Generate profile for UEFI update workflow. ${FW_FILE} variable
+    ...    should contain path to earlier UEFI fw release that allows for
+    ...    update workflow. If ${FW_FILE} isn't defined then you'll be asked to
+    ...    manually flash correct fw version on DUT
+    Flash FW Automatically Or Manually
+    ...    FW_FILE    "Flash earlier version of Dasharo firmware"
+    Make Sure That Flash Locks Are Disabled
+    IF    "${DASHARO_INTEL_ME_MENU_SUPPORT}" == "${TRUE}"
+        TRY
+            Set UEFI Option    MeMode    Disabled (HAP)
+        EXCEPT
+            Log    Couldn't disable ME, previous fw likely doesn't have that option
+        END
+    END
+    Boot Dasharo Tools Suite    iPXE
+    Enter Shell In DTS
+    Prepare DTS For Profile Generation
+    ${dpp_keys_defined}=    Are DPP Keys Defined
+    IF    ${dpp_keys_defined} == ${TRUE}    Provide DPP Credentials
+    Go Through Update    skip_me=${TRUE}
+    Get Profile After Workflow
+
+DTG002.001 Generate Profile for DTS SeaBIOS Update Workflow
+    [Documentation]
+    ...    Generate profile for SeaBIOS update workflow. ${FW_FILE} variable
+    ...    should contain path to earlier SeaBIOS fw release that allows for
+    ...    update workflow. If ${FW_FILE} isn't defined then you'll be asked to
+    ...    manually flash correct fw version on DUT
+    Flash FW Automatically Or Manually
+    ...    FW_FILE    "Flash earlier version of Dasharo firmware"
+    Execute Manual Step While Freeing Serial Connection
+    ...    "Boot into DTS. Continue after DTS UI is shown"
+    Enter Shell In DTS
+    Prepare DTS For Profile Generation
+    ${dpp_keys_defined}=    Are DPP Keys Defined
+    IF    ${dpp_keys_defined} == ${TRUE}    Provide DPP Credentials
+    Go Through Update    skip_me=${TRUE}
+    Get Profile After Workflow    trim_last_line=${TRUE}
+
+DTG003.001 Generate Profile for DTS UEFI Initial Deployment workflow
+    [Documentation]
+    ...    Generate profile for DTS UEFI initial deployment. ${FW_FILE}
+    ...    variable should contain path to original/propertiary fw release that
+    ...    allows for initial deployment workflow. If ${FW_FILE} isn't defined
+    ...    then you'll be asked to manually flash correct fw version on DUT
+    ${version}=    Prepare For Initial Deployment    seabios=${False}
+    Go Through Initial Deployment    ${version}    skip_me=${TRUE}
+    Get Profile After Workflow
+
+DTG004.001 Generate Profile for DTS SeaBIOS Initial Deployment workflow
+    [Documentation]
+    ...    Generate profile for DTS SeaBIOS initial deployment. ${FW_FILE}
+    ...    variable should contain path to original/propertiary fw release that
+    ...    allows for initial deployment workflow. If ${FW_FILE} isn't defined
+    ...    then you'll be asked to manually flash correct fw version on DUT
+    ${version}=    Prepare For Initial Deployment    seabios=${True}
+    Go Through Initial Deployment    ${version}    skip_me=${TRUE}
+    Get Profile After Workflow
+
+DTG005.001 Generate Profile for DTS Heads Transition workflow
+    [Documentation]
+    ...    Generate profile for DTS Heads transition. ${FW_FILE}
+    ...    variable should contain path to UEFI fw release that
+    ...    allows for heads transition workflow. If ${FW_FILE} isn't defined
+    ...    then you'll be asked to manually flash correct fw version on DUT
+    Flash FW Automatically Or Manually
+    ...    FW_FILE    "Flash Dasharo firmware"
+    Make Sure That Flash Locks Are Disabled
+    IF    "${DASHARO_INTEL_ME_MENU_SUPPORT}" == "${TRUE}"
+        TRY
+            Set UEFI Option    MeMode    Disabled (HAP)
+        EXCEPT
+            Log    Couldn't disable ME
+        END
+    END
+    Boot Dasharo Tools Suite    iPXE
+    Enter Shell In DTS
+    Prepare DTS For Profile Generation
+    ${dpp_keys_defined}=    Are DPP Keys Defined
+    IF    ${dpp_keys_defined} == ${TRUE}    Provide DPP Credentials
+    Go Through Heads Transition    skip_me=${TRUE}
+    Get Profile After Workflow
+
+DTG006.001 Generate Profile for DTS UEFI->SeaBIOS Transition workflow
+    [Documentation]
+    ...    Generate profile for DTS SeaBIOS->UEFI initial deployment.
+    ...    ${FW_FILE} variable should contain path to UEFI fw release that
+    ...    allows for SeaBIOS transition workflow. If ${FW_FILE} isn't defined
+    ...    then you'll be asked to manually flash correct fw version on DUT
+    Flash FW Automatically Or Manually
+    ...    FW_FILE    "Flash Dasharo firmware"
+    Make Sure That Flash Locks Are Disabled
+    IF    "${DASHARO_INTEL_ME_MENU_SUPPORT}" == "${TRUE}"
+        TRY
+            Set UEFI Option    MeMode    Disabled (HAP)
+        EXCEPT
+            Log    Couldn't disable ME
+        END
+    END
+    Boot Dasharo Tools Suite    iPXE
+    Enter Shell In DTS
+    Prepare DTS For Profile Generation
+    Provide DPP Credentials
+    Go Through Transition    DPP SeaBIOS    skip_me=${TRUE}
+    Get Profile After Workflow
+
+DTG007.001 Generate Profile for DTS SeaBIOS->UEFI Transition workflow
+    [Documentation]
+    ...    Generate profile for DTS SeaBIOS->UEFI initial deployment.
+    ...    ${FW_FILE} variable should contain path to SeaBIOS fw release that
+    ...    allows for UEFI transition workflow. If ${FW_FILE} isn't defined
+    ...    then you'll be asked to manually flash correct fw version on DUT
+    Flash FW Automatically Or Manually
+    ...    FW_FILE    "Flash Dasharo SeaBIOS firmware"
+    Execute Manual Step While Freeing Serial Connection
+    ...    "Boot into DTS. Continue after DTS UI is shown"
+    Enter Shell In DTS
+    Prepare DTS For Profile Generation
+    ${dpp_keys_defined}=    Are DPP Keys Defined
+    IF    ${dpp_keys_defined} == ${TRUE}
+        Provide DPP Credentials
+        VAR    ${version}=    DPP UEFI
+    ELSE
+        VAR    ${version}=    DCR UEFI
+    END
+    Go Through Transition    ${version}    skip_me=${TRUE}
+    Get Profile After Workflow
+
+
+*** Keywords ***
+DTS Gen Test Setup
+    Depends On    ${DTS_SUPPORT}
+    Depends On    ${TESTS_IN_FIRMWARE_SUPPORT}
+    IF    ${TESTS_IN_FIRMWARE_SUPPORT}    Restore Initial DUT Connection Method
+
+Prepare DTS Gen Suite
+    Prepare Test Suite
+    VAR    ${DEVICE_OS_USERNAME}=    root    scope=SUITE
+    VAR    ${DEVICE_OS_PASSWORD}=    ${EMPTY}    scope=SUITE
+
+Prepare DTS For Profile Generation
+    [Documentation]    Should be called inside DTS shell. After keyword finishes
+    ...    you should be in DTS UI
+    Execute Command In Terminal    rm -f /tmp/logs/*profile
+    Execute Command In Terminal    mkdir -p /tmp/bin
+    Execute Command In Terminal    echo '#!/bin/bash' >/tmp/bin/reboot
+    Execute Command In Terminal    chmod +x /tmp/bin/reboot
+    Write Into Terminal    PATH="/tmp/bin:$PATH" dts-boot
+
+Get Profile After Workflow
+    [Documentation]    Should be called after workflow completes. This keyword
+    ...    should be used with update/initial deployment/transition workflows
+    ...    which end up with reboot.
+    [Arguments]    ${trim_last_line}=${FALSE}
+    # After fake 'reboot' call DTS displays DTS_CONFIRM_CHECKPOINT prompt
+    Wait For Checkpoint And Press Enter    ${DTS_CONFIRM_CHECKPOINT}
+    Wait For Checkpoint    ${DTS_CHECKPOINT}
+    Enter Shell In DTS
+    ${date}=    Get Current Date    exclude_millis=${TRUE}
+    Execute Command In Terminal    systemctl start sshd
+    # get all logs + profiles
+    VAR    ${logs_dir}=    ${CURDIR}/dts-gen-profiles/${date}-${CONFIG}-${TEST_NAME}
+    Get File From DUT    /tmp/logs/*
+    ...    ${logs_dir}/    verify=${FALSE}
+    IF    ${trim_last_line}
+        ${rc}=    Run And Return Rc
+        ...    sed -i '$ d' "${logs_dir}/profile"
+        Should Be Equal As Integers    ${rc}    0
+        ${rc}=    Run And Return Rc
+        ...    sed -i '$ d' "${logs_dir}/debug_profile"
+        Should Be Equal As Integers    ${rc}    0
+    END
+
+Prepare For Initial Deployment
+    [Documentation]    Prepare for deployment, from flashing up to entering
+    ...    DPP keys. Returns deployment type to pass to
+    ...    'Go Through Initial Deployment' keyword
+    [Arguments]    ${seabios}=${False}
+    Flash FW Automatically Or Manually
+    ...    FW_FILE    "Flash non-Dasharo/propertiary firmware"
+    Execute Manual Step While Freeing Serial Connection
+    ...    "Boot into DTS. Continue after DTS UI is shown"
+    IF    '${DUT_CONNECTION_METHOD}' == 'pikvm'
+        Write Bare Into Terminal    K
+        VAR    ${DUT_CONNECTION_METHOD}=    SSH    scope=TEST
+        Login To Linux Via SSH Without Password    root    root@DasharoToolsSuite:~#
+        # Spawn DTS menu on SSH console
+        Write Into Terminal    dts-boot
+    END
+    Enter Shell In DTS
+    Prepare DTS For Profile Generation
+    ${dpp_keys_defined}=    Are DPP Keys Defined
+    IF    ${seabios}
+        Provide DPP Credentials
+        VAR    ${version}=    DPP SeaBIOS
+    ELSE IF    ${dpp_keys_defined} == ${TRUE}
+        Provide DPP Credentials
+        VAR    ${version}=    DPP UEFI
+    ELSE
+        VAR    ${version}=    DCR UEFI
+    END
+    RETURN    ${version}

--- a/dts/profiles/msi-pro-z690-a-ddr5 UEFI Update - DPP.profile
+++ b/dts/profiles/msi-pro-z690-a-ddr5 UEFI Update - DPP.profile
@@ -1,0 +1,45 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 1
+flashrom -p internal 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
+cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
+cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 0
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 1
+cbmem -1 0
+cbmem -1 0
+flashrom -p internal -N --ifd -i bios -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+futility show /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -r /tmp/bios.bin 0
+futility show /tmp/bios.bin 0
+flashrom -p internal --ifd -i bios -i fd -i me -w /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -i fd -i me -w /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/msi-pro-z690-a-ddr5 UEFI->Heads Transition - DPP.profile
+++ b/dts/profiles/msi-pro-z690-a-ddr5 UEFI->Heads Transition - DPP.profile
@@ -1,0 +1,42 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 1
+flashrom -p internal 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
+cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
+cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 1
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 0
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 1
+cbmem -1 0
+cbmem -1 0
+flashrom -p internal -N --ifd -i bios -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+flashrom -p internal --ifd -i bios -i fd -i me -w /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -i fd -i me -w /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/msi-pro-z690-a-wifi-ddr4 Initial Deployment - DCR.profile
+++ b/dts/profiles/msi-pro-z690-a-wifi-ddr4 Initial Deployment - DCR.profile
@@ -1,0 +1,92 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+lspci -nnvvvxxxx 0
+lsusb -vvv 0
+superiotool -deV 0
+ectool -ip 0
+msrtool  1
+dmidecode  0
+dmesg  0
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+flashrom -p internal 0
+flashrom -V -p internal:laptop=force_I_want_a_brick -r logs/rom.bin --ifd -i fd -i bios -i me 0
+dmesg  0
+cbmem  1
+cbmem -1 1
+mei-amt-check  1
+intelmetool -m 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s bios-version 0
+dmidecode -s system-product-name 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+fsread_tool test -f /sys/class/mei/mei0/fw_status 0
+fsread_tool cat /sys/class/mei/mei0/fw_status 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 1
+flashrom -p internal 0
+flashrom -p internal -r /fw_backup/rom.bin --ifd -i fd -i bios -i me 0
+flashrom -p internal 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 1
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 0
+setpci -s 00:16.0 42.B 0
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+cbfstool /tmp/biosupdate layout -w 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --ifd -i fd -i bios -i me --fmap -i FMAP -i BOOTSPLASH 1
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+dmidecode -s system-uuid 0
+dmidecode -s baseboard-serial-number 0
+cbfstool /tmp/biosupdate layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+cbfstool /tmp/biosupdate add -f /tmp/serial_number.txt -n serial_number -t raw -r COREBOOT 0
+cbfstool /tmp/biosupdate add -f /tmp/system_uuid.txt -n system_uuid -t raw -r COREBOOT 0
+cbfstool /tmp/biosupdate expand -r FW_MAIN_A 0
+cbfstool /tmp/biosupdate add -f /tmp/serial_number.txt -n serial_number -t raw -r FW_MAIN_A 0
+cbfstool /tmp/biosupdate add -f /tmp/system_uuid.txt -n system_uuid -t raw -r FW_MAIN_A 0
+cbfstool /tmp/biosupdate truncate -r FW_MAIN_A 0
+cbfstool /tmp/biosupdate expand -r FW_MAIN_B 0
+cbfstool /tmp/biosupdate add -f /tmp/serial_number.txt -n serial_number -t raw -r FW_MAIN_B 0
+cbfstool /tmp/biosupdate add -f /tmp/system_uuid.txt -n system_uuid -t raw -r FW_MAIN_B 0
+cbfstool /tmp/biosupdate truncate -r FW_MAIN_B 0
+flashrom -p internal -N --ifd -i bios -w /tmp/biosupdate_resigned.rom 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/msi-pro-z690-a-wifi-ddr4 Initial Deployment - DPP.profile
+++ b/dts/profiles/msi-pro-z690-a-wifi-ddr4 Initial Deployment - DPP.profile
@@ -1,0 +1,95 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+lspci -nnvvvxxxx 0
+lsusb -vvv 0
+superiotool -deV 0
+ectool -ip 0
+msrtool  1
+dmidecode  0
+dmesg  0
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+flashrom -p internal 0
+flashrom -V -p internal:laptop=force_I_want_a_brick -r logs/rom.bin --ifd -i fd -i bios -i me 0
+dmesg  0
+cbmem  1
+cbmem -1 1
+mei-amt-check  1
+intelmetool -m 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s bios-version 0
+dmidecode -s system-product-name 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+fsread_tool test -f /sys/class/mei/mei0/fw_status 0
+fsread_tool cat /sys/class/mei/mei0/fw_status 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 1
+flashrom -p internal 0
+flashrom -p internal -r /fw_backup/rom.bin --ifd -i fd -i bios -i me 0
+flashrom -p internal 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 0
+setpci -s 00:16.0 42.B 0
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+cbfstool /tmp/biosupdate layout -w 0
+flashrom -p internal -r /tmp/rom.bin --ifd -i bios 0
+cbfstool /tmp/biosupdate write -r ROMHOLE -f /tmp/romhole.bin -u 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --ifd -i fd -i bios -i me --fmap -i FMAP -i BOOTSPLASH 1
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+dmidecode -s system-uuid 0
+dmidecode -s baseboard-serial-number 0
+cbfstool /tmp/biosupdate layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+cbfstool /tmp/biosupdate add -f /tmp/serial_number.txt -n serial_number -t raw -r COREBOOT 0
+cbfstool /tmp/biosupdate add -f /tmp/system_uuid.txt -n system_uuid -t raw -r COREBOOT 0
+cbfstool /tmp/biosupdate expand -r FW_MAIN_A 0
+cbfstool /tmp/biosupdate add -f /tmp/serial_number.txt -n serial_number -t raw -r FW_MAIN_A 0
+cbfstool /tmp/biosupdate add -f /tmp/system_uuid.txt -n system_uuid -t raw -r FW_MAIN_A 0
+cbfstool /tmp/biosupdate truncate -r FW_MAIN_A 0
+cbfstool /tmp/biosupdate expand -r FW_MAIN_B 0
+cbfstool /tmp/biosupdate add -f /tmp/serial_number.txt -n serial_number -t raw -r FW_MAIN_B 0
+cbfstool /tmp/biosupdate add -f /tmp/system_uuid.txt -n system_uuid -t raw -r FW_MAIN_B 0
+cbfstool /tmp/biosupdate truncate -r FW_MAIN_B 0
+flashrom -p internal -N --ifd -i bios -i fd -w /tmp/biosupdate_resigned.rom 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/msi-pro-z690-a-wifi-ddr4 UEFI Update - DCR.profile
+++ b/dts/profiles/msi-pro-z690-a-wifi-ddr4 UEFI Update - DCR.profile
@@ -1,0 +1,45 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 1
+lscpu  0
+flashrom -p internal 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
+cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
+cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 1
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 1
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 1
+cbmem -1 0
+cbmem -1 0
+flashrom -p internal -N --ifd -i bios -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+futility show /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -r /tmp/bios.bin 0
+futility show /tmp/bios.bin 0
+flashrom -p internal --ifd -i bios -w /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -w /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/msi-pro-z690-a-wifi-ddr4 UEFI Update - DPP.profile
+++ b/dts/profiles/msi-pro-z690-a-wifi-ddr4 UEFI Update - DPP.profile
@@ -1,0 +1,45 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 1
+flashrom -p internal 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
+cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
+cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 0
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 1
+cbmem -1 0
+cbmem -1 0
+flashrom -p internal -N --ifd -i bios -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+futility show /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -r /tmp/bios.bin 0
+futility show /tmp/bios.bin 0
+flashrom -p internal --ifd -i bios -i fd -i me -w /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -i fd -i me -w /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/msi-pro-z690-a-wifi-ddr4 UEFI->Heads Transition - DPP.profile
+++ b/dts/profiles/msi-pro-z690-a-wifi-ddr4 UEFI->Heads Transition - DPP.profile
@@ -1,0 +1,43 @@
+# Couldn't verify: https://github.com/Dasharo/dasharo-issues/issues/1533
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 1
+flashrom -p internal 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
+cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
+cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 1
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 0
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 1
+cbmem -1 0
+cbmem -1 0
+flashrom -p internal -N --ifd -i bios -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+flashrom -p internal --ifd -i bios -i fd -w /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -i fd -w /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/msi-pro-z790-p-ddr5 Initial Deployment - DPP.profile
+++ b/dts/profiles/msi-pro-z790-p-ddr5 Initial Deployment - DPP.profile
@@ -1,0 +1,82 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+lspci -nnvvvxxxx 0
+lsusb -vvv 0
+superiotool -deV 0
+ectool -ip 0
+msrtool  1
+dmidecode  0
+dmesg  0
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+flashrom -p internal 0
+flashrom -V -p internal:laptop=force_I_want_a_brick -r logs/rom.bin --ifd -i fd -i bios -i me 0
+dmesg  0
+cbmem  1
+cbmem -1 1
+mei-amt-check  1
+intelmetool -m 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s bios-version 0
+dmidecode -s system-product-name 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+fsread_tool test -f /sys/class/mei/mei0/fw_status 0
+fsread_tool cat /sys/class/mei/mei0/fw_status 0
+rdmsr 0x13a -0 0
+rdmsr 0x13a -0 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 1
+flashrom -p internal 0
+flashrom -p internal -r /fw_backup/rom.bin --ifd -i fd -i bios -i me 0
+flashrom -p internal 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 0
+setpci -s 00:16.0 42.B 0
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+cbfstool /tmp/biosupdate layout -w 0
+flashrom -p internal -r /tmp/rom.bin --ifd -i bios 0
+cbfstool /tmp/biosupdate write -r ROMHOLE -f /tmp/romhole.bin -u 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --ifd -i fd -i bios -i me --fmap -i FMAP -i BOOTSPLASH 1
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+flashrom -p internal -N --ifd -i bios -N -w /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/msi-pro-z790-p-ddr5 UEFI Update - DPP.profile
+++ b/dts/profiles/msi-pro-z790-p-ddr5 UEFI Update - DPP.profile
@@ -1,0 +1,45 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 1
+flashrom -p internal 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
+cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
+cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 0
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 1
+cbmem -1 0
+cbmem -1 0
+flashrom -p internal -N --ifd -i bios -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+futility show /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -r /tmp/bios.bin 0
+futility show /tmp/bios.bin 0
+flashrom -p internal --ifd -i bios -i fd -i me -w /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -i fd -i me -w /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/msi-pro-z790-p-ddr5 UEFI->Heads Transition - DPP.profile
+++ b/dts/profiles/msi-pro-z790-p-ddr5 UEFI->Heads Transition - DPP.profile
@@ -1,0 +1,42 @@
+# don't trust this profile: https://github.com/Dasharo/dasharo-issues/issues/1536
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 1
+flashrom -p internal 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
+cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
+cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 1
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 0
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 0
+setpci -s 00:16.0 42.B 0
+flashrom -p internal -N --ifd -i bios -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+flashrom -p internal --ifd -i bios -N -w /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -N -w /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/novacustom-ns50mu UEFI Update - DCR.profile
+++ b/dts/profiles/novacustom-ns50mu UEFI Update - DCR.profile
@@ -1,0 +1,47 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 0
+fsread_tool cat /sys/class/power_supply/AC/online 0
+flashrom -p internal 0
+dasharo_ectool info 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
+cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
+cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 0
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 1
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 1
+cbmem -1 0
+cbmem -1 0
+flashrom -p internal -N --ifd -i bios -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+futility show /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -r /tmp/bios.bin 0
+futility show /tmp/bios.bin 0
+flashrom -p internal --ifd -i bios -w /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -w /tmp/biosupdate 0
+dasharo_ectool flash /tmp/ecupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/novacustom-ns50pu UEFI Update - DCR.profile
+++ b/dts/profiles/novacustom-ns50pu UEFI Update - DCR.profile
@@ -1,0 +1,47 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 0
+fsread_tool cat /sys/class/power_supply/AC/online 0
+flashrom -p internal 0
+dasharo_ectool info 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
+cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
+cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 0
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 1
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 1
+cbmem -1 0
+cbmem -1 0
+flashrom -p internal -N --ifd -i bios -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+futility show /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -r /tmp/bios.bin 0
+futility show /tmp/bios.bin 0
+flashrom -p internal --ifd -i bios -w /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -w /tmp/biosupdate 0
+dasharo_ectool flash /tmp/ecupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/novacustom-ns70mu UEFI Update - DCR.profile
+++ b/dts/profiles/novacustom-ns70mu UEFI Update - DCR.profile
@@ -1,0 +1,47 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 0
+fsread_tool cat /sys/class/power_supply/AC/online 0
+flashrom -p internal 0
+dasharo_ectool info 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
+cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
+cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 0
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 1
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 1
+cbmem -1 0
+cbmem -1 0
+flashrom -p internal -N --ifd -i bios -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+futility show /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -r /tmp/bios.bin 0
+futility show /tmp/bios.bin 0
+flashrom -p internal --ifd -i bios -w /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -w /tmp/biosupdate 0
+dasharo_ectool flash /tmp/ecupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/novacustom-ns70pu UEFI Update - DCR.profile
+++ b/dts/profiles/novacustom-ns70pu UEFI Update - DCR.profile
@@ -1,0 +1,47 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 0
+fsread_tool cat /sys/class/power_supply/AC/online 0
+flashrom -p internal 0
+dasharo_ectool info 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
+cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
+cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 0
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 1
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 1
+cbmem -1 0
+cbmem -1 0
+flashrom -p internal -N --ifd -i bios -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+futility show /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -r /tmp/bios.bin 0
+futility show /tmp/bios.bin 0
+flashrom -p internal --ifd -i bios -w /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -w /tmp/biosupdate 0
+dasharo_ectool flash /tmp/ecupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/novacustom-nv41mb UEFI Update - DCR.profile
+++ b/dts/profiles/novacustom-nv41mb UEFI Update - DCR.profile
@@ -1,0 +1,47 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 0
+fsread_tool cat /sys/class/power_supply/AC/online 0
+flashrom -p internal 0
+dasharo_ectool info 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
+cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
+cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 0
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 1
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 1
+cbmem -1 0
+cbmem -1 0
+flashrom -p internal -N --ifd -i bios -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+futility show /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -r /tmp/bios.bin 0
+futility show /tmp/bios.bin 0
+flashrom -p internal --ifd -i bios -w /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -w /tmp/biosupdate 0
+dasharo_ectool flash /tmp/ecupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/novacustom-nv41mz UEFI Update - DCR.profile
+++ b/dts/profiles/novacustom-nv41mz UEFI Update - DCR.profile
@@ -1,0 +1,47 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 0
+fsread_tool cat /sys/class/power_supply/AC/online 0
+flashrom -p internal 0
+dasharo_ectool info 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
+cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
+cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 0
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 1
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 1
+cbmem -1 0
+cbmem -1 0
+flashrom -p internal -N --ifd -i bios -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+futility show /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -r /tmp/bios.bin 0
+futility show /tmp/bios.bin 0
+flashrom -p internal --ifd -i bios -w /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -w /tmp/biosupdate 0
+dasharo_ectool flash /tmp/ecupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/novacustom-nv41pz UEFI Update - DCR.profile
+++ b/dts/profiles/novacustom-nv41pz UEFI Update - DCR.profile
@@ -1,0 +1,47 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 0
+fsread_tool cat /sys/class/power_supply/AC/online 0
+flashrom -p internal 0
+dasharo_ectool info 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
+cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
+cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 0
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 1
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 1
+cbmem -1 0
+cbmem -1 0
+flashrom -p internal -N --ifd -i bios -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+futility show /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -r /tmp/bios.bin 0
+futility show /tmp/bios.bin 0
+flashrom -p internal --ifd -i bios -w /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -w /tmp/biosupdate 0
+dasharo_ectool flash /tmp/ecupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/novacustom-nv41pz UEFI->Heads Transition - DPP.profile
+++ b/dts/profiles/novacustom-nv41pz UEFI->Heads Transition - DPP.profile
@@ -1,0 +1,43 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 0
+fsread_tool cat /sys/class/power_supply/AC/online 0
+flashrom -p internal 0
+dasharo_ectool info 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
+cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
+cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 1
+cbmem -1 0
+cbmem -1 0
+flashrom -p internal -N --ifd -i bios -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+flashrom -p internal --ifd -i bios -i fd -w /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -i fd -w /tmp/biosupdate 0
+dasharo_ectool flash /tmp/ecupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/novacustom-v540tu UEFI->Heads Transition - DPP.profile
+++ b/dts/profiles/novacustom-v540tu UEFI->Heads Transition - DPP.profile
@@ -1,0 +1,46 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode -s baseboard-version 0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+dmidecode -s baseboard-version 0
+fsread_tool test -e /sys/class/power_supply/AC/online 0
+fsread_tool cat /sys/class/power_supply/AC/online 0
+flashrom -p internal 0
+dasharo_ectool info 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
+cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
+cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 1
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 0
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 0
+setpci -s 00:16.0 42.B 0
+flashrom -p internal -N --ifd -i bios -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+flashrom -p internal --ifd -i bios -i fd -i me -w /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -i fd -i me -w /tmp/biosupdate 0
+dasharo_ectool flash /tmp/ecupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/novacustom-v560tu UEFI->Heads Transition - DPP.profile
+++ b/dts/profiles/novacustom-v560tu UEFI->Heads Transition - DPP.profile
@@ -1,0 +1,46 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode -s baseboard-version 0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+dmidecode -s baseboard-version 0
+fsread_tool test -e /sys/class/power_supply/AC/online 0
+fsread_tool cat /sys/class/power_supply/AC/online 0
+flashrom -p internal 0
+dasharo_ectool info 0
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
+cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
+cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 1
+flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 0
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 0
+setpci -s 00:16.0 42.B 0
+flashrom -p internal -N --ifd -i bios -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+flashrom -p internal --ifd -i bios -i fd -i me -w /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -i fd -i me -w /tmp/biosupdate 0
+dasharo_ectool flash /tmp/ecupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/odroid-h4-plus Dasharo (Slim Bootloader+UEFI) Initial Deployment - DPP.profile
+++ b/dts/profiles/odroid-h4-plus Dasharo (Slim Bootloader+UEFI) Initial Deployment - DPP.profile
@@ -1,0 +1,80 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+lspci -nnvvvxxxx 0
+lsusb -vvv 0
+superiotool -deV 0
+ectool -ip 0
+msrtool  1
+dmidecode  0
+dmesg  0
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+flashrom -p internal 0
+flashrom -V -p internal:laptop=force_I_want_a_brick -r logs/rom.bin --ifd -i fd -i bios -i me 0
+dmesg  0
+cbmem  1
+cbmem -1 1
+mei-amt-check  1
+intelmetool -m 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s bios-version 0
+dmidecode -s system-product-name 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+fsread_tool test -f /sys/class/mei/mei0/fw_status 0
+fsread_tool cat /sys/class/mei/mei0/fw_status 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 1
+flashrom -p internal 0
+flashrom -p internal -r /fw_backup/rom.bin --ifd -i fd -i bios -i me 0
+flashrom -p internal 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 0
+setpci -s 00:16.0 42.B 0
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 1
+dmidecode -s system-uuid 0
+dmidecode -s baseboard-serial-number 0
+cbfstool /tmp/biosupdate layout -w 1
+cbfstool /tmp/biosupdate layout -w 1
+cbfstool /tmp/biosupdate layout -w 1
+flashrom -p internal -N --ifd -i bios -i fd -w /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/odroid-h4-plus Dasharo (coreboot+UEFI) to Dasharo (Slim Bootloader+UEFI) Transition - DPP.profile
+++ b/dts/profiles/odroid-h4-plus Dasharo (coreboot+UEFI) to Dasharo (Slim Bootloader+UEFI) Transition - DPP.profile
@@ -1,0 +1,38 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+flashrom -p internal -r /tmp/dts-temp-files/rom_seabios_check 0
+cbfstool /tmp/dts-temp-files/rom_seabios_check extract -n config -f /tmp/dts-temp-files/config 0
+flashrom -p internal 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 0
+setpci -s 00:16.0 42.B 0
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 1
+dmidecode -s system-uuid 0
+dmidecode -s baseboard-serial-number 0
+cbfstool /tmp/biosupdate layout -w 1
+cbfstool /tmp/biosupdate layout -w 1
+cbfstool /tmp/biosupdate layout -w 1
+flashrom -p internal -N --ifd -i bios -i fd -w /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/odroid-h4-plus Initial Deployment - DPP.profile
+++ b/dts/profiles/odroid-h4-plus Initial Deployment - DPP.profile
@@ -1,0 +1,86 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+lspci -nnvvvxxxx 0
+lsusb -vvv 0
+superiotool -deV 0
+ectool -ip 0
+msrtool  1
+dmidecode  0
+dmesg  0
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+flashrom -p internal 0
+flashrom -V -p internal:laptop=force_I_want_a_brick -r logs/rom.bin --ifd -i fd -i bios -i me 0
+dmesg  0
+cbmem  1
+cbmem -1 1
+mei-amt-check  1
+intelmetool -m 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s bios-version 0
+dmidecode -s system-product-name 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+fsread_tool test -f /sys/class/mei/mei0/fw_status 0
+fsread_tool cat /sys/class/mei/mei0/fw_status 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 1
+flashrom -p internal 0
+flashrom -p internal -r /fw_backup/rom.bin --ifd -i fd -i bios -i me 0
+flashrom -p internal 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 0
+setpci -s 00:16.0 42.B 0
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+dmidecode -s system-uuid 0
+dmidecode -s baseboard-serial-number 0
+cbfstool /tmp/biosupdate layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+cbfstool /tmp/biosupdate add -f /tmp/serial_number.txt -n serial_number -t raw -r COREBOOT 0
+cbfstool /tmp/biosupdate add -f /tmp/system_uuid.txt -n system_uuid -t raw -r COREBOOT 0
+cbfstool /tmp/biosupdate expand -r FW_MAIN_A 0
+cbfstool /tmp/biosupdate add -f /tmp/serial_number.txt -n serial_number -t raw -r FW_MAIN_A 0
+cbfstool /tmp/biosupdate add -f /tmp/system_uuid.txt -n system_uuid -t raw -r FW_MAIN_A 0
+cbfstool /tmp/biosupdate truncate -r FW_MAIN_A 0
+flashrom -p internal -N --ifd -i bios -i fd -w /tmp/biosupdate_resigned.rom 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/optiplex-7010 Initial Deployment - DPP.profile
+++ b/dts/profiles/optiplex-7010 Initial Deployment - DPP.profile
@@ -1,0 +1,85 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+lspci -nnvvvxxxx 0
+lsusb -vvv 0
+superiotool -deV 0
+ectool -ip 0
+msrtool  1
+dmidecode  0
+dmesg  0
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+flashrom -p internal 0
+flashrom -V -p internal:laptop=force_I_want_a_brick -r logs/rom.bin --ifd -i fd -i bios -i me -i gbe 0
+dmesg  0
+cbmem  1
+cbmem -1 1
+mei-amt-check  1
+intelmetool -m 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s bios-version 0
+dmidecode -s system-product-name 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+fsread_tool test -f /sys/class/mei/mei0/fw_status 1
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 1
+flashrom -p internal 0
+flashrom -p internal -r /fw_backup/rom.bin --ifd -i fd -i bios -i me -i gbe 0
+flashrom -p internal 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 1
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 1
+cbmem -1 1
+cbmem -1 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+dmidecode -s system-uuid 0
+dmidecode -s baseboard-serial-number 0
+cbfstool /tmp/biosupdate layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+cbfstool /tmp/biosupdate add -f /tmp/serial_number.txt -n serial_number -t raw -r COREBOOT 0
+cbfstool /tmp/biosupdate add -f /tmp/system_uuid.txt -n system_uuid -t raw -r COREBOOT 0
+cbfstool /tmp/biosupdate add -f /tmp/_O7010A29.exe.extracted/65C10_output/pfsobject/section-7ec6c2b0-3fe3-42a0-a316-22dd0517c1e8/volume-0x50000/file-d386beb8-4b54-4e69-94f5-06091f67e0d3/section0.raw -n sch5545_ecfw.bin -t raw 1
+cbfstool /tmp/biosupdate add -f /tmp/_O7010A29.exe.extracted/65C10_output/pfsobject/section-7ec6c2b0-3fe3-42a0-a316-22dd0517c1e8/volume-0x500000/file-2d27c618-7dcd-41f5-bb10-21166be7e143/object-0.raw -n txt_bios_acm.bin -t raw -a 0x20000 1
+cbfstool /tmp/biosupdate add -f /tmp/SNB_IVB_SINIT_20190708_PW.bin -n txt_sinit_acm.bin -t raw -c lzma 0
+flashrom -p internal -N --ifd -i bios -w /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/optiplex-7010 UEFI Update - DPP.profile
+++ b/dts/profiles/optiplex-7010 UEFI Update - DPP.profile
@@ -1,0 +1,36 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 1
+flashrom -p internal 0
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 1
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 1
+cbmem -1 0
+cbmem -1 0
+flashrom -p internal -N --ifd -i bios -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+flashrom -p internal -N --fmap -i COREBOOT -w /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/optiplex-9010 Initial Deployment - DPP.profile
+++ b/dts/profiles/optiplex-9010 Initial Deployment - DPP.profile
@@ -1,0 +1,85 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+lspci -nnvvvxxxx 0
+lsusb -vvv 0
+superiotool -deV 0
+ectool -ip 0
+msrtool  1
+dmidecode  0
+dmesg  0
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+flashrom -p internal 0
+flashrom -V -p internal:laptop=force_I_want_a_brick -r logs/rom.bin --ifd -i fd -i bios -i me -i gbe 0
+dmesg  0
+cbmem  1
+cbmem -1 1
+mei-amt-check  1
+intelmetool -m 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s bios-version 0
+dmidecode -s system-product-name 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+fsread_tool test -f /sys/class/mei/mei0/fw_status 1
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 1
+flashrom -p internal 0
+flashrom -p internal -r /fw_backup/rom.bin --ifd -i fd -i bios -i me -i gbe 0
+flashrom -p internal 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 1
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 1
+cbmem -1 1
+cbmem -1 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+dmidecode -s system-uuid 0
+dmidecode -s baseboard-serial-number 0
+cbfstool /tmp/biosupdate layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+cbfstool /tmp/biosupdate add -f /tmp/serial_number.txt -n serial_number -t raw -r COREBOOT 0
+cbfstool /tmp/biosupdate add -f /tmp/system_uuid.txt -n system_uuid -t raw -r COREBOOT 0
+cbfstool /tmp/biosupdate add -f /tmp/_O9010A30.exe.extracted/65C10_output/pfsobject/section-7ec6c2b0-3fe3-42a0-a316-22dd0517c1e8/volume-0x50000/file-d386beb8-4b54-4e69-94f5-06091f67e0d3/section0.raw -n sch5545_ecfw.bin -t raw 1
+cbfstool /tmp/biosupdate add -f /tmp/_O9010A30.exe.extracted/65C10_output/pfsobject/section-7ec6c2b0-3fe3-42a0-a316-22dd0517c1e8/volume-0x500000/file-2d27c618-7dcd-41f5-bb10-21166be7e143/object-0.raw -n txt_bios_acm.bin -t raw -a 0x20000 1
+cbfstool /tmp/biosupdate add -f /tmp/SNB_IVB_SINIT_20190708_PW.bin -n txt_sinit_acm.bin -t raw -c lzma 0
+flashrom -p internal -N --ifd -i bios -w /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/optiplex-9010 UEFI Update - DPP.profile
+++ b/dts/profiles/optiplex-9010 UEFI Update - DPP.profile
@@ -1,0 +1,36 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 1
+flashrom -p internal 0
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 1
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 1
+cbmem -1 0
+cbmem -1 0
+flashrom -p internal -N --ifd -i bios -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+flashrom -p internal -N --fmap -i COREBOOT -w /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/pcengines-apu2 SeaBIOS Update - DPP.profile
+++ b/dts/profiles/pcengines-apu2 SeaBIOS Update - DPP.profile
@@ -1,0 +1,40 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 1
+flashrom -p internal -c W25Q64BV/W25Q64CV/W25Q64FV --flash-name 0
+flashrom -p internal -c W25Q64BV/W25Q64CV/W25Q64FV --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 1
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -r /tmp/dts-temp-files/rom_seabios_check 0
+cbfstool /tmp/dts-temp-files/rom_seabios_check extract -n config -f /tmp/dts-temp-files/config 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
+cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
+cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 1
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -N --fmap -i COREBOOT -w /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/pcengines-apu2 SeaBIOS->UEFI Transition - DPP.profile
+++ b/dts/profiles/pcengines-apu2 SeaBIOS->UEFI Transition - DPP.profile
@@ -1,0 +1,34 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 1
+flashrom -p internal -c W25Q64BV/W25Q64CV/W25Q64FV --flash-name 0
+flashrom -p internal -c W25Q64BV/W25Q64CV/W25Q64FV --flash-size 0
+fsread_tool test -d /sys/firmware/efi 1
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -r /tmp/dts-temp-files/rom_seabios_check 0
+cbfstool /tmp/dts-temp-files/rom_seabios_check extract -n config -f /tmp/dts-temp-files/config 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV 0
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 1
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -w /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/pcengines-apu3 SeaBIOS Update - DPP.profile
+++ b/dts/profiles/pcengines-apu3 SeaBIOS Update - DPP.profile
@@ -1,0 +1,40 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 1
+flashrom -p internal -c W25Q64BV/W25Q64CV/W25Q64FV --flash-name 0
+flashrom -p internal -c W25Q64BV/W25Q64CV/W25Q64FV --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 1
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -r /tmp/dts-temp-files/rom_seabios_check 0
+cbfstool /tmp/dts-temp-files/rom_seabios_check extract -n config -f /tmp/dts-temp-files/config 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
+cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
+cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 1
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -N --fmap -i COREBOOT -w /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/pcengines-apu3 SeaBIOS->UEFI Transition - DPP.profile
+++ b/dts/profiles/pcengines-apu3 SeaBIOS->UEFI Transition - DPP.profile
@@ -1,0 +1,34 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 1
+flashrom -p internal -c W25Q64BV/W25Q64CV/W25Q64FV --flash-name 0
+flashrom -p internal -c W25Q64BV/W25Q64CV/W25Q64FV --flash-size 0
+fsread_tool test -d /sys/firmware/efi 1
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -r /tmp/dts-temp-files/rom_seabios_check 0
+cbfstool /tmp/dts-temp-files/rom_seabios_check extract -n config -f /tmp/dts-temp-files/config 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV 0
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 1
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -w /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/pcengines-apu4 SeaBIOS Update - DPP.profile
+++ b/dts/profiles/pcengines-apu4 SeaBIOS Update - DPP.profile
@@ -1,0 +1,40 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 1
+flashrom -p internal -c W25Q64BV/W25Q64CV/W25Q64FV --flash-name 0
+flashrom -p internal -c W25Q64BV/W25Q64CV/W25Q64FV --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 1
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -r /tmp/dts-temp-files/rom_seabios_check 0
+cbfstool /tmp/dts-temp-files/rom_seabios_check extract -n config -f /tmp/dts-temp-files/config 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
+cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
+cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 1
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -N --fmap -i COREBOOT -w /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/pcengines-apu4 SeaBIOS->UEFI Transition - DPP.profile
+++ b/dts/profiles/pcengines-apu4 SeaBIOS->UEFI Transition - DPP.profile
@@ -1,0 +1,34 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 1
+flashrom -p internal -c W25Q64BV/W25Q64CV/W25Q64FV --flash-name 0
+flashrom -p internal -c W25Q64BV/W25Q64CV/W25Q64FV --flash-size 0
+fsread_tool test -d /sys/firmware/efi 1
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -r /tmp/dts-temp-files/rom_seabios_check 0
+cbfstool /tmp/dts-temp-files/rom_seabios_check extract -n config -f /tmp/dts-temp-files/config 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV 0
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 1
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -w /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/pcengines-apu6 SeaBIOS Update - DPP.profile
+++ b/dts/profiles/pcengines-apu6 SeaBIOS Update - DPP.profile
@@ -1,0 +1,40 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 1
+flashrom -p internal -c W25Q64BV/W25Q64CV/W25Q64FV --flash-name 0
+flashrom -p internal -c W25Q64BV/W25Q64CV/W25Q64FV --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 1
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -r /tmp/dts-temp-files/rom_seabios_check 0
+cbfstool /tmp/dts-temp-files/rom_seabios_check extract -n config -f /tmp/dts-temp-files/config 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
+cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
+cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 1
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -N --fmap -i COREBOOT -w /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/pcengines-apu6 SeaBIOS->UEFI Transition - DPP.profile
+++ b/dts/profiles/pcengines-apu6 SeaBIOS->UEFI Transition - DPP.profile
@@ -1,0 +1,34 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 1
+flashrom -p internal -c W25Q64BV/W25Q64CV/W25Q64FV --flash-name 0
+flashrom -p internal -c W25Q64BV/W25Q64CV/W25Q64FV --flash-size 0
+fsread_tool test -d /sys/firmware/efi 1
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -r /tmp/dts-temp-files/rom_seabios_check 0
+cbfstool /tmp/dts-temp-files/rom_seabios_check extract -n config -f /tmp/dts-temp-files/config 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV 0
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 1
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+flashrom -p internal:boardmismatch=force -c W25Q64BV/W25Q64CV/W25Q64FV -w /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/lib/dts-lib.robot
+++ b/lib/dts-lib.robot
@@ -66,7 +66,7 @@ Boot Dasharo Tools Suite Via IPXE Shell
     Set DUT Response Timeout    60s
 
     # 4) Try to boot via the link:
-    Write Bare Into Terminal    chain ${dts_chain_link}\n
+    Write Bare Into Terminal    chain ${dts_chain_link}\n    interval=0.2
     Set DUT Response Timeout    5m
     Read From Terminal Until    .cpio.gz...
     Read From Terminal Until    ok
@@ -299,8 +299,27 @@ Wait For Checkpoint And Press Enter
     [Arguments]    ${checkpoint}    ${regexp}=${FALSE}
     ${out}=    Wait For Checkpoint    ${checkpoint}    ${regexp}
     Sleep    1s
-    Write Bare Into Terminal    \r\n
+    Write Bare Into Terminal    ${ENTER}
     RETURN    ${out}
+
+Wait For ME Warning Or Reboot
+    [Documentation]    Helper keyword to deal with ME warning that shows up
+    ...    during multiple workflows
+    [Arguments]    ${skip_me}
+    ${checkpoint}=    Wait For Either Checkpoint
+    ...    ${DTS_ME_WARN}
+    ...    Rebooting
+    IF    """${DTS_ME_WARN}""" in """${checkpoint}"""
+        IF    ${skip_me}
+            Write Into Terminal    Y
+            ${checkpoint2}=    Wait For Checkpoint    Rebooting in
+            VAR    ${checkpoint}=    ${checkpoint}    ${checkpoint2}    separator=\n
+        ELSE
+            Fail    Cannot update Intel ME
+        END
+    END
+
+    RETURN    ${checkpoint}
 
 Go Through Initial Deployment
     [Documentation]    This KW goes through standard Dasharo initial deployment
@@ -308,7 +327,7 @@ Go Through Initial Deployment
     ...    only thing which needs to be specified - the Dasharo version to
     ...    deploy (first argument), available versions: DCR UEFI, DPP UEFI, DPP
     ...    SeaBIOS.
-    [Arguments]    ${dasharo_version}
+    [Arguments]    ${dasharo_version}    ${skip_me}=${FALSE}
 
     IF    '${dasharo_version}' == 'DCR UEFI'
         VAR    ${opt}=    ${DTS_DCR_UEFI_OPT}
@@ -357,13 +376,16 @@ Go Through Initial Deployment
     Wait For Checkpoint And Write    ${DTS_SPECIFICATION_WARN}    Y
     Wait For Checkpoint And Write    ${DTS_DEPLOY_WARN}    Y
 
+    Wait For ME Warning Or Reboot    ${skip_me}
+    Wait For Checkpoint    Rebooting
+
 Go Through Transition
     [Documentation]    This KW goes through standard Dasharo Transition
     ...    choosing all needed menu options and answering all questions. The
     ...    only thing which needs to be specified - the Dasharo version to
     ...    transit to (first argument), available versions: DCR UEFI, DPP UEFI,
     ...    DPP SeaBIOS.
-    [Arguments]    ${dasharo_version}
+    [Arguments]    ${dasharo_version}    ${skip_me}=${FALSE}
     # 1) Select transition:
     Wait For Checkpoint And Write    ${DTS_CHECKPOINT}    ${DTS_TRANSITION_OPT}
 
@@ -388,6 +410,9 @@ Go Through Transition
     Wait For Checkpoint And Write    ${DTS_SPECIFICATION_WARN}    Y
     Wait For Checkpoint And Write    ${DTS_DEPLOY_WARN}    Y
 
+    Wait For ME Warning Or Reboot    ${skip_me}
+    Wait For Checkpoint    Rebooting
+
 Go Through Update
     [Documentation]    This KW goes through standard Dasharo update workflow
     ...    choosing all needed menu options and answering all questions.
@@ -407,21 +432,14 @@ Go Through Update
     END
     Wait For Checkpoint And Write    ${DTS_DEPLOY_WARN}    Y
     Set DUT Response Timeout    5m
-    ${dts_me_warn_escaped}=    Evaluate    re.escape("""${DTS_ME_WARN}""")
-    ${checkpoint}=    Wait For Checkpoint
-    ...    ${dts_me_warn_escaped}|Rebooting    regexp=${TRUE}
-    IF    """${DTS_ME_WARN}""" in """${checkpoint}"""
-        IF    ${skip_me}
-            Write Into Terminal    Y
-            Wait For Checkpoint    Rebooting
-        ELSE
-            Fail    Cannot update Intel ME
-        END
-    END
+
+    Wait For ME Warning Or Reboot    ${skip_me}
+    Wait For Checkpoint    Rebooting
 
 Go Through Heads Transition
     [Documentation]    This KW goes through transition to Dasharo Heads choosing
     ...    all needed menu options and answering all questions.
+    [Arguments]    ${skip_me}=${FALSE}
     Set DUT Response Timeout    120s
     # 1) Start update:
     Wait For Checkpoint And Write    ${DTS_CHECKPOINT}    ${DTS_DEPLOY_OPT}
@@ -433,39 +451,107 @@ Go Through Heads Transition
 
     Set DUT Response Timeout    5m
     # 3) Check for Heads firmware deployment success:
-    Wait For Checkpoint    Successfully switched to Dasharo Heads firmware
-    Wait For Checkpoint And Write    ${DTS_CONFIRM_CHECKPOINT}    1
+    ${checkpoint}=    Wait For Either Checkpoint
+    ...    ${DTS_ME_WARN}
+    ...    Successfully switched to Dasharo Heads firmware
+    IF    """${DTS_ME_WARN}""" in """${checkpoint}"""
+        IF    ${skip_me}
+            Write Into Terminal    Y
+            Wait For Checkpoint
+            ...    Successfully switched to Dasharo Heads firmware
+        ELSE
+            Fail    Cannot update Intel ME
+        END
+    END
+    Wait For Checkpoint And Press Enter    ${DTS_CONFIRM_CHECKPOINT}
+    Wait For Checkpoint    Rebooting in
+    Wait For Checkpoint    Rebooting
 
 Export Shell Variables For Emulation
     [Documentation]    Export variables needed for this test
-    [Arguments]    ${workflow}    ${dts_test_variables}    ${dts_config_ref_value}=refs/heads/main
-    @{exports}=    Prepare Test Exports    ${workflow}    ${dts_test_variables}    ${dts_config_ref_value}
+    [Arguments]    ${workflow}
+    ...    ${release}
+    ...    ${dts_test_variables}
+    ...    ${dts_config_ref_value}=refs/heads/main
+    @{exports}=    Prepare Test Exports    ${workflow}    ${release}
+    ...    ${dts_test_variables}    ${dts_config_ref_value}
     FOR    ${export_string}    IN    @{exports}
-        Execute Command In Terminal    export ${export_string}
+        Execute Command In Terminal    ${export_string}
     END
 
 Prepare Test Exports
     [Documentation]    Create list with 'export VARIABLE=VALUE` strings.
-    [Arguments]    ${workflow}    ${dts_test_variables}    ${dts_config_ref_value}=refs/heads/main
+    [Arguments]    ${workflow}
+    ...    ${release}
+    ...    ${dts_test_variables}
+    ...    ${dts_config_ref_value}=refs/heads/main
     VAR    &{exports_dict}=    &{dts_test_variables}[DTS_TEST_EXPORTS]
-    Set To Dictionary    ${exports_dict}    TEST_BIOS_VERSION=${dts_test_variables}[DTS_TEST_VERSIONS][${workflow}]
-    Set To Dictionary    ${exports_dict}    DTS_CONFIG_REF=${dts_config_ref_value}
-    IF    "Initial Deployment" in "${workflow}"
-        Set To Dictionary    ${exports_dict}    TEST_BIOS_VENDOR=proprietary
-    ELSE
-        IF    ${dts_test_variables}[DTS_TEST_HAS_EC]
-            Set To Dictionary    ${exports_dict}    TEST_USING_OPENSOURCE_EC_FIRM=true
-        END
-    END
-    IF    "SeaBIOS Update" in "${workflow}" or "SeaBIOS->" in "${workflow}"
-        Set To Dictionary    ${exports_dict}    TEST_EFI_PRESENT=false
-        Set To Dictionary    ${exports_dict}    TEST_IS_SEABIOS=true
+
+    # Base exports for every workflow
+    VAR    &{exports}=    &{EMPTY}
+    Set To Dictionary    ${exports}
+    ...    TEST_BIOS_VERSION=${dts_test_variables}[DTS_TEST_VERSIONS][${workflow}]
+    ...    DTS_CONFIG_REF=${dts_config_ref_value}
+    FOR    ${export_variable}    ${export_value}    IN    &{exports_dict}
+        Set To Dictionary    ${exports}    ${export_variable}=${export_value}
     END
 
-    VAR    @{exports}=    @{EMPTY}
-    FOR    ${export_variable}    ${export_value}    IN    &{exports_dict}
-        Append To List    ${exports}
+    # Specific, per workflow exports
+    &{workflow_exports}=    Get From Dictionary
+    ...    ${dts_test_variables}[DTS_TEST_EXPORTS_PER_WORKFLOW]    ${workflow}
+    ...    default=&{EMPTY}
+    FOR    ${export_variable}    ${export_value}    IN    &{workflow_exports}
+        Set To Dictionary    ${exports}    ${export_variable}=${export_value}
+    END
+
+    # Most specific exports, per workflow & release version
+    &{full_workflow_exports}=    Get From Dictionary
+    ...    ${dts_test_variables}[DTS_TEST_EXPORTS_PER_FULL_WORKFLOW]
+    ...    ${{ ("${workflow}", "${release}") }}
+    ...    default=&{EMPTY}
+    FOR    ${export_variable}    ${export_value}    IN    &{full_workflow_exports}
+        Set To Dictionary    ${exports}    ${export_variable}=${export_value}
+    END
+
+    # Create list of export strings
+    VAR    @{export_strings}=    @{EMPTY}
+    FOR    ${export_variable}    ${export_value}    IN    &{exports}
+        Append To List    ${export_strings}
         ...    export ${export_variable}="${export_value}"
     END
 
-    RETURN    ${exports}
+    RETURN    ${export_strings}
+
+Are DPP Keys Defined
+    ${email}=    Run Keyword And Return Status
+    ...    Variable Should Exist    $DPP_EMAIL
+    ${password}=    Run Keyword And Return Status
+    ...    Variable Should Exist    $DPP_PASSWORD
+    ${status}=    Run Keyword And Return Status    Should Be True
+    ...    ${email} and ${password}
+    RETURN    ${status}
+
+Flash FW Automatically Or Manually
+    [Documentation]    Flash firmware automatically if it's possible and
+    ...    variable with name passed in fw_var exists
+    [Arguments]    ${fw_var}    ${msg}="Flash firmware"
+    ${variable_exists}=    Run Keyword And Return Status
+    ...    Variable Should Exist    \${${fw_var}}
+    # Without POWER_CTRL Flash Firmware will try to boot into Linux which won't
+    # work
+    IF    not ${variable_exists} or '''${POWER_CTRL}''' == '''none'''
+        Execute Manual Step While Freeing Serial Connection    ${msg}
+    ELSE
+        Flash Firmware    ${${fw_var}}
+        Power On
+        Set DUT Response Timeout    5m
+    END
+
+Execute Manual Step While Freeing Serial Connection
+    [Documentation]    In case you need to connect to DUT via serial to do
+    ...    manual steps. Arguments are the same as for 'Execute Manual Step'
+    [Arguments]    ${msg}
+    Telnet.Close All Connections
+    Execute Manual Step
+    ...    ${msg}. Make sure to close serial connection before continuing
+    Serial Setup    ${RTE_IP}    ${RTE_S2_N_PORT}

--- a/lib/flash.robot
+++ b/lib/flash.robot
@@ -8,7 +8,7 @@ Flash Via Internal Programmer With Args
     ...    using extra arguments.
     [Arguments]    ${fw_file_path}    ${args}    ${timeout}=3m
     ${out_flash}=    Execute Command In Terminal
-    ...    flashrom -p internal -c ${INTERNAL_PROGRAMMER_CHIPNAME} -w ${fw_file_path} ${args}
+    ...    flashrom -p internal -c "${INTERNAL_PROGRAMMER_CHIPNAME}" -w ${fw_file_path} ${args}
     ...    timeout=${timeout}
     IF    "Warning: Chip content is identical to the requested image." in """${out_flash}"""
         RETURN

--- a/lib/network.robot
+++ b/lib/network.robot
@@ -43,7 +43,11 @@ Send File To DUT
 
 Get File From DUT
     [Documentation]    Downloads a file from DUT and saves it at given location
-    [Arguments]    ${source_path}    ${target_path}
+    ...
+    ...    === Requirements ===
+    ...    Keyword has to be called when in OS shell
+    ...    DUT OS has to have sshd service or socket enabled
+    [Arguments]    ${source_path}    ${target_path}    ${verify}=${TRUE}
     Run    rm -f ${target_path}
     ${hash_source}=    Execute Command In Terminal    md5sum ${source_path} | cut -d ' ' -f 1
 
@@ -64,9 +68,11 @@ Get File From DUT
     ELSE
         SSHLibrary.Get File    ${source_path}    ${target_path}
     END
-    ${hash_target}=    Run    md5sum ${target_path} | cut -d ' ' -f 1
-    ${hash_target}=    Strip String    ${hash_target}
-    Should Be Equal    ${hash_source}    ${hash_target}    msg=File was not correctly sent to DUT
+    IF    ${verify}
+        ${hash_target}=    Run    md5sum ${target_path} | cut -d ' ' -f 1
+        ${hash_target}=    Strip String    ${hash_target}
+        Should Be Equal    ${hash_source}    ${hash_target}    msg=File was not correctly sent to DUT
+    END
 
 Get Hostname Ip
     [Documentation]    Returns local IP address of the DUT.

--- a/lib/network.robot
+++ b/lib/network.robot
@@ -76,10 +76,17 @@ Get File From DUT
 
 Get Hostname Ip
     [Documentation]    Returns local IP address of the DUT.
-    ${out_hostname}=    Execute Command In Terminal    hostname -I
-    Should Not Contain    ${out_hostname}    link is not ready
-    ${ip_address}=    String.Get Regexp Matches    ${out_hostname}    \\b(?:192\\.168|10\\.0)\\.\\d{1,3}\\.\\d{1,3}\\b
-    Should Not Be Empty    ${ip_address}
+    VAR    ${ip_regexp}=    \\b(?:192\\.168|10\\.0)\\.\\d{1,3}\\.\\d{1,3}\\b
+    TRY
+        ${out_hostname}=    Execute Command In Terminal    hostname -I
+        Should Not Contain    ${out_hostname}    link is not ready
+        ${ip_address}=    String.Get Regexp Matches    ${out_hostname}    ${ip_regexp}
+        Should Not Be Empty    ${ip_address}
+    EXCEPT
+        ${out_hostname}=    Execute Command In Terminal    ip a
+        ${ip_address}=    String.Get Regexp Matches    ${out_hostname}    ${ip_regexp}
+        Should Not Be Empty    ${ip_address}
+    END
     RETURN    ${ip_address[0]}
 
 Check Internet Connection On Linux

--- a/platform-configs/include/default.robot
+++ b/platform-configs/include/default.robot
@@ -25,7 +25,7 @@ ${POWER_CTRL}=                                      ${TBD}
 ${FLASH_VERIFY_METHOD}=                             ${TBD}
 ${WIFI_CARD}=                                       ${TBD}
 ${MAX_CPU_TEMP}=                                    ${TBD}
-${INTERNAL_PROGRAMMER_CHIPNAME}=                    "Opaque flash chip"
+${INTERNAL_PROGRAMMER_CHIPNAME}=                    Opaque flash chip
 ${FLASHING_METHOD}=                                 external
 ${SNIPEIT}=                                         yes
 ${SEABIOS_BOOT_DEVICE}=                             ${EMPTY}
@@ -406,18 +406,36 @@ ${DTS_TEST_VERSION_BASE}=                           v0.0.0
 ...                                                 Dasharo (coreboot+UEFI) to Dasharo (Slim Bootloader+UEFI) Transition=Dasharo (coreboot+UEFI) ${DTS_TEST_VERSION_BASE}
 &{DTS_TEST_VERSIONS}=                               &{DTS_TEST_VERSIONS_BASE}
 # TEST_SYSTEM_MODEL, TEST_BOARD_MODEL, TEST_SYSTEM_VENDOR variables to export
-${DTS_TEST_SYSTEM_MODEL}=                           ${EMPTY}
 ${DTS_TEST_BOARD_MODEL}=                            ${EMPTY}
 ${DTS_TEST_SYSTEM_VENDOR}=                          ${EMPTY}
-${DTS_TEST_BIOS_VENDOR}=                            3mdeb
 ${DTS_TEST_HAS_EC}=                                 ${False}
 &{DTS_TEST_BASE_EXPORTS}=
-...                                                 TEST_SYSTEM_MODEL=${DTS_TEST_SYSTEM_MODEL}
+...                                                 DTS_TESTING=true
+...                                                 TEST_SYSTEM_MODEL=${DMIDECODE_PRODUCT_NAME}
 ...                                                 TEST_BOARD_MODEL=${DTS_TEST_BOARD_MODEL}
 ...                                                 TEST_SYSTEM_VENDOR=${DTS_TEST_SYSTEM_VENDOR}
-...                                                 TEST_BIOS_VENDOR=${DTS_TEST_BIOS_VENDOR}
-...                                                 DTS_TESTING=true
+...                                                 TEST_BIOS_VENDOR=${DMIDECODE_VENDOR}
+...                                                 TEST_CPU_VERSION=${CPU}
+...                                                 TEST_INTERNAL_PROGRAMMER_CHIPNAME=${INTERNAL_PROGRAMMER_CHIPNAME}
+...                                                 TEST_USING_OPENSOURCE_EC_FIRM=${{"true" if ${DTS_TEST_HAS_EC} else "false" }}
 &{DTS_TEST_EXPORTS}=                                &{DTS_TEST_BASE_EXPORTS}
+&{DTS_TEST_EXPORTS_PER_WORKFLOW_BASE}=
+...                                                 UEFI Update=&{{ {"TEST_IS_COREBOOT": "true"} }}
+...                                                 SeaBIOS Update=&{{ {"TEST_IS_COREBOOT": "true", "TEST_EFI_PRESENT": "false", "TEST_IS_SEABIOS": "true"} }}
+...                                                 UEFI->Heads Transition=&{{ {"TEST_IS_COREBOOT": "true"} }}
+...                                                 SeaBIOS->UEFI Transition=&{{ {"TEST_IS_COREBOOT": "true", "TEST_EFI_PRESENT": "false", "TEST_IS_SEABIOS": "true"} }}
+...                                                 Dasharo (coreboot+UEFI) to Dasharo (Slim Bootloader+UEFI) Transition=&{{ {"TEST_IS_COREBOOT": "true"} }}
+...                                                 Initial Deployment=&{{ {"TEST_BIOS_VENDOR": "proprietary", "TEST_USING_OPENSOURCE_EC_FIRM": "false"} }}
+# dict[workflow, dict[variable, value]]
+&{DTS_TEST_EXPORTS_PER_WORKFLOW}=                   &{DTS_TEST_EXPORTS_PER_WORKFLOW_BASE}
+# dict[tuple[workflow,release], dict[variable, value]]
+# Export variables per matching workflow and release
+# Used if e.g. DCR and DPP updates need different exports
+# Example usage:
+# &{DTS_TEST_EXPORTS_PER_FULL_WORKFLOW}=
+# ...    ${{ ("UEFI Update", "DCR") }}=${{ {"TEST_FMAP_REGIONS": "", "TEST_ME_DISABLED": "false"] }}
+# ...    ${{ ("UEFI Update", "DPP") }}=${{ {"TEST_FMAP_REGIONS": "BOOTSPLASH"] }}
+&{DTS_TEST_EXPORTS_PER_FULL_WORKFLOW}=              &{EMPTY}
 # Possible values: check DTS_TEST_POSSIBLE_WORKFLOWS
 @{DTS_TEST_WORKFLOWS}=                              @{EMPTY}
 @{DTS_TEST_POSSIBLE_WORKFLOWS}=
@@ -439,6 +457,12 @@ ${DTS_TEST_HAS_EC}=                                 ${False}
 ...                                                 UEFI->Heads Transition=@{{["DPP"]}}
 ...                                                 Dasharo (coreboot+UEFI) to Dasharo (Slim Bootloader+UEFI) Transition=@{{["DPP"]}}
 ...                                                 Dasharo (Slim Bootloader+UEFI) Initial Deployment=@{{["DPP"]}}
+# List of workflows which require profile comparison in the format:
+# list[tuple[workflow, release]] e.g.:
+# @{DTS_TEST_WORKFLOW_PROFILES}=
+# ...    ${{ ("UEFI->Heads Transition", "DPP") }}
+# ...    ${{ ("UEFI Update", "DPP") }}
+@{DTS_TEST_WORKFLOW_PROFILES}=                      @{EMPTY}
 
 
 *** Keywords ***

--- a/platform-configs/include/msi-z690-common.robot
+++ b/platform-configs/include/msi-z690-common.robot
@@ -118,6 +118,24 @@ ${BOOT_FROM_USB_ITERATIONS_NUMBER}=             5
 ${DTS_TEST_SYSTEM_VENDOR}=                      Micro-Star International Co., Ltd.
 @{DTS_TEST_WORKFLOWS}=                          Initial Deployment    UEFI Update    UEFI->Heads Transition
 
+&{DTS_TEST_EXPORTS}=
+...                                             &{DTS_TEST_BASE_EXPORTS}
+...                                             TEST_BOARD_HAS_BOOTSPLASH=false
+...                                             TEST_VBOOT_KEYS=true
+...                                             TEST_FMAP_REGIONS=BOOTSPLASH
+...                                             TEST_SOUND_CARD_PRESENT=false
+...                                             TEST_BOARD_HAS_GBE_REGION=false
+
+&{DTS_TEST_EXPORTS_PER_WORKFLOW}=
+...                                             &{DTS_TEST_EXPORTS_PER_WORKFLOW_BASE}
+...                                             UEFI Update=&{{ {"TEST_IS_COREBOOT": "true"} }}
+...                                             UEFI->Heads Transition=&{{ { "TEST_IS_COREBOOT": "true", "TEST_ME_DISABLED": "false" } }}
+...                                             Initial Deployment=&{{ {"TEST_HCI_PRESENT": "true", "TEST_FMAP_REGIONS": ""} }}
+
+&{DTS_TEST_EXPORTS_PER_FULL_WORKFLOW}=
+...                                             ${{ ("UEFI Update", "DCR") }}=${{ {"TEST_FMAP_REGIONS": "", "TEST_ME_DISABLED": "false"} }}
+...                                             ${{ ("UEFI Update", "DPP") }}=${{ {"TEST_ME_OP_MODE": "2", "TEST_ME_HAP_DISABLED": "true"} }}
+
 
 *** Keywords ***
 Power On

--- a/platform-configs/include/novacustom-adl.robot
+++ b/platform-configs/include/novacustom-adl.robot
@@ -25,3 +25,16 @@ ${DMIDECODE_FIRMWARE_VERSION}=      Dasharo (coreboot+UEFI) v1.7.2
 ${DMIDECODE_RELEASE_DATE}=          03/17/2022
 
 ${L3_CACHE_SUPPORT}=                ${TRUE}
+
+# DTS E2E variables
+&{DTS_TEST_EXPORTS}=
+...                                 &{DTS_TEST_BASE_EXPORTS}
+...                                 TEST_AC_PRESENT=true
+...                                 TEST_ME_DISABLED=false
+...                                 TEST_ME_OP_MODE=1
+...                                 TEST_VBOOT_KEYS=true
+...                                 TEST_FMAP_REGIONS=BOOTSPLASH
+...                                 TEST_BOARD_HAS_BOOTSPLASH=false
+
+@{DTS_TEST_WORKFLOW_PROFILES}=
+...                                 ${{ ("UEFI Update", "DCR") }}

--- a/platform-configs/include/novacustom-common.robot
+++ b/platform-configs/include/novacustom-common.robot
@@ -151,6 +151,9 @@ ${DTS_TEST_SYSTEM_VENDOR}=                          Notebook
 # deploys EC in those cases
 @{DTS_TEST_WORKFLOWS}=                              Initial Deployment    UEFI Update
 @{DTS_TEST_DEFAULT_RELEASES}=                       DCR
+&{DTS_TEST_EXPORTS}=
+...                                                 &{DTS_TEST_BASE_EXPORTS}
+...                                                 TEST_AC_PRESENT=${TRUE}
 
 
 *** Keywords ***

--- a/platform-configs/include/novacustom-mtl.robot
+++ b/platform-configs/include/novacustom-mtl.robot
@@ -40,4 +40,10 @@ ${DASHARO_POWER_MGMT_MENU_SUPPORT}=                 ${FALSE}
 # DTS E2E variables
 &{DTS_TEST_EXPORTS}=
 ...                                                 &{DTS_TEST_BASE_EXPORTS}
+...                                                 TEST_AC_PRESENT=true
 ...                                                 TEST_NOVACUSTOM_MODEL=${DTS_TEST_BOARD_MODEL}
+...                                                 TEST_FMAP_REGIONS=BOOTSPLASH
+...                                                 TEST_BOARD_HAS_BOOTSPLASH=false
+...                                                 TEST_HCI_PRESENT=true
+...                                                 TEST_ME_HAP_DISABLED=true
+...                                                 TEST_ME_OP_MODE=2

--- a/platform-configs/include/novacustom-tgl.robot
+++ b/platform-configs/include/novacustom-tgl.robot
@@ -29,3 +29,15 @@ ${L3_CACHE_SUPPORT}=                ${TRUE}
 # DTS-E2E variables
 &{DTS_TEST_VERSIONS}=               &{DTS_TEST_VERSIONS_BASE}
 ...                                 UEFI Update=Dasharo (coreboot+UEFI) v1.5.0
+
+&{DTS_TEST_EXPORTS}=
+...                                 &{DTS_TEST_BASE_EXPORTS}
+...                                 TEST_AC_PRESENT=true
+...                                 TEST_ME_DISABLED=false
+...                                 TEST_ME_OP_MODE=1
+...                                 TEST_VBOOT_KEYS=true
+...                                 TEST_FMAP_REGIONS=BOOTSPLASH
+...                                 TEST_BOARD_HAS_BOOTSPLASH=false
+
+@{DTS_TEST_WORKFLOW_PROFILES}=
+...                                 ${{ ("UEFI Update", "DCR") }}

--- a/platform-configs/include/optiplex-common.robot
+++ b/platform-configs/include/optiplex-common.robot
@@ -11,9 +11,9 @@ ${FLASH_VERIFY_OPTION}=                         UEFI Shell    # Selected One Tim
 ${INITIAL_DUT_CONNECTION_METHOD}=               Telnet
 ${DUT_CONNECTION_METHOD}=                       ${INITIAL_DUT_CONNECTION_METHOD}
 ${FLASH_SIZE}=                                  ${4*1024*1024}
-${BOOT_MENU_KEY}=                               ${F7}
+${BOOT_MENU_KEY}=                               ${F12}
 ${SETUP_MENU_KEY}=                              ${F2}
-${IPXE_BOOT_ENTRY}=                             Network Boot and Utilities
+${IPXE_BOOT_ENTRY}=                             iPXE Network Boot
 ${POWER_CTRL}=                                  sonoff
 ${MAX_CPU_TEMP}=                                80
 ${CHECK_POWER_LED_SUPPORT}=                     ${FALSE}
@@ -92,13 +92,26 @@ ${BASE_PORT_RAMSTAGE_SUPPORT}=                  ${TRUE}
 ${BASE_PORT_ALLOCATOR_V4_SUPPORT}=              ${TRUE}
 ${SERIAL_NUMBER_VERIFICATION}=                  ${TRUE}
 ${FAMILY_VERIFICATION}=                         ${TRUE}
-${NETBOOT_UTILITIES_SUPPORT}=                   ${TRUE}
+${NETBOOT_UTILITIES_SUPPORT}=                   ${FALSE}
 ${HIBERNATION_AND_RESUME_SUPPORT}=              ${TRUE}
+
+${DMIDECODE_SERIAL_NUMBER}=                     123456789
+${DMIDECODE_MANUFACTURER}=                      Dell Inc.
 
 # DTS E2E variables
 ${DTS_TEST_SYSTEM_VENDOR}=                      Dell Inc.
 @{DTS_TEST_WORKFLOWS}=                          Initial Deployment    UEFI Update
 @{DTS_TEST_DEFAULT_RELEASES}=                   DPP
+&{DTS_TEST_EXPORTS}=
+...                                             &{DTS_TEST_BASE_EXPORTS}
+...                                             TEST_SOUND_CARD_PRESENT=false
+...                                             TEST_MEI_CONF_PRESENT=false
+&{DTS_TEST_EXPORTS_PER_WORKFLOW}=
+...                                             &{DTS_TEST_EXPORTS_PER_WORKFLOW_BASE}
+...                                             UEFI Update=&{{ {"TEST_IS_COREBOOT": "true", "TEST_ME_DISABLED": "false", "TEST_ME_HAP_DISABLED": "true"} }}
+@{DTS_TEST_WORKFLOW_PROFILES}=
+...                                             ${{ ("Initial Deployment", "DPP") }}
+...                                             ${{ ("UEFI Update", "DPP") }}
 
 
 *** Keywords ***

--- a/platform-configs/include/pcengines.robot
+++ b/platform-configs/include/pcengines.robot
@@ -105,13 +105,21 @@ ${TRENCHBOOT_SUPPORT}=                      ${TRUE}
 
 # DTS E2E variables
 ${DTS_TEST_SYSTEM_VENDOR}=                  PC Engines
-${DTS_TEST_BIOS_VENDOR}=                    coreboot
 &{DTS_TEST_VERSIONS}=                       &{DTS_TEST_VERSIONS_BASE}
 ...                                         SeaBIOS Update=v24.04.00.05    SeaBIOS->UEFI Transition=v24.04.00.05
 @{DTS_TEST_WORKFLOWS}=                      UEFI Update    SeaBIOS Update    SeaBIOS->UEFI Transition
 # TODO: Also seabios, add to tests
 @{DTS_TEST_DEFAULT_RELEASES}=               DPP
-${DTS_TEST_BOARD_MODEL}=                    ${DTS_TEST_SYSTEM_MODEL}
+${DTS_TEST_BOARD_MODEL}=                    ${DMIDECODE_PRODUCT_NAME}
+&{DTS_TEST_EXPORTS}=
+...                                         &{DTS_TEST_BASE_EXPORTS}
+...                                         TEST_INTERNAL_MULTIPLE_DEFINITIONS=true
+...                                         TEST_BOARD_HAS_BOOTSPLASH=false
+...                                         TEST_BOARD_HAS_FD_REGION=false
+...                                         TEST_BOARD_HAS_ME_REGION=false
+@{DTS_TEST_WORKFLOW_PROFILES}=
+...                                         ${{ ("SeaBIOS->UEFI Transition", "DPP") }}
+...                                         ${{ ("SeaBIOS Update", "DPP") }}
 
 
 *** Keywords ***

--- a/platform-configs/msi-pro-z690-a-ddr5.robot
+++ b/platform-configs/msi-pro-z690-a-ddr5.robot
@@ -3,26 +3,36 @@ Resource    include/msi-z690-common.robot
 
 
 *** Variables ***
-${FW_VERSION}=                      v1.1.4-rc1
-${DMIDECODE_SERIAL_NUMBER}=         N/A
-${DMIDECODE_FIRMWARE_VERSION}=      Dasharo (coreboot+UEFI) ${FW_VERSION}
-${DMIDECODE_PRODUCT_NAME}=          MS-7D25
-${DMIDECODE_RELEASE_DATE}=          09/27/2024
+${FW_VERSION}=                          v1.1.4-rc1
+${DMIDECODE_SERIAL_NUMBER}=             N/A
+${DMIDECODE_FIRMWARE_VERSION}=          Dasharo (coreboot+UEFI) ${FW_VERSION}
+${DMIDECODE_PRODUCT_NAME}=              MS-7D25
+${DMIDECODE_RELEASE_DATE}=              09/27/2024
 
-${CPU_MAX_FREQUENCY}=               5200
-${CPU_MIN_FREQUENCY}=               300
+${CPU_MAX_FREQUENCY}=                   5200
+${CPU_MIN_FREQUENCY}=                   300
 
-${DEF_THREADS_PER_CORE}=            2
-${DEF_THREADS_TOTAL}=               20
-${DEF_ONLINE_CPU}=                  0-19
-${DEF_SOCKETS}=                     1
+${DEF_THREADS_PER_CORE}=                2
+${DEF_THREADS_TOTAL}=                   20
+${DEF_ONLINE_CPU}=                      0-19
+${DEF_SOCKETS}=                         1
 
-${DEF_CORES_PER_SOCKET}=            14
+${DEF_CORES_PER_SOCKET}=                14
 
-${CPU_P_CORES_MAX}=                 6
-${CPU_E_CORES_MAX}=                 8
+${CPU_P_CORES_MAX}=                     6
+${CPU_E_CORES_MAX}=                     8
 
 # DTS E2E variables
-&{DTS_TEST_VERSIONS}=               &{DTS_TEST_VERSIONS_BASE}    UEFI->Heads Transition=Dasharo (coreboot+UEFI) 1.1.4
-${DTS_TEST_SYSTEM_MODEL}=           MS-7D25
-${DTS_TEST_BOARD_MODEL}=            PRO Z690-A WIFI (MS-7D25)
+&{DTS_TEST_VERSIONS}=
+...                                     &{DTS_TEST_VERSIONS_BASE}
+...                                     UEFI->Heads Transition=Dasharo (coreboot+UEFI) 1.1.4
+${DTS_TEST_BOARD_MODEL}=                PRO Z690-A WIFI (MS-7D25)
+&{DTS_TEST_EXPORTS_PER_WORKFLOW}=
+...                                     &{DTS_TEST_EXPORTS_PER_WORKFLOW_BASE}
+...                                     UEFI Update=&{{ {"TEST_IS_COREBOOT": "true"} }}
+...                                     UEFI->Heads Transition=&{{ { "TEST_IS_COREBOOT": "true", "TEST_ME_DISABLED": "false", "TEST_ME_HAP_DISABLED": "true" } }}
+...                                     Initial Deployment=&{{ {"TEST_HCI_PRESENT": "true", "TEST_FMAP_REGIONS": ""} }}
+
+@{DTS_TEST_WORKFLOW_PROFILES}=
+...                                     ${{ ("UEFI->Heads Transition", "DPP") }}
+...                                     ${{ ("UEFI Update", "DPP") }}

--- a/platform-configs/msi-pro-z690-a-wifi-ddr4.robot
+++ b/platform-configs/msi-pro-z690-a-wifi-ddr4.robot
@@ -34,5 +34,10 @@ ${CPU_E_CORES_MAX}=                     12
 &{DTS_TEST_VERSIONS}=
 ...                                     &{DTS_TEST_VERSIONS_BASE}
 ...                                     UEFI->Heads Transition=Dasharo (coreboot+UEFI) 1.1.4
-${DTS_TEST_SYSTEM_MODEL}=               MS-7D25
 ${DTS_TEST_BOARD_MODEL}=                PRO Z690-A WIFI DDR4(MS-7D25)
+@{DTS_TEST_WORKFLOW_PROFILES}=
+...                                     ${{ ("UEFI->Heads Transition", "DPP") }}
+...                                     ${{ ("UEFI Update", "DPP") }}
+...                                     ${{ ("UEFI Update", "DCR") }}
+...                                     ${{ ("Initial Deployment", "DCR") }}
+...                                     ${{ ("Initial Deployment", "DPP") }}

--- a/platform-configs/msi-pro-z790-p-ddr5.robot
+++ b/platform-configs/msi-pro-z790-p-ddr5.robot
@@ -3,19 +3,39 @@ Resource    include/msi-z690-common.robot
 
 
 *** Variables ***
-${FW_VERSION}=                      v0.9.2-rc3
-${DMIDECODE_SERIAL_NUMBER}=         N/A
-${DMIDECODE_FIRMWARE_VERSION}=      Dasharo (coreboot+UEFI) v0.9.2-rc3
-${DMIDECODE_PRODUCT_NAME}=          MS-7E06
-${DMIDECODE_RELEASE_DATE}=          11/27/2023
+${FW_VERSION}=                          v0.9.2-rc3
+${DMIDECODE_SERIAL_NUMBER}=             N/A
+${DMIDECODE_FIRMWARE_VERSION}=          Dasharo (coreboot+UEFI) v0.9.2-rc3
+${DMIDECODE_PRODUCT_NAME}=              MS-7E06
+${DMIDECODE_RELEASE_DATE}=              11/27/2023
 
-${CPU_MAX_FREQUENCY}=               5200
-${CPU_MIN_FREQUENCY}=               300
+${CPU_MAX_FREQUENCY}=                   5200
+${CPU_MIN_FREQUENCY}=                   300
 
 # DTS E2E variables
 &{DTS_TEST_VERSIONS}=
-...                                 &{DTS_TEST_VERSIONS_BASE}
-...                                 UEFI->Heads Transition=Dasharo (coreboot+UEFI) 0.9.2
-${DTS_TEST_SYSTEM_MODEL}=           MS-7E06
-${DTS_TEST_BOARD_MODEL}=            PRO Z790-P WIFI (MS-7E06)
-@{DTS_TEST_DEFAULT_RELEASES}=       DPP
+...                                     &{DTS_TEST_VERSIONS_BASE}
+...                                     UEFI->Heads Transition=Dasharo (coreboot+UEFI) 0.9.2
+${DTS_TEST_BOARD_MODEL}=                PRO Z790-P WIFI (MS-7E06)
+@{DTS_TEST_DEFAULT_RELEASES}=           DPP
+&{DTS_TEST_EXPORTS}=
+...                                     &{DTS_TEST_BASE_EXPORTS}
+...                                     TEST_BOARD_HAS_BOOTSPLASH=false
+...                                     TEST_VBOOT_KEYS=true
+...                                     TEST_ME_HAP_DISABLED=true
+...                                     TEST_SOUND_CARD_PRESENT=false
+...                                     TEST_BOARD_HAS_GBE_REGION=false
+...                                     TEST_INTEL_IS_FUSED=true
+...                                     TEST_HCI_PRESENT=true
+...                                     TEST_BOARD_FD_REGION_RW=false
+...                                     TEST_BOARD_ME_REGION_RW=false
+# robocop: off=LEN08
+&{DTS_TEST_EXPORTS_PER_WORKFLOW}=
+...                                     &{DTS_TEST_EXPORTS_PER_WORKFLOW_BASE}
+...                                     UEFI Update=&{{ {"TEST_IS_COREBOOT": "true", "TEST_FMAP_REGIONS": "BOOTSPLASH", "TEST_HCI_PRESENT": "false", "TEST_BOARD_FD_REGION_RW": "true", "TEST_BOARD_ME_REGION_RW": "true"} }}
+...                                     UEFI->Heads Transition=&{{ {"TEST_IS_COREBOOT": "true", "TEST_FMAP_REGIONS": "BOOTSPLASH"} }}
+# robocop: on=LEN08
+@{DTS_TEST_WORKFLOW_PROFILES}=
+...                                     ${{ ("UEFI->Heads Transition", "DPP") }}
+...                                     ${{ ("UEFI Update", "DPP") }}
+...                                     ${{ ("Initial Deployment", "DPP") }}

--- a/platform-configs/novacustom-ns50mu.robot
+++ b/platform-configs/novacustom-ns50mu.robot
@@ -45,4 +45,3 @@ ${CACHEBENCH_TEST_SCORE}=               97428.4
 ${BLAKE2_TEST_SCORE}=                   3.51
 
 # DTS E2E variables
-${DTS_TEST_SYSTEM_MODEL}=               NS50_70MU

--- a/platform-configs/novacustom-ns50pu.robot
+++ b/platform-configs/novacustom-ns50pu.robot
@@ -24,4 +24,3 @@ ${CPU_MIN_FREQUENCY}=           300
 ${OPTIONS_LIB}=                 options-lib_dcu
 
 # DTS E2E variables
-${DTS_TEST_SYSTEM_MODEL}=       NS5x_NS7xPU

--- a/platform-configs/novacustom-ns70mu.robot
+++ b/platform-configs/novacustom-ns70mu.robot
@@ -32,4 +32,3 @@ ${EC_NO_SYNC_VERSION}=              2023-10-31_f148431
 ${OPTIONS_LIB}=                     options-lib_dcu
 
 # DTS E2E variables
-${DTS_TEST_SYSTEM_MODEL}=           NS50_70MU

--- a/platform-configs/novacustom-ns70pu.robot
+++ b/platform-configs/novacustom-ns70pu.robot
@@ -24,4 +24,3 @@ ${CPU_MIN_FREQUENCY}=           300
 ${OPTIONS_LIB}=                 options-lib_dcu
 
 # DTS E2E variables
-${DTS_TEST_SYSTEM_MODEL}=       NS5x_NS7xPU

--- a/platform-configs/novacustom-nv41mb.robot
+++ b/platform-configs/novacustom-nv41mb.robot
@@ -30,4 +30,3 @@ ${CACHEBENCH_TEST_SCORE}=           104565.1
 ${BLAKE2_TEST_SCORE}=               3.64
 
 # DTS E2E variables
-${DTS_TEST_SYSTEM_MODEL}=           NV4XMB,ME,MZ

--- a/platform-configs/novacustom-nv41mz.robot
+++ b/platform-configs/novacustom-nv41mz.robot
@@ -24,4 +24,3 @@ ${CPU_MIN_FREQUENCY}=           300
 ${OPTIONS_LIB}=                 options-lib_dcu
 
 # DTS E2E variables
-${DTS_TEST_SYSTEM_MODEL}=       NV4XMB,ME,MZ

--- a/platform-configs/novacustom-nv41pz.robot
+++ b/platform-configs/novacustom-nv41pz.robot
@@ -5,41 +5,44 @@ Resource    include/novacustom-common.robot
 
 *** Variables ***
 # CPU
-${CPU}=                         Intel(R) Core(TM) i5-1240P CPU
+${CPU}=                             Intel(R) Core(TM) i5-1240P CPU
 
 # Test configuration
-${3_MDEB_WIFI_NETWORK}=         3mdeb_abr
-${CLEVO_BATTERY_CAPACITY}=      3200*1000
-${CLEVO_DISK}=                  Samsung SSD 980 PRO
-${CLEVO_USB_C_HUB}=             4-port
-${DEVICE_NVME_DISK}=            Non-Volatile memory controller
-${DEVICE_USB_KEYBOARD}=         Logitech, Inc. Keyboard K120
-${DMIDECODE_PRODUCT_NAME}=      NV4xPZ
-${EXTERNAL_HEADSET}=            USB PnP Audio Device
-${USB_DEVICE}=                  Kingston
-${USB_MODEL}=                   USB Flash Memory
-${CPU_MAX_FREQUENCY}=           4800
-${CPU_MIN_FREQUENCY}=           300
+${3_MDEB_WIFI_NETWORK}=             3mdeb_abr
+${CLEVO_BATTERY_CAPACITY}=          3200*1000
+${CLEVO_DISK}=                      Samsung SSD 980 PRO
+${CLEVO_USB_C_HUB}=                 4-port
+${DEVICE_NVME_DISK}=                Non-Volatile memory controller
+${DEVICE_USB_KEYBOARD}=             Logitech, Inc. Keyboard K120
+${DMIDECODE_PRODUCT_NAME}=          NV4xPZ
+${EXTERNAL_HEADSET}=                USB PnP Audio Device
+${USB_DEVICE}=                      Kingston
+${USB_MODEL}=                       USB Flash Memory
+${CPU_MAX_FREQUENCY}=               4800
+${CPU_MIN_FREQUENCY}=               300
 
-${BLUETOOTH_CARD_UBUNTU}=       8087:0026
+${BLUETOOTH_CARD_UBUNTU}=           8087:0026
 
-${POWER_CTRL}=                  none
+${POWER_CTRL}=                      none
 
-${USB_STACK_SUPPORT}=           ${TRUE}
-${TESTS_IN_WINDOWS_SUPPORT}=    ${FALSE}
+${USB_STACK_SUPPORT}=               ${TRUE}
+${TESTS_IN_WINDOWS_SUPPORT}=        ${FALSE}
 
-${TPM_SUPPORTED_VERSION}=       2
-${TPM_EXPECTED_CHIP}=           SLB9670
+${TPM_SUPPORTED_VERSION}=           2
+${TPM_EXPECTED_CHIP}=               SLB9670
 
-${OPTIONS_LIB}=                 options-lib_dcu
+${OPTIONS_LIB}=                     options-lib_dcu
 
 # cpu performance Windows
-${SMALLPT_TEST_SCORE}=          30.796
-${CRAFTY_TEST_SCORE}=           7480997
-${CACHEBENCH_TEST_SCORE}=       75584.7
-${BLAKE2_TEST_SCORE}=           3.22
+${SMALLPT_TEST_SCORE}=              30.796
+${CRAFTY_TEST_SCORE}=               7480997
+${CACHEBENCH_TEST_SCORE}=           75584.7
+${BLAKE2_TEST_SCORE}=               3.22
 
 # DTS E2E variables
-&{DTS_TEST_VERSIONS}=           &{DTS_TEST_VERSIONS_BASE}    UEFI->Heads Transition=Dasharo (coreboot+UEFI) 1.7.2
-${DTS_TEST_SYSTEM_MODEL}=       NV4xPZ
-@{DTS_TEST_WORKFLOWS}=          Initial Deployment    UEFI Update    UEFI->Heads Transition
+&{DTS_TEST_VERSIONS}=               &{DTS_TEST_VERSIONS_BASE}    UEFI->Heads Transition=Dasharo (coreboot+UEFI) 1.7.2
+@{DTS_TEST_WORKFLOWS}=              Initial Deployment    UEFI Update    UEFI->Heads Transition
+
+@{DTS_TEST_WORKFLOW_PROFILES}=
+...                                 ${{ ("UEFI Update", "DCR") }}
+...                                 ${{ ("UEFI->Heads Transition", "DPP") }}

--- a/platform-configs/novacustom-v540tnd.robot
+++ b/platform-configs/novacustom-v540tnd.robot
@@ -84,6 +84,5 @@ ${OPTIONS_LIB}=                                 options-lib_dcu
 &{DTS_TEST_VERSIONS}=
 ...                                             &{DTS_TEST_VERSIONS_BASE}
 ...                                             UEFI->Heads Transition=Dasharo (coreboot+UEFI) 0.9.0
-${DTS_TEST_SYSTEM_MODEL}=                       V5xTNC_TND_TNE
 ${DTS_TEST_BOARD_MODEL}=                        V540TNx
 @{DTS_TEST_WORKFLOWS}=                          Initial Deployment    UEFI Update

--- a/platform-configs/novacustom-v540tu.robot
+++ b/platform-configs/novacustom-v540tu.robot
@@ -88,9 +88,11 @@ ${UNIGINE_SUPERPOSITION_RESULT_BAT}=    20.3    # FPS
 &{DTS_TEST_VERSIONS}=
 ...                                     &{DTS_TEST_VERSIONS_BASE}
 ...                                     UEFI->Heads Transition=Dasharo (coreboot+UEFI) 0.9.0
-${DTS_TEST_SYSTEM_MODEL}=               V54x_6x_TU
 ${DTS_TEST_BOARD_MODEL}=                V540TU
 @{DTS_TEST_WORKFLOWS}=                  Initial Deployment    UEFI Update    UEFI->Heads Transition
+
+@{DTS_TEST_WORKFLOW_PROFILES}=
+...                                     ${{ ("UEFI->Heads Transition", "DPP") }}
 
 
 *** Keywords ***

--- a/platform-configs/novacustom-v560tnd.robot
+++ b/platform-configs/novacustom-v560tnd.robot
@@ -95,6 +95,5 @@ ${UNIGINE_SUPERPOSITION_RESULT_BAT}=    24.0    # FPS
 &{DTS_TEST_VERSIONS}=
 ...                                     &{DTS_TEST_VERSIONS_BASE}
 ...                                     UEFI->Heads Transition=Dasharo (coreboot+UEFI) 0.9.0
-${DTS_TEST_SYSTEM_MODEL}=               V5xTNC_TND_TNE
 ${DTS_TEST_BOARD_MODEL}=                V560TNx
 @{DTS_TEST_WORKFLOWS}=                  Initial Deployment    UEFI Update

--- a/platform-configs/novacustom-v560tne.robot
+++ b/platform-configs/novacustom-v560tne.robot
@@ -61,6 +61,5 @@ ${UNIGINE_SUPERPOSITION_RESULT_BAT}=    26.2    # FPS
 ${OPTIONS_LIB}=                         options-lib_dcu
 
 # DTS E2E variables
-${DTS_TEST_SYSTEM_MODEL}=               V5xTNC_TND_TNE
 ${DTS_TEST_BOARD_MODEL}=                V560TNx
 @{DTS_TEST_WORKFLOWS}=                  Initial Deployment    UEFI Update

--- a/platform-configs/novacustom-v560tu.robot
+++ b/platform-configs/novacustom-v560tu.robot
@@ -75,6 +75,7 @@ ${OPTIONS_LIB}=                         options-lib_dcu
 &{DTS_TEST_VERSIONS}=
 ...                                     &{DTS_TEST_VERSIONS_BASE}
 ...                                     UEFI->Heads Transition=Dasharo (coreboot+UEFI) 0.9.0
-${DTS_TEST_SYSTEM_MODEL}=               V54x_6x_TU
 ${DTS_TEST_BOARD_MODEL}=                V560TU
 @{DTS_TEST_WORKFLOWS}=                  Initial Deployment    UEFI Update    UEFI->Heads Transition
+@{DTS_TEST_WORKFLOW_PROFILES}=
+...                                     ${{ ("UEFI->Heads Transition", "DPP") }}

--- a/platform-configs/odroid-h4-plus.robot
+++ b/platform-configs/odroid-h4-plus.robot
@@ -112,11 +112,26 @@ ${DTS_SUPPORT}=                                 ${TRUE}
 
 # DTS E2E variables
 ${DTS_TEST_SYSTEM_VENDOR}=                      HARDKERNEL
-${DTS_TEST_SYSTEM_MODEL}=                       ODROID-H4
+${DTS_TEST_BOARD_MODEL}=                        ODROID-H4
 @{DTS_TEST_WORKFLOWS}=                          Initial Deployment    UEFI Update
 ...                                             Dasharo (coreboot+UEFI) to Dasharo (Slim Bootloader+UEFI) Transition
 ...                                             Dasharo (Slim Bootloader+UEFI) Initial Deployment
 @{DTS_TEST_DEFAULT_RELEASES}=                   DPP
+&{DTS_TEST_EXPORTS}=                            &{DTS_TEST_BASE_EXPORTS}
+...                                             TEST_ME_DISABLED=false
+...                                             TEST_FMAP_REGIONS=RW_SECTION_A
+...                                             TEST_VBOOT_ENABLED=true
+...                                             TEST_BOARD_HAS_GBE_REGION=false
+...                                             TEST_SOUND_CARD_PRESENT=false
+...                                             TEST_HCI_PRESENT=true
+
+&{DTS_TEST_EXPORTS_PER_WORKFLOW}=
+...                                             &{DTS_TEST_EXPORTS_PER_WORKFLOW_BASE}
+...                                             UEFI Update=&{{ {"TEST_VBOOT_KEYS": "true", "TEST_IS_COREBOOT": "true"} }}
+@{DTS_TEST_WORKFLOW_PROFILES}=
+...                                             ${{ ("Initial Deployment", "DPP") }}
+...                                             ${{ ("Dasharo (coreboot+UEFI) to Dasharo (Slim Bootloader+UEFI) Transition", "DPP") }}
+...                                             ${{ ("Dasharo (Slim Bootloader+UEFI) Initial Deployment", "DPP") }}
 
 
 *** Keywords ***

--- a/platform-configs/optiplex-7010.robot
+++ b/platform-configs/optiplex-7010.robot
@@ -24,11 +24,8 @@ ${DEF_CPU}=                     2
 ${DRAM_SIZE}=                   ${16384}
 ${PLATFORM_RAM_SIZE}=           16384
 
-${DMIDECODE_PRODUCT_NAME}=      OptiPlex 9010
-${DMIDECODE_SERIAL_NUMBER}=     123456789
-${DMIDECODE_MANUFACTURER}=      Dell Inc.
+${DMIDECODE_PRODUCT_NAME}=      OptiPlex 7010
 
 ${DEVICE_NVME_DISK}=            Non-Volatile memory controller
 
 # DTS E2E variables
-${DTS_TEST_SYSTEM_MODEL}=       OptiPlex 7010

--- a/platform-configs/optiplex-9010.robot
+++ b/platform-configs/optiplex-9010.robot
@@ -3,5 +3,4 @@ Resource    include/optiplex-common.robot
 
 
 *** Variables ***
-# DTS E2E variables
-${DTS_TEST_SYSTEM_MODEL}=       OptiPlex 7010
+${DMIDECODE_PRODUCT_NAME}=      OptiPlex 9010

--- a/platform-configs/pcengines-apu2.robot
+++ b/platform-configs/pcengines-apu2.robot
@@ -11,7 +11,6 @@ ${PLATFORM_RAM_SIZE}=           4096
 ${BIOS_LOCK_SUPPORT}=           ${True}
 
 # DTS E2E variables
-${DTS_TEST_SYSTEM_MODEL}=       APU2
 
 
 *** Keywords ***

--- a/platform-configs/pcengines-apu3.robot
+++ b/platform-configs/pcengines-apu3.robot
@@ -6,4 +6,3 @@ Resource    include/pcengines.robot
 ${DMIDECODE_PRODUCT_NAME}=      apu3
 
 # DTS E2E variables
-${DTS_TEST_SYSTEM_MODEL}=       APU3

--- a/platform-configs/pcengines-apu4.robot
+++ b/platform-configs/pcengines-apu4.robot
@@ -6,4 +6,3 @@ Resource    include/pcengines.robot
 ${DMIDECODE_PRODUCT_NAME}=      apu4
 
 # DTS E2E variables
-${DTS_TEST_SYSTEM_MODEL}=       APU4

--- a/platform-configs/pcengines-apu6.robot
+++ b/platform-configs/pcengines-apu6.robot
@@ -6,4 +6,3 @@ Resource    include/pcengines.robot
 ${DMIDECODE_PRODUCT_NAME}=      apu6
 
 # DTS E2E variables
-${DTS_TEST_SYSTEM_MODEL}=       APU6

--- a/scripts/ci/ipxe-run.sh
+++ b/scripts/ci/ipxe-run.sh
@@ -23,7 +23,7 @@ cat <<EOF > "$IPXE_PATH/dts.ipxe"
 #!ipxe
 imgfetch --name file_kernel $BZ_IMAGE_FILENAME
 imgfetch --name file_initrd $DTS_IMAGE_FILENAME
-kernel file_kernel root=/dev/nfs initrd=file_initrd
+kernel file_kernel initrd=file_initrd
 boot
 EOF
 


### PR DESCRIPTION
Related to https://github.com/Dasharo/dts-scripts/pull/97 (needs those changes to work).
UEFI Update profile will need to be generated again because of https://github.com/Dasharo/dts-scripts/commit/171d8decee567e3c55a953c1b28973f0a0a66249

This PR adds basic support for profile checking along with implementing those checks for ODROID H4 workflows.

Comparing profiles is done in TRY block: https://github.com/Dasharo/open-source-firmware-validation/blob/4e0efd9e20e442c64f970906f1bac8ef68d29f05/dts/dts-e2e.robot#L169 in test teardown only if the profile for the test exists.
Maybe adding separate variable in platform config to decide whether profile has to be checked for that workflow would be good idea just in case file or test is renamed. In the current state test would succeed, because it would skip profile checking if it couldn't find reference file.