### PR TITLE
tree-wide: drop robot:private tag

### DIFF
--- a/dasharo-compatibility/audio-subsystem.robot
+++ b/dasharo-compatibility/audio-subsystem.robot
@@ -329,7 +329,6 @@ AUD007.301 HDMI Audio recognition
 Audio Subsystem Detection Linux
     [Documentation]    Ensures Ubuntu is currently active and that the
     ...    audio chip was detected.
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     Power On
     Boot System Or From Connected Disk    ${os_id}
@@ -340,7 +339,6 @@ Audio Subsystem Detection Linux
 Get Sound Devices In Windows
     [Documentation]    Get and return sound devices via PowerShell
     ...    filtered as all devices, audio-sink only, or microphones only
-    [Tags]    robot:private
     [Arguments]    ${class}=all
     IF    '${class}' == 'all'
         VAR    ${filter_condition}=    {$_.Class -match "Audio"}
@@ -362,7 +360,6 @@ Get Sound Devices In Windows
 Switch Active Sink Port Using Pactl
     [Documentation]    Using Pulse Audio Controller (pactl), attempt to switch
     ...    to specified sink port.
-    [Tags]    robot:private
     [Arguments]    ${class}
     ${sink}=    Execute Command In Terminal
     ...    pactl list short sinks | awk '{print $1}'
@@ -385,7 +382,6 @@ Switch Active Source Port Using Pactl
     ...    to set a source port, we need to specify device by full name,
     ...    so we filter it with "grep alsa_input", in contrast to sink change
     ...    which only requires a numeric ID.
-    [Tags]    robot:private
     [Arguments]    ${class}
     ${source}=    Execute Command In Terminal
     ...    pactl list sources | grep alsa_input | awk 'NR==1 {print $2}'
@@ -403,7 +399,6 @@ Switch Active Source Port Using Pactl
 Verify Active Sink Port Using Pactl
     [Documentation]    Using Pulse Audio Controller (pactl), verify that specified
     ...    class of sink ports aka audio output is available
-    [Tags]    robot:private
     [Arguments]    ${class}
     ${sinks}=    Execute Command In Terminal    pactl list sinks | grep "Active Port"
     Should Not Be Empty    ${sinks}
@@ -421,7 +416,6 @@ Verify Active Sink Port Using Pactl
 Verify Active Source Port Using Pactl
     [Documentation]    Using Pulse Audio Controller (pactl), verify that specified
     ...    class of source ports is available
-    [Tags]    robot:private
     [Arguments]    ${class}
     ${sources}=    Execute Command In Terminal    pactl list sources | grep "Active Port"
     Should Not Be Empty    ${sources}
@@ -437,7 +431,6 @@ Verify Active Source Port Using Pactl
 Verify External Headset Is Plugged In
     [Documentation]    Using Pulse Audio Controller (pactl), verify that
     ...    external headset is plugged in.
-    [Tags]    robot:private
     ${result}=    Execute Command In Terminal
     ...    pactl list sinks | grep analog-output-headphones | awk 'NR==1'
     Should Not Contain    ${result}    not available

--- a/dasharo-compatibility/auto-boot-time-out.robot
+++ b/dasharo-compatibility/auto-boot-time-out.robot
@@ -95,7 +95,6 @@ BMM003.001 Check Auto Boot Time-out option not accept non-numeric values
 *** Keywords ***
 Try To Insert Non-numeric Values Into Numeric Option
     [Documentation]    Check whether accepts only numeric values.
-    [Tags]    robot:private
     [Arguments]    ${menu}    ${option}
 
     VAR    ${non_numeric_characters}=

--- a/dasharo-compatibility/cpu-status.robot
+++ b/dasharo-compatibility/cpu-status.robot
@@ -278,7 +278,6 @@ Check Cache Support
 CPU Cache Enabled Linux
     [Documentation]    Check whether the all declared for the DUT cache levels
     ...    are enabled.
-    [Tags]    robot:private
     ${mem_info}=    Execute Linux Command    getconf -a | grep CACHE
     Check Cache Support    ${mem_info}    LEVEL1
     Pass Execution If    not ${L2_CACHE_SUPPORT}    DUT supports only L1 cache
@@ -290,7 +289,6 @@ CPU Cache Enabled Linux
 
 Multiple CPU Support Linux
     [Documentation]    Check whether the DUT has multiple CPU support.
-    [Tags]    robot:private
     Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    CPU003.001 not supported
     ${cpu_info}=    Execute Linux Command    lscpu
     ${cpu}=    Get Lines Matching Regexp    ${cpu_info}    ^CPU\\(s\\):\\s+\\d+$    flags=MULTILINE
@@ -300,7 +298,6 @@ Multiple CPU Support Linux
 
 Multiple-Core Support Linux
     [Documentation]    Check whether the DUT has multi-core support.
-    [Tags]    robot:private
     ${cpu_info}=    Execute Linux Command    lscpu
     ${sockets}=    Get Lines Containing String    ${cpu_info}    Socket(s):
     Should Contain    ${sockets}    ${DEF_SOCKETS}    Different number of sockets than ${DEF_SOCKETS}

--- a/dasharo-compatibility/dcu.robot
+++ b/dasharo-compatibility/dcu.robot
@@ -141,7 +141,6 @@ Verify SMMSTORE Changes (Setup Menu)
 Verify SMMSTORE Changes (DCU)
     [Documentation]    This keyword verifies that changes made to the
     ...    SMMSTORE via DCU are properly applied and visible in DCU.
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     # Initial value cannot be checked and restored using DCU because the
     # variable store may not be initialized yet.
@@ -168,7 +167,6 @@ Make Sure New Firmware Is Booted After Flashing
     ...    Platforms without POWER_CTRL typically do nothing
     ...    as an implementation of Power On etc. and they need a reboot after
     ...    flashing
-    [Tags]    robot:private
     [Arguments]    ${os_id}=${DEFAULT_BOOT_OS_ID}
     IF    '''${POWER_CTRL}''' == '''none'''
         Power On
@@ -181,7 +179,6 @@ Make Sure New Firmware Is Booted After Flashing
 Change The UUID
     [Documentation]    This test case verifies that the UUID encoded in the DMI
     ...    table of an image can be changed using DCU.
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     Power On
     Boot System Or From Connected Disk    ${os_id}
@@ -201,7 +198,6 @@ Change The UUID
 Change The Serial Number
     [Documentation]    This test case verifies that the serial number encoded
     ...    in the DMI table of an image can be changed using DCU.
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     Power On
     Boot System Or From Connected Disk    ${os_id}
@@ -223,7 +219,6 @@ Change The Bootsplash Logo
     ...    into an image can be changed using DCU.
     ...    PLEASE NOTE that a display device needs to be physically connected
     ...    to the DUT for this test to work.
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     Power On
     Boot System Or From Connected Disk    ${os_id}
@@ -255,7 +250,6 @@ Verify SMMSTORE Changes
     ...    Verified using Setup menu where possible. When tested on a device
     ...    which uses DCU for accessing Setup variables the results might not
     ...    be trustworthy.
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     IF    "${OPTIONS_LIB}"=="options-lib_uefi-setup-menu"
         Verify SMMSTORE Changes (Setup Menu)    ${os_id}

--- a/dasharo-compatibility/display-ports-and-lcd-support.robot
+++ b/dasharo-compatibility/display-ports-and-lcd-support.robot
@@ -178,7 +178,6 @@ External HDMI Display
     [Documentation]    Check whether an external HDMI display is visible in
     ...    Linux OS. An external HDMI display must be provided in
     ...    the platform config.
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     Power On
     Boot System Or From Connected Disk    ${os_id}
@@ -189,7 +188,6 @@ External HDMI Display
 
 Internal Display In OS
     [Documentation]    Check whether an internal display is visible
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     Power On
     Boot System Or From Connected Disk    ${os_id}
@@ -202,7 +200,6 @@ External DP Display In OS
     [Documentation]    Check whether an external Display Port is visible in
     ...    Linux OS. An external Display Port must be provided in
     ...    the platform config.
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     Power On
     Boot System Or From Connected Disk    ${os_id}

--- a/dasharo-compatibility/dmidecode.robot
+++ b/dasharo-compatibility/dmidecode.robot
@@ -182,7 +182,6 @@ Get SMBIOS Values
     ...    and Chassis) and store them in suite variables. Each table is stored
     ...    in a dedicated variable because their fields have generic names (e.g.
     ...    Type) that is later extracted in the test cases.
-    [Tags]    robot:private
     [Arguments]    ${os_id}=${DEFAULT_BOOT_OS_ID}
     Power On
     Boot System Or From Connected Disk    ${os_id}

--- a/dasharo-compatibility/ec-and-super-IO.robot
+++ b/dasharo-compatibility/ec-and-super-IO.robot
@@ -488,7 +488,6 @@ ECR023.001 EC sync doesn't update with power adapter disconnected
 Keyboard Function Key Brightness Down In Linux
     [Documentation]    Check whether function key: brightness down works in
     ...    Linux OS.
-    [Tags]    robot:private
     Turn On ACPI CALL Module In Linux
     ${max_brightness}=    Get Maximum Brightness In Linux
     Set Brightness In Linux    ${max_brightness}
@@ -500,7 +499,6 @@ Keyboard Function Key Brightness Down In Linux
 Keyboard Function Key Brightness Up In Linux
     [Documentation]    Check whether function key: brightness up works in
     ...    Linux OS.
-    [Tags]    robot:private
     Turn On ACPI CALL Module In Linux
     Set Brightness In Linux    0
     ${brightness1}=    Get Current Brightness In Linux
@@ -510,7 +508,6 @@ Keyboard Function Key Brightness Up In Linux
 
 Keyboard Function Key Camera OnOff In Linux
     [Documentation]    Check whether the camera on/off hotkey works correctly.
-    [Tags]    robot:private
     Turn On ACPI CALL Module In Linux
     ${out}=    List Devices In Linux    usb
     Should Contain Any    ${out}    Camera    BisonCam
@@ -524,7 +521,6 @@ Keyboard Function Key Camera OnOff In Linux
 Keyboard Function Key Flight Mode In Linux
     [Documentation]    Check whether function key: flight mode works in
     ...    Linux OS.
-    [Tags]    robot:private
     Turn On ACPI CALL Module In Linux
     ${wifi_status}=    Get WiFi Block Status
     ${bt_status}=    Get Bluetooth Block Status

--- a/dasharo-compatibility/miniPCIe-slot-verification.robot
+++ b/dasharo-compatibility/miniPCIe-slot-verification.robot
@@ -130,7 +130,6 @@ MWL002.301 Wi-Fi scanning (Windows)
 Wireless Card Detection
     [Documentation]    Check whether the Wi-Fi/Bluetooth card is enumerated
     ...    correctly and can be detected from the operating system.
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     Power On
     Boot System Or From Connected Disk    ${os_id}
@@ -144,7 +143,6 @@ Wi-Fi Scanning
     [Documentation]    Check whether the Wi-Fi functionality of card is
     ...    initialized correctly and can be used from within the
     ...    operating system.
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     Power On
     Boot System Or From Connected Disk    ${os_id}
@@ -157,7 +155,6 @@ Bluetooth Scanning
     [Documentation]    Check whether the Bluetooth functionality of card is
     ...    initialized correctly and can be used from within the
     ...    operating system.
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     Power On
     Boot System Or From Connected Disk    ${os_id}
@@ -169,7 +166,6 @@ Bluetooth Scanning
 LTE Card Detection
     [Documentation]    Check whether the LTE card is detected correctly in the
     ...    operating system.
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     Power On
     Boot System Or From Connected Disk    ${os_id}

--- a/dasharo-compatibility/nvme-support.robot
+++ b/dasharo-compatibility/nvme-support.robot
@@ -96,7 +96,6 @@ NVM002.201 NVMe slot change to x2 support in OS (Ubuntu)
 NVMe Support In OS
     [Documentation]    Check whether the Operating System can boot from NVMe
     ...    disk in M.2 slot.
-    [Tags]    robot:private
     [Arguments]    ${os_id}=${DEFAULT_BOOT_OS_ID}
     Power On
     Boot System Or From Connected Disk    ${os_id}

--- a/dasharo-compatibility/usb-camera.robot
+++ b/dasharo-compatibility/usb-camera.robot
@@ -100,7 +100,6 @@ Integrated Webcam Linux
     [Documentation]    Check whether the integrated USB camera is initialized
     ...    correctly and can be accessed from the Linux OS. Assumption: No
     ...    external cameras connected.
-    [Tags]    robot:private
     ${out}=    List Devices In Linux    usb
     Should Contain Any    ${out}    Camera    BisonCam
     ${out0}=    Execute Linux Command    ffprobe /dev/video0
@@ -114,7 +113,6 @@ Integrated IR Camera Linux
     ...    initialized correctly and can be accessed from the Linux OS.
     ...    Assumption: No external camera connected. Camera exposes separate
     ...    devnodes for visible-spectrum and IR modes, in that order.
-    [Tags]    robot:private
     ${out}=    List Devices In Linux    usb
     Should Contain Any    ${out}    Camera    BisonCam
     ${out0}=    Execute Linux Command    ffprobe /dev/video2

--- a/dasharo-compatibility/usb-hid-and-msc-support.robot
+++ b/dasharo-compatibility/usb-hid-and-msc-support.robot
@@ -217,7 +217,6 @@ USB003.301 Upload 1GB file on USB storage (Windows)
 *** Keywords ***
 Prepare USB HID Test Suite
     [Documentation]    Prepare this test suite
-    [Tags]    robot:private
     Prepare Test Suite
     IF    "${DEVICE_USB_KEYBOARD}" != "${EMPTY}" or "${DUT_CONNECTION_METHOD}" == "pikvm"
         VAR    ${HAS_KEYBOARD}=    ${TRUE}    scope=SUITE
@@ -239,7 +238,6 @@ Prepare USB HID Test Suite
 USB Devices Detected By OS
     [Documentation]    Check whether the external USB devices are detected
     ...    correctly in Linux OS.
-    [Tags]    robot:private
     [Arguments]    ${os_id}=${DEFAULT_BOOT_OS_ID}
     Power On
     Boot System Or From Connected Disk    ${os_id}
@@ -254,7 +252,6 @@ USB Devices Detected By OS
 USB Keyboard In OS
     [Documentation]    Check whether the external USB keyboard is detected
     ...    correctly by the Linux OS.
-    [Tags]    robot:private
     [Arguments]    ${os_id}=${DEFAULT_BOOT_OS_ID}
     Power On
     Boot System Or From Connected Disk    ${os_id}
@@ -266,7 +263,6 @@ USB Keyboard In OS
 Upload 1GB File On USB Storage
     [Documentation]    Check whether the 1GB file can be transferred from the
     ...    operating system to the USB storage.
-    [Tags]    robot:private
     [Arguments]    ${os_id}=${DEFAULT_BOOT_OS_ID}
     Power On
     Boot System Or From Connected Disk    ${os_id}

--- a/dasharo-compatibility/wifi-bluetooth-support.robot
+++ b/dasharo-compatibility/wifi-bluetooth-support.robot
@@ -155,7 +155,6 @@ WLE001.205 Wireless card detection (XCP-NG)
 Wireless Card Detection
     [Documentation]    Check whether the Wi-Fi/Bluetooth card is enumerated
     ...    correctly and can be detected from the operating system.
-    [Tags]    robot:private
     [Arguments]    ${os_id}=${DEFAULT_BOOT_OS_ID}
     Log To Console    Remember to test all variants of wireless cards.
     Log    Remember to test all variants of wireless cards.    WARN
@@ -174,7 +173,6 @@ Wi-Fi Scanning
     [Documentation]    Check whether the Wi-Fi functionality of card is
     ...    initialized correctly and can be used from within the
     ...    operating system..
-    [Tags]    robot:private
     [Arguments]    ${os_id}=${DEFAULT_BOOT_OS_ID}
     Log To Console    Remember to test all variants of wireless cards.
     Log    Remember to test all variants of wireless cards.    WARN
@@ -201,7 +199,6 @@ Bluetooth Scanning
     [Documentation]    Check whether the Bluetooth functionality of card is
     ...    initialized correctly and can be used from within the
     ...    operating system.
-    [Tags]    robot:private
     [Arguments]    ${os_id}=${DEFAULT_BOOT_OS_ID}
     Log To Console    Remember to test all variants of wireless cards.
     Log    Remember to test all variants of wireless cards.    WARN

--- a/dasharo-performance/boot-time-measure.robot
+++ b/dasharo-performance/boot-time-measure.robot
@@ -88,7 +88,6 @@ Serial Boot Time Measure Coreboot Booting Time After Coldboot
     [Documentation]    Check whether the DUT boots after coldboot and how
     ...    long it takes for coreboot to boot after coldboot if
     ...    CPU is serial initialized.
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     ${min}    ${max}    ${average}    ${stddev}=
     ...    Measure Coldboot Time    ${ITERATIONS}    ${os_id}
@@ -106,7 +105,6 @@ Serial Boot Time Measure Coreboot Booting Time After Warmboot
     [Documentation]    Check whether the DUT boots after warmboot and how
     ...    long it takes for coreboot to boot after warmboot if
     ...    CPU is serial initialized.
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     ${min}    ${max}    ${average}    ${stddev}=
     ...    Measure Warmboot Time    ${ITERATIONS}    ${os_id}
@@ -124,7 +122,6 @@ Serial Boot Time Measure Coreboot Booting Time After System Reboot
     [Documentation]    Check whether the DUT boots after system reboot and how
     ...    long it takes for coreboot to boot after system reboot
     ...    if CPU is serial initialized.
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    CBMEM003.001 not supported
 

--- a/dasharo-performance/cpu-frequency.robot
+++ b/dasharo-performance/cpu-frequency.robot
@@ -468,7 +468,6 @@ CPF012.301 CPU with load runs on expected frequency (Windows) (USB-PD)
 
 *** Keywords ***
 CPU Not Stuck On Initial Frequency (Linux)
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     Power On
     Boot System Or From Connected Disk    ${os_id}
@@ -478,7 +477,6 @@ CPU Not Stuck On Initial Frequency (Linux)
     Check If CPU Not Stuck On Initial Frequency In Linux
 
 CPU Not Stuck On Initial Frequency (Windows)
-    [Tags]    robot:private
     Power On
     Login To Windows
     Sleep    10s
@@ -486,7 +484,6 @@ CPU Not Stuck On Initial Frequency (Windows)
     Execute Shutdown Command
 
 CPU Not Stuck On Initial Frequency (Heads+Debian)
-    [Tags]    robot:private
     Power On
     Detect Heads Main Menu
     # Proceed with default boot
@@ -498,7 +495,6 @@ CPU Not Stuck On Initial Frequency (Heads+Debian)
     Check If CPU Not Stuck On Initial Frequency In Linux
 
 CPU Runs On Expected Frequency (Linux)
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     ${cpu_max_frequency_tol}=    Evaluate    ${CPU_MAX_FREQUENCY} * 1.125
     ${cpu_min_frequency_tol}=    Evaluate    ${CPU_MIN_FREQUENCY} * 0.875
@@ -523,7 +519,6 @@ CPU Runs On Expected Frequency (Linux)
     END
 
 CPU Runs On Expected Frequency (Windows)
-    [Tags]    robot:private
     Power On
     Login To Windows
     ${timer}=    Convert To Integer    0
@@ -537,7 +532,6 @@ CPU Runs On Expected Frequency (Windows)
     Execute Shutdown Command
 
 CPU With Load Runs On Expected Frequency (Linux)
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     ${cpu_max_frequency_tol}=    Evaluate    ${CPU_MAX_FREQUENCY} * 1.125
     ${cpu_min_frequency_tol}=    Evaluate    ${CPU_MIN_FREQUENCY} * 0.875
@@ -563,7 +557,6 @@ CPU With Load Runs On Expected Frequency (Linux)
     END
 
 CPU With Load Runs On Expected Frequency (Windows)
-    [Tags]    robot:private
     Power On
     Login To Windows
     SSHLibrary.Put File    stress-test-windows.ps1    /C:/Users/user

--- a/dasharo-performance/cpu-performance.robot
+++ b/dasharo-performance/cpu-performance.robot
@@ -84,7 +84,6 @@ CPP004.201 Multi Threaded CPU Benchmark (Ubuntu) (Battery)
 
 *** Keywords ***
 CPU Performance Suite Setup
-    [Tags]    robot:private
     Prepare Test Suite
     Skip If    not ${CPU_PERFORMANCE_TESTS_SUPPORT}
     Check Power Supply
@@ -115,7 +114,6 @@ CPU Performance Suite Setup
 
 Run C-Ray Single-thread Render
     [Documentation]    Run C-Ray benchmark with all resolutions (1080p, 4K, 5K) on single thread
-    [Tags]    robot:private
     Log To Console    \n    # new line for readability
     VAR    ${test_name_to_path}=    cpuperformance
     VAR    ${test_name_to_path}=    ${test_name_to_path}    ${CURRENT_DATE}    separator=${EMPTY}
@@ -133,7 +131,6 @@ Run C-Ray Single-thread Render
 
 Run Coremark Single-thread
     [Documentation]    Run Coremark benchmark on single thread
-    [Tags]    robot:private
     VAR    ${test_name_to_path}=    cpuperformance
     VAR    ${test_name_to_path}=    ${test_name_to_path}    ${CURRENT_DATE}    separator=${EMPTY}
 
@@ -152,7 +149,6 @@ Run Coremark Single-thread
 
 7-Zip Multi-thread Compression And Decompression Average
     [Documentation]    Run 7-Zip Multi-thread Compression and Decompression benchmark on multiple threads
-    [Tags]    robot:private
     Log To Console    \n    # new line for readability
     VAR    ${test_name_to_path}=    cpuperformance
     VAR    ${test_name_to_path}=    ${test_name_to_path}    ${CURRENT_DATE}    separator=${EMPTY}
@@ -169,7 +165,6 @@ Run Coremark Single-thread
     RETURN    ${test_passed}
 
 Read The Results
-    [Tags]    robot:private
     [Arguments]    ${perf_results_path_ubuntu}    ${test_name_to_path}    ${test_description}
     VAR    ${awk_commmand}=
     ...    awk -F '[<>]' '/<Description>${test_description}<\\/Description>/
@@ -180,7 +175,6 @@ Read The Results
     RETURN    ${test_result_values}
 
 Validate The Results
-    [Tags]    robot:private
     [Arguments]    ${nums}    ${combined_ref_val}
     ${ref_val}=    Convert To Number    ${combined_ref_val}
     ${min}=    Evaluate    ${ref_val} * ${DEVIATION_DOWN}
@@ -202,7 +196,6 @@ Validate The Results
     RETURN    ${return_val}
 
 Validate Multiple Results
-    [Tags]    robot:private
     [Arguments]    ${perf_results_path_ubuntu}    ${test_name_to_path}    @{reference_data}
     Should Not Be Empty    ${reference_data}
     VAR    ${test_passed}=    ${True}

--- a/dasharo-performance/custom-fan-curve.robot
+++ b/dasharo-performance/custom-fan-curve.robot
@@ -149,7 +149,6 @@ Save Measurements
 Verify Fan Speeds
     [Documentation]    Compares RPM/PWM to target values depending
     ...    on CPU temperature and a fan curve.
-    [Tags]    robot:private
     [Arguments]    ${range_data}    ${fan_speed}    ${fan_mode}    ${cpu_temp}
 
     ${expected_fan_speed}=    Calculate Expected Speed    ${cpu_temp}    ${fan_mode}    ${range_data}
@@ -190,7 +189,6 @@ Get Fan Curve Range
 Get Fan Curve Range From Curve
     [Documentation]    Returns the dictionary with settings for temperature
     ...    range where the current temperature fits
-    [Tags]    robot:private
     [Arguments]    ${temperature}    @{temperature_curve}
 
     ${expected_speed}=    Evaluate    -1
@@ -205,7 +203,6 @@ Calculate Expected Speed
     ...    for a given temperature based on an algorithm and a
     ...    defined curve. Speed unit should be defined as "pwm" or "rpm" to
     ...    choose the curve unit.
-    [Tags]    robot:private
     [Arguments]    ${temperature}    ${speed_unit}    ${range_data}
 
     ${expected_speed}=    Evaluate    -1

--- a/dasharo-performance/fast-boot.robot
+++ b/dasharo-performance/fast-boot.robot
@@ -55,7 +55,6 @@ FBT001.201 Fast Boot Reduces Boot Time
 *** Keywords ***
 Set Fast Boot State
     [Documentation]    Set fast boot to on/off via Linux Shell
-    [Tags]    robot:private
     [Arguments]    ${state}
 
     ${var_file_name}=    Execute Linux Command
@@ -82,7 +81,6 @@ Set Fast Boot State
 Measure FW Boot Time On Linux
     [Documentation]    Performs a measurement of firmware boot time
     ...    over number of iterations provided as argument.
-    [Tags]    robot:private
     [Arguments]    ${iterations}
     VAR    @{durations}=    @{EMPTY}
     Log To Console    \n
@@ -103,7 +101,6 @@ Measure FW Boot Time On Linux
 
 Get FW Boot Time From Systemd-analyze
     [Documentation]    Use systemd-analyze to get firmware boot time
-    [Tags]    robot:private
     FOR    ${index}    IN RANGE    0    10
         ${boot_time}=    Execute Linux Command
         ...    systemd-analyze | awk 'NR==1 {print $4}' | sed 's/s//g'
@@ -121,7 +118,6 @@ Get FW Boot Time From Systemd-analyze
 Initialize Fast Boot Suite
     [Documentation]    Use efibootmgr to list entries, and set new order,
     ...    with Ubuntu at the top of the list.
-    [Tags]    robot:private
     Prepare Test Suite
     Skip If    not ${FAST_AND_QUIET_BOOT_SUPPORT}    Boot performance measurement tests not supported
     Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    Boot performance measurement tests not supported

--- a/dasharo-performance/gpu-performance.robot
+++ b/dasharo-performance/gpu-performance.robot
@@ -47,7 +47,6 @@ GPP002.201 GPU Performance Measure (Ubuntu) (Battery)
 *** Keywords ***
 GPU Performance Suite Setup
     [Documentation]    Load config and download tooling for supported OSes
-    [Tags]    robot:private
     Prepare Test Suite
     Skip If    not ${GPU_PERFORMANCE_TESTS_SUPPORT}
     ${get_date}=    Get Current Date    result_format=%d%m%Y%H%M%S

--- a/dasharo-performance/platform-stability.robot
+++ b/dasharo-performance/platform-stability.robot
@@ -134,7 +134,6 @@ Verify If No Reboot Occurs In Linux
     ...    Operating System does not reset. The test is performed in multiple
     ...    iterations - after a defined time an attempt to read the output of
     ...    specific commands confirming the stability of work is repeated.
-    [Tags]    robot:private
     [Arguments]    ${os_id}=${DEFAULT_BOOT_OS_ID}
     Power On
     Boot System Or From Connected Disk    ${os_id}
@@ -162,7 +161,6 @@ Verify If No Reboot Occurs In Linux
 Verify If No Unexpected Boot Errors Appear In Linux Logs
     [Documentation]    This test aims to verify that there are no unexpected
     ...    error ,essages in Linux kernel logs.
-    [Tags]    robot:private
     [Arguments]    ${os_id}=${DEFAULT_BOOT_OS_ID}
     Power On
     Boot System Or From Connected Disk    ${os_id}

--- a/dasharo-security/bios-lock.robot
+++ b/dasharo-security/bios-lock.robot
@@ -68,19 +68,16 @@ BLS002.202 BIOS lock support deactivation (Fedora)
 
 *** Keywords ***
 BIOS Lock Support
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     ${pr0}=    Get Bios Lock State    ${os_id}
     Should Not Be Empty    ${pr0}
 
 BIOS Lock Support Deactivation
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     ${pr0}=    Get Bios Lock State    ${os_id}
     Should Not Be Empty    ${pr0}
 
 Get Bios Lock State
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     Set UEFI Option    LockBios    ${TRUE}
     Power On

--- a/dasharo-security/cbnt.robot
+++ b/dasharo-security/cbnt.robot
@@ -112,7 +112,6 @@ CBNT005.201 Converged Boot Guard and TXT - Fused platform EoM set and FPFs Commi
 Check TPM Startup From Locality 3
     [Documentation]    Check TPM Startup locality print in cbmem to verify
     ...    that TPM started from locality 3
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     Boot OS And Enter Root Shell    ${os_id}
     ${out_cbmem}=    Execute Command In Terminal    cbmem -1 | grep Startup
@@ -122,7 +121,6 @@ Check TPM Startup From Locality 3
 Check EoM And FPFs Committed
     [Documentation]    Check Manufacturing Mode and FPFs Committed
     ...    prints in cbmem for the expected state
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     Boot OS And Enter Root Shell    ${os_id}
     ${out_cbmem}=    Execute Command In Terminal    cbmem -1 | grep ME
@@ -133,7 +131,6 @@ Check EoM And FPFs Committed
 Check CBnT Profile 5
     [Documentation]    Check if F, V and M components of the boot policy match
     ...    profile 5
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     Boot OS And Enter Root Shell    ${os_id}
     ${out_cbmem}=    Execute Command In Terminal    cbmem -1
@@ -145,7 +142,6 @@ Check CBnT Profile 5
 Boot OS And Enter Root Shell
     [Documentation]    Boots a specified OS and prepares for running commands as
     ...    root
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     Power On
     Boot System Or From Connected Disk    ${os_id}

--- a/dasharo-security/me-neuter.robot
+++ b/dasharo-security/me-neuter.robot
@@ -103,7 +103,6 @@ MNE006.202 Check Intel ME version (Fedora)
 Intel ME Mode Option Enabled Works Correctly
     [Documentation]    Check whether the Intel ME mode option in state Enabled
     ...    works correctly.
-    [Tags]    robot:private
     [Arguments]    ${os_id}=${DEFAULT_BOOT_OS_ID}
     Set UEFI Option    MeMode    Enabled
     Boot System Or From Connected Disk    ${os_id}
@@ -115,7 +114,6 @@ Intel ME Mode Option Enabled Works Correctly
 Intel ME Mode Option Disabled (Soft) Works Correctly
     [Documentation]    Check whether the Intel ME mode option in state
     ...    Disabled (Soft) works correctly
-    [Tags]    robot:private
     [Arguments]    ${os_id}=${DEFAULT_BOOT_OS_ID}
     Set UEFI Option    MeMode    Disabled (Soft)
     Boot System Or From Connected Disk    ${os_id}
@@ -131,7 +129,6 @@ Intel ME Mode Option Disabled (Soft) Works Correctly
 Intel ME Mode Option Disabled (HAP) Works Correctly
     [Documentation]    Check whether the Intel ME mode option in state
     ...    Disabled (HAP) works correctly.
-    [Tags]    robot:private
     [Arguments]    ${os_id}=${DEFAULT_BOOT_OS_ID}
     Set UEFI Option    MeMode    Disabled (HAP)
     Boot System Or From Connected Disk    ${os_id}
@@ -148,7 +145,6 @@ Check Intel ME Version
     [Documentation]    This test aims to verify that the Intel ME version might
     ...    be read on the Operating System level. The read version should be
     ...    the same as in the release notes.
-    [Tags]    robot:private
     [Arguments]    ${os_id}=${DEFAULT_BOOT_OS_ID}
     Set UEFI Option    MeMode    Enabled
     Power On

--- a/dasharo-security/measured-boot.robot
+++ b/dasharo-security/measured-boot.robot
@@ -293,7 +293,6 @@ Get Default PCRs State
     ...    configuration to default and then returns PCRs values. Next call
     ...    return values measured in first call (remembers value in whole
     ...    Test Suite).
-    [Tags]    robot:private
     ${default_pcr_state}=    Get Variable Value    $DEFAULT_PCR_STATE_SUITE
     IF    ${default_pcr_state} is ${NONE}
         Restore SB And Tianocore Defaults And Reset
@@ -305,7 +304,6 @@ Get Default PCRs State
 
 Boot Linux And Login To Root
     [Documentation]    Boots Ubuntu and logins as root
-    [Tags]    robot:private
     [Arguments]    ${os_id}=${DEFAULT_BOOT_OS_ID}
     Boot System Or From Connected Disk    ${os_id}
     Login To Linux
@@ -314,13 +312,11 @@ Boot Linux And Login To Root
 Restore SB And Tianocore Defaults And Reset
     [Documentation]    Restores Secure Boot and Tianocore to defaults and then
     ...    restarts
-    [Tags]    robot:private
     Restore Secure Boot Defaults
     Reset To Defaults Tianocore
     Save Changes And Reset
 
 Measured Boot Suite Setup
-    [Tags]    robot:private
     Prepare Test Suite
     Skip If    ${TPM_SUPPORTED_VERSION} == None    Measured boot tests require TPM
     Skip If    not ${MEASURED_BOOT_SUPPORT}    Measured boot is not supported
@@ -335,7 +331,6 @@ Measured Boot Suite Setup
 Linux Measured Boot Support
     [Documentation]    Check whether Measured Boot is functional and
     ...    measurements are stored into the TPM.
-    [Tags]    robot:private
     ${pcr_hashes}=    Get PCRs State From Linux    [0-3]
     FOR    ${pcr_hash}    IN    @{pcr_hashes}
         ${pcr}    ${hash}=    Split String    ${pcr_hash}    separator=:

--- a/dasharo-security/secure-boot.robot
+++ b/dasharo-security/secure-boot.robot
@@ -267,7 +267,6 @@ SBO008.001 Attempt to enroll the key in the incorrect format (firmware)
 
 *** Keywords ***
 Set Secure Boot State To Disabled
-    [Tags]    robot:private
     Power On
     ${sb_menu}=    Enter Secure Boot Menu And Return Construction
     Disable Secure Boot    ${sb_menu}

--- a/dasharo-security/wifi-bluetooth-switch.robot
+++ b/dasharo-security/wifi-bluetooth-switch.robot
@@ -64,7 +64,6 @@ WBS002.202 Wifi and Bluetooth card power switch enabled (Fedora)
 Wifi And Bluetooth Card Power Switch Disabled
     [Documentation]    Checks whether Wifi + Bluetooth is detected by Linux
     ...    after setting Enable Wi-Fi + BT radios option to false
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     Power On
     Boot System Or From Connected Disk    ${os_id}
@@ -81,7 +80,6 @@ Wifi And Bluetooth Card Power Switch Disabled
 Wifi And Bluetooth Card Power Switch
     [Documentation]    Checks whether Wifi + Bluetooth is detected by Linux
     ...    after setting Enable Wi-Fi + BT radios option to true
-    [Tags]    robot:private
     [Arguments]    ${os_id}
     Power On
     Boot System Or From Connected Disk    ${os_id}

--- a/dasharo-stability/m2-wifi.robot
+++ b/dasharo-stability/m2-wifi.robot
@@ -195,7 +195,6 @@ SMW006.202 Wi-fi connection after suspension (Fedora) (S3)
 
 *** Keywords ***
 Wi-fi Connection After Suspension
-    [Tags]    robot:private
     [Arguments]    ${platform_sleep_type}=${EMPTY}
     Check Platform Sleep Type Is Correct On Linux    ${platform_sleep_type}
 
@@ -213,7 +212,6 @@ Wi-fi Connection After Suspension
 Wi-Fi Connection After Warm Boot
     [Documentation]    Check whether the Wi-Fi card is detected and working
     ...    correctly after performing a warm boot.
-    [Tags]    robot:private
     ${out}=    Execute Command In Terminal    lspci | grep "Network controller:"
     Should Match    ${out}    *${WIFI_CARD_UBUNTU}*
     Scan For Wi-Fi In Linux
@@ -231,7 +229,6 @@ Wi-Fi Connection After Warm Boot
 Wi-Fi Connection After Reboot
     [Documentation]    Check whether the Wi-Fi card is detected and working
     ...    correctly after performing a reboot.
-    [Tags]    robot:private
     ${out}=    Execute Command In Terminal    lspci | grep "Network controller:"
     Should Match    ${out}    *${WIFI_CARD_UBUNTU}*
     Scan For Wi-Fi In Linux

--- a/dasharo-stability/network-interface-after-suspend.robot
+++ b/dasharo-stability/network-interface-after-suspend.robot
@@ -162,7 +162,6 @@ NET006.202 NET controller after suspend (Fedora) (S3)
 
 *** Keywords ***
 NET Controller After Suspend
-    [Tags]    robot:private
     [Arguments]    ${platform_sleep_type}=${EMPTY}
     Check Platform Sleep Type Is Correct On Linux    ${platform_sleep_type}
     ${is_suspend_performed_correctly}=    Perform Suspend Test Using FWTS
@@ -175,7 +174,6 @@ NET Controller After Suspend
 Net Controller After Warmboot
     [Documentation]    This test aims to verify that the network controller works and
     ...    the platform is able to connect to the network after reboot.
-    [Tags]    robot:private
     FOR    ${ind}    IN RANGE    ${STABILITY_DETECTION_REBOOT_ITERATIONS}
         Perform Warmboot Using Rtcwake
         Boot System Or From Connected Disk    ${BOOTED_OS_ID}
@@ -188,7 +186,6 @@ Net Controller After Warmboot
 Net Controller After Reboot
     [Documentation]    This test aims to verify that the network controller works and
     ...    the platform is able to connect to the network after reboot.
-    [Tags]    robot:private
     FOR    ${ind}    IN RANGE    ${STABILITY_DETECTION_REBOOT_ITERATIONS}
         Execute Reboot Command
         Boot System Or From Connected Disk    ${BOOTED_OS_ID}

--- a/dasharo-stability/nvme-detection.robot
+++ b/dasharo-stability/nvme-detection.robot
@@ -182,7 +182,6 @@ SNV006.202 NVMe detection after suspension (Fedora) (S3)
 NVMe Detection After Suspension
     [Documentation]    Check whether the NVMe disk is correctly detected after
     ...    performing suspension.
-    [Tags]    robot:private
     [Arguments]    ${platform_sleep_type}=${EMPTY}
     Check Platform Sleep Type Is Correct On Linux    ${platform_sleep_type}
     ${out}=    List Devices In Linux    pci
@@ -196,7 +195,6 @@ NVMe Detection After Suspension
 NVMe Detection After Reboot
     [Documentation]    Check whether the NVMe disk is detected and working
     ...    correctly after performing a reboot.
-    [Tags]    robot:private
     ${out}=    List Devices In Linux    pci
     Should Contain    ${out}    ${DEVICE_NVME_DISK}
     FOR    ${index}    IN RANGE    0    ${STABILITY_DETECTION_REBOOT_ITERATIONS}
@@ -211,7 +209,6 @@ NVMe Detection After Reboot
 NVMe Detection After Warm Boot
     [Documentation]    Check whether the NVMe disk is detected and working
     ...    correctly after performing a warm boot.
-    [Tags]    robot:private
     ${out}=    List Devices In Linux    pci
     Should Contain    ${out}    ${DEVICE_NVME_DISK}
     FOR    ${index}    IN RANGE    0    ${STABILITY_DETECTION_WARMBOOT_ITERATIONS}

--- a/dasharo-stability/tpm-detect.robot
+++ b/dasharo-stability/tpm-detect.robot
@@ -76,7 +76,6 @@ TPD004.202 Detect TPM after platform suspend (Fedora)
 Detect TPM After Platform Reboot
     [Documentation]    This test aims to verify that the TPM is initialized
     ...    correctly after the platform's reboot.
-    [Tags]    robot:private
     ${out}=    List Devices In Linux    pci
     Should Contain    ${out}    ${DEVICE_NVME_DISK}
     FOR    ${index}    IN RANGE    0    ${STABILITY_DETECTION_REBOOT_ITERATIONS}

--- a/dasharo-stability/usb-type-a-devices-detection.robot
+++ b/dasharo-stability/usb-type-a-devices-detection.robot
@@ -183,7 +183,6 @@ SUD006.202 USB devices detection after suspension (Fedora) (S3)
 USB Devices Detection After Suspension
     [Documentation]    Check whether the external USB devices are detected
     ...    correctly after suspension.
-    [Tags]    robot:private
     [Arguments]    ${platform_sleep_type}=${EMPTY}
     Check Platform Sleep Type Is Correct On Linux    ${platform_sleep_type}
     ${out}=    List Devices In Linux    usb
@@ -197,7 +196,6 @@ USB Devices Detection After Suspension
 USB Devices Detection After Warm Boot
     [Documentation]    Check whether the external USB devices are detected
     ...    correctly after a warm boot.
-    [Tags]    robot:private
     ${out}=    List Devices In Linux    usb
     Should Contain    ${out}    ${USB_DEVICE}
 
@@ -213,7 +211,6 @@ USB Devices Detection After Warm Boot
 USB Devices Detection After Reboot
     [Documentation]    Check whether the external USB devices are detected
     ...    correctly after a reboot.
-    [Tags]    robot:private
     ${out}=    List Devices In Linux    usb
     Should Contain    ${out}    ${USB_DEVICE}
     FOR    ${index}    IN RANGE    0    ${STABILITY_DETECTION_REBOOT_ITERATIONS}

--- a/lib/utc.robot
+++ b/lib/utc.robot
@@ -586,7 +586,6 @@ Docking Station Detection After Suspend Then Hotplug (S3)
 
 Pause Execution In Console
     [Documentation]    Pauses execution until user press ENTER.
-    [Tags]    robot:private
     [Arguments]    ${message}= Press ENTER to continue...
     Run    notify-send "Please execute Manual Step in ${TEST_NAME}"    # GUI message
     Run    echo -ne '\007'    # ASCII BEL (\007)


### PR DESCRIPTION
It produces lot's of warning with little benefit. Must be disabled until it works proparly, if at all.

Related issue:
https://github.com/Dasharo/open-source-firmware-validation/issues/966