### PR TITLE
dts-e2e: add MTL UEFI update profiles

### DIFF
--- a/dts/profiles/novacustom-v540tnd UEFI Update - DCR.profile
+++ b/dts/profiles/novacustom-v540tnd UEFI Update - DCR.profile
@@ -1,0 +1,44 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+dmidecode -s baseboard-version 0
+fsread_tool test -e /sys/class/power_supply/AC/online 0
+fsread_tool cat /sys/class/power_supply/AC/online 0
+flashrom -p internal:boardmismatch=force 0
+dasharo_ectool info 0
+flashrom -p internal:boardmismatch=force -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
+cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
+cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 0
+flashrom -p internal:boardmismatch=force -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 0
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal:boardmismatch=force 0
+ifdtool -d /tmp/biosupdate 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 0
+setpci -s 00:16.0 42.B 0
+flashrom -p internal:boardmismatch=force -N --ifd -i bios -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+flashrom -p internal:boardmismatch=force --ifd -i bios -i fd -i me -w /tmp/biosupdate 0
+flashrom -p internal:boardmismatch=force --ifd -i bios -i fd -i me -w /tmp/biosupdate 0
+dasharo_ectool flash /tmp/ecupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/novacustom-v540tu UEFI Update - DCR.profile
+++ b/dts/profiles/novacustom-v540tu UEFI Update - DCR.profile
@@ -1,0 +1,44 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+dmidecode -s baseboard-version 0
+fsread_tool test -e /sys/class/power_supply/AC/online 0
+fsread_tool cat /sys/class/power_supply/AC/online 0
+flashrom -p internal:boardmismatch=force 0
+dasharo_ectool info 0
+flashrom -p internal:boardmismatch=force -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
+cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
+cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 0
+flashrom -p internal:boardmismatch=force -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 0
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal:boardmismatch=force 0
+ifdtool -d /tmp/biosupdate 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 0
+setpci -s 00:16.0 42.B 0
+flashrom -p internal:boardmismatch=force -N --ifd -i bios -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+flashrom -p internal:boardmismatch=force --ifd -i bios -i fd -i me -w /tmp/biosupdate 0
+flashrom -p internal:boardmismatch=force --ifd -i bios -i fd -i me -w /tmp/biosupdate 0
+dasharo_ectool flash /tmp/ecupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/novacustom-v560tnd UEFI Update - DCR.profile
+++ b/dts/profiles/novacustom-v560tnd UEFI Update - DCR.profile
@@ -1,0 +1,44 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+dmidecode -s baseboard-version 0
+fsread_tool test -e /sys/class/power_supply/AC/online 0
+fsread_tool cat /sys/class/power_supply/AC/online 0
+flashrom -p internal:boardmismatch=force 0
+dasharo_ectool info 0
+flashrom -p internal:boardmismatch=force -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
+cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
+cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 0
+flashrom -p internal:boardmismatch=force -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 0
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal:boardmismatch=force 0
+ifdtool -d /tmp/biosupdate 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 0
+setpci -s 00:16.0 42.B 0
+flashrom -p internal:boardmismatch=force -N --ifd -i bios -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+flashrom -p internal:boardmismatch=force --ifd -i bios -i fd -i me -w /tmp/biosupdate 0
+flashrom -p internal:boardmismatch=force --ifd -i bios -i fd -i me -w /tmp/biosupdate 0
+dasharo_ectool flash /tmp/ecupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/novacustom-v560tne UEFI Update - DCR.profile
+++ b/dts/profiles/novacustom-v560tne UEFI Update - DCR.profile
@@ -1,0 +1,44 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+dmidecode -s baseboard-version 0
+fsread_tool test -e /sys/class/power_supply/AC/online 0
+fsread_tool cat /sys/class/power_supply/AC/online 0
+flashrom -p internal:boardmismatch=force 0
+dasharo_ectool info 0
+flashrom -p internal:boardmismatch=force -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
+cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
+cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 0
+flashrom -p internal:boardmismatch=force -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 0
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal:boardmismatch=force 0
+ifdtool -d /tmp/biosupdate 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 0
+setpci -s 00:16.0 42.B 0
+flashrom -p internal:boardmismatch=force -N --ifd -i bios -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+flashrom -p internal:boardmismatch=force --ifd -i bios -i fd -i me -w /tmp/biosupdate 0
+flashrom -p internal:boardmismatch=force --ifd -i bios -i fd -i me -w /tmp/biosupdate 0
+dasharo_ectool flash /tmp/ecupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/novacustom-v560tu UEFI Update - DCR.profile
+++ b/dts/profiles/novacustom-v560tu UEFI Update - DCR.profile
@@ -1,0 +1,44 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+dmidecode -s baseboard-version 0
+fsread_tool test -e /sys/class/power_supply/AC/online 0
+fsread_tool cat /sys/class/power_supply/AC/online 0
+flashrom -p internal:boardmismatch=force 0
+dasharo_ectool info 0
+flashrom -p internal:boardmismatch=force -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
+cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
+cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 0
+flashrom -p internal:boardmismatch=force -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 0
+cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal:boardmismatch=force 0
+ifdtool -d /tmp/biosupdate 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 0
+setpci -s 00:16.0 42.B 0
+flashrom -p internal:boardmismatch=force -N --ifd -i bios -r /tmp/bios.bin 0
+cbfstool /tmp/bios.bin layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+flashrom -p internal:boardmismatch=force --ifd -i bios -i fd -i me -w /tmp/biosupdate 0
+flashrom -p internal:boardmismatch=force --ifd -i bios -i fd -i me -w /tmp/biosupdate 0
+dasharo_ectool flash /tmp/ecupdate 0
+reboot  0
+dmidecode  0

--- a/platform-configs/include/novacustom-mtl.robot
+++ b/platform-configs/include/novacustom-mtl.robot
@@ -48,5 +48,10 @@ ${DASHARO_POWER_MGMT_MENU_SUPPORT}=                 ${FALSE}
 ...                                                 TEST_HCI_PRESENT=true
 ...                                                 TEST_ME_HAP_DISABLED=true
 ...                                                 TEST_ME_OP_MODE=2
+&{DTS_TEST_EXPORTS_PER_WORKFLOW}=
+...                                                 &{DTS_TEST_EXPORTS_PER_WORKFLOW_BASE}
+...                                                 UEFI Update=&{{ {"TEST_IS_COREBOOT": "true", "TEST_DIFFERENT_FMAP": "true"} }}
+
+# End DTS E2E variables
 
 ${CAPSULE_UPDATE_SUPPORT}=                          ${TRUE}

--- a/platform-configs/novacustom-v540tnd.robot
+++ b/platform-configs/novacustom-v540tnd.robot
@@ -115,3 +115,5 @@ ${OPTIONS_LIB}=                                 options-lib_dcu
 ...                                             UEFI->Heads Transition=Dasharo (coreboot+UEFI) 0.9.0
 ${DTS_TEST_BOARD_MODEL}=                        V540TNx
 @{DTS_TEST_WORKFLOWS}=                          Initial Deployment    UEFI Update
+@{DTS_TEST_WORKFLOW_PROFILES}=
+...                                             ${{ ("UEFI Update", "DCR") }}

--- a/platform-configs/novacustom-v540tu.robot
+++ b/platform-configs/novacustom-v540tu.robot
@@ -113,11 +113,12 @@ ${UNIGINE_SUPERPOSITION_RESULT_BAT}=    20.3    # FPS
 &{DTS_TEST_VERSIONS}=
 ...                                     &{DTS_TEST_VERSIONS_BASE}
 ...                                     UEFI->Heads Transition=Dasharo (coreboot+UEFI) 0.9.0
+...                                     UEFI Update=Dasharo (coreboot+UEFI) 0.9.0
 ${DTS_TEST_BOARD_MODEL}=                V540TU
 @{DTS_TEST_WORKFLOWS}=                  Initial Deployment    UEFI Update    UEFI->Heads Transition
-
 @{DTS_TEST_WORKFLOW_PROFILES}=
 ...                                     ${{ ("UEFI->Heads Transition", "DPP") }}
+...                                     ${{ ("UEFI Update", "DCR") }}
 
 
 *** Keywords ***

--- a/platform-configs/novacustom-v560tnd.robot
+++ b/platform-configs/novacustom-v560tnd.robot
@@ -121,3 +121,5 @@ ${UNIGINE_SUPERPOSITION_RESULT_BAT}=    24.0    # FPS
 ...                                     UEFI->Heads Transition=Dasharo (coreboot+UEFI) 0.9.0
 ${DTS_TEST_BOARD_MODEL}=                V560TNx
 @{DTS_TEST_WORKFLOWS}=                  Initial Deployment    UEFI Update
+@{DTS_TEST_WORKFLOW_PROFILES}=
+...                                     ${{ ("UEFI Update", "DCR") }}

--- a/platform-configs/novacustom-v560tne.robot
+++ b/platform-configs/novacustom-v560tne.robot
@@ -93,3 +93,5 @@ ${OPTIONS_LIB}=                         options-lib_dcu
 # DTS E2E variables
 ${DTS_TEST_BOARD_MODEL}=                V560TNx
 @{DTS_TEST_WORKFLOWS}=                  Initial Deployment    UEFI Update
+@{DTS_TEST_WORKFLOW_PROFILES}=
+...                                     ${{ ("UEFI Update", "DCR") }}

--- a/platform-configs/novacustom-v560tu.robot
+++ b/platform-configs/novacustom-v560tu.robot
@@ -99,7 +99,9 @@ ${OPTIONS_LIB}=                         options-lib_dcu
 &{DTS_TEST_VERSIONS}=
 ...                                     &{DTS_TEST_VERSIONS_BASE}
 ...                                     UEFI->Heads Transition=Dasharo (coreboot+UEFI) 0.9.0
+...                                     UEFI Update=Dasharo (coreboot+UEFI) 0.9.0
 ${DTS_TEST_BOARD_MODEL}=                V560TU
 @{DTS_TEST_WORKFLOWS}=                  Initial Deployment    UEFI Update    UEFI->Heads Transition
 @{DTS_TEST_WORKFLOW_PROFILES}=
 ...                                     ${{ ("UEFI->Heads Transition", "DPP") }}
+...                                     ${{ ("UEFI Update", "DCR") }}


### PR DESCRIPTION
```
==============================================================================
Dts-E2E
==============================================================================
Create tests                                                          | PASS |
------------------------------------------------------------------------------
E2E001: novacustom-v540tnd UEFI Update - DCR                          | PASS |
------------------------------------------------------------------------------
[ WARN ] Workflow isn't configured for profile verification.
E2E002: novacustom-v560tnd UEFI Update - DCR                          | PASS |
------------------------------------------------------------------------------
E2E003: novacustom-v560tne UEFI Update - DCR                          | PASS |
------------------------------------------------------------------------------
E2E004: novacustom-v540tu UEFI Update - DCR                           | PASS |
------------------------------------------------------------------------------
E2E005: novacustom-v560tu UEFI Update - DCR                           | PASS |
------------------------------------------------------------------------------
Dts-E2E                                                               | PASS |
6 tests, 6 passed, 0 failed
==============================================================================
```