### PR TITLE
scripts/ci/develop_pr_auto_regression.sh: don't check nonexistent run 0

### DIFF
--- a/scripts/ci/develop_pr_auto_regression.sh
+++ b/scripts/ci/develop_pr_auto_regression.sh
@@ -69,13 +69,12 @@ done
 
 
 exit_code=0
-i=0
-for code in "${statuses[@]}"; do
+for i in "${!statuses[@]}"; do
+    code=${statuses[$i]}
     if [[ "$code" -ne 0 ]]; then
         echo "Run ${i} failed with exit code ${code}. Check $LOGS_DIR/run_${i}.log for details."
         exit_code=1
     fi
-    (( i++))
 done
 
 exit $exit_code


### PR DESCRIPTION
The loop was using a 0-based index on an 1-based array.  Enumerate keys and query values per key instead.