### PR TITLE
keywords.robot: Default value of SNIPEIT_ALREADY_CHECKED_OUT_MANUALLY

### DIFF
--- a/keywords.robot
+++ b/keywords.robot
@@ -495,6 +495,7 @@ Prepare Test Suite
     IF    '${MANUFACTURER}' != 'QEMU' and '${CONFIG}' != 'no-rte'
         Import Osfv Libraries
     END
+    VAR    ${SNIPEIT_ALREADY_CHECKED_OUT_MANUALLY}=    ${TRUE}    scope=GLOBAL
     IF    '${DUT_CONNECTION_METHOD}' == 'SSH'
         Prepare To SSH Connection
     ELSE IF    '${DUT_CONNECTION_METHOD}' == 'Telnet'


### PR DESCRIPTION
Set to ${TRUE} unless proven otherwise

When testing without an RTE this variable
is undefined and the test teardown fails