### PR TITLE
lib: terminal.robot: fix VAR assignment (remove '=')

### DIFF
--- a/lib/terminal.robot
+++ b/lib/terminal.robot
@@ -65,7 +65,7 @@ Set DUT Response Timeout
         ${prev_timeout}=    Telnet.Set Timeout    ${timeout}
     ELSE IF    '${DUT_CONNECTION_METHOD}' in ['SSH', 'open-bmc']
         ${con}=    Get Connection
-        VAR    ${prev_timeout}=    ${con.timeout}=
+        VAR    ${prev_timeout}=    ${con.timeout}
         SSHLibrary.Set Client Configuration    timeout=${timeout}
     ELSE
         FAIL    Unknown connection method: ${DUT_CONNECTION_METHOD}


### PR DESCRIPTION
When testing on QEMU I got error that argument with wrong format was used: `180.0=`. Likely when trying to set DUT timeout to previous one by some keyword.

```
ValueError: Invalid time string '180.0='.
```