### PR TITLE
sleep-lib: Allow `[s2idle] deep` as a mark of s0ix enabled

### DIFF
--- a/lib/sleep-lib.robot
+++ b/lib/sleep-lib.robot
@@ -48,7 +48,7 @@ Check Platform Sleep Type Is Correct On Linux
     [Arguments]    ${platform_sleep_type}=${EMPTY}
     IF    '${platform_sleep_type}' == 'S0ix'
         ${power_mem_sleep}=    Execute Command In Terminal    cat /sys/power/mem_sleep
-        Should Contain    ${power_mem_sleep}    [s2idle] shallow    # Six0
+        Should Contain Any    ${power_mem_sleep}    [s2idle] shallow    [s2idle] deep    # S0ix
     ELSE IF    '${platform_sleep_type}' == 'S3'
         ${power_mem_sleep}=    Execute Command In Terminal    cat /sys/power/mem_sleep
         Should Contain    ${power_mem_sleep}    s2idle [deep]    # S3


### PR DESCRIPTION
That's just what Fedora shows when s0ix is enabled. It either shows `[s2idle] deep` or `s2idle [deep]` meaning that both s2idle and deep suspends are supported, but only one of them is selected at a given moment.
Something must have changed a bit in Dasharo if before it was either `[s2idle] shallow` or `s2idle [deep]`, but it doesn't look like a bug