### PR TITLE
keywords.robot: Prepare To SSH Connection remove RTE dep

### DIFF
--- a/keywords.robot
+++ b/keywords.robot
@@ -550,8 +550,6 @@ Prepare To SSH Connection
     ...    asset in SnipeIt . Keyword used in [Suite Setup]
     ...    sections if the communication with the platform based on
     ...    the SSH protocol
-    # tu leci zmiana, musimy brać platformy zgodnie z tym co zostało pobrane w dasharo
-    Open Connection And Log In
     VAR    ${PLATFORM}=    ${CONFIG}    scope=GLOBAL
     IF    '${DEFAULT_BOOT_OS_ID}'
         Import Variables    ${CURDIR}/os-config/${DEFAULT_BOOT_OS_ID}-credentials.py


### PR DESCRIPTION
Open Connection And Log In opens a connection to the RTE. An RTE is not necessary when testing via SSH.
This line makes it impossible to run tests withou an RTE.