### PR TITLE
pfSense & OPNsense: test skipping with ENV ID

### DIFF
--- a/dasharo-compatibility/os-opnsense.robot
+++ b/dasharo-compatibility/os-opnsense.robot
@@ -13,6 +13,8 @@ Resource            ../keys.robot
 # Log Out And Close Connection - elementary teardown keyword for all tests.
 Suite Setup         Run Keywords
 ...                     Prepare Test Suite
+...                     AND
+...                     Skip If    '${ENV_ID_OPNSENSE}' not in ${TESTED_LINUX_DISTROS}    OPNsense tests not supported
 Suite Teardown      Run Keywords
 ...                     Log Out And Close Connection
 Test Setup          Run Keyword

--- a/dasharo-compatibility/os-opnsense.robot
+++ b/dasharo-compatibility/os-opnsense.robot
@@ -14,13 +14,11 @@ Resource            ../keys.robot
 Suite Setup         Run Keywords
 ...                     Prepare Test Suite
 ...                     AND
-...                     Skip If    '${ENV_ID_OPNSENSE}' not in ${TESTED_LINUX_DISTROS}    OPNsense tests not supported
+...                     Skip If    '${ENV_ID_OPNSENSE}' not in ${TESTED_BSD_DISTROS}    OPNsense tests not supported
 Suite Teardown      Run Keywords
 ...                     Log Out And Close Connection
 Test Setup          Run Keyword
 ...                     Restore Initial DUT Connection Method
-
-Default Tags        semiauto
 
 
 *** Test Cases ***
@@ -32,6 +30,7 @@ OPN001.503 Install operating system on disk (OPNsense)
     ...    modification.
     ...
     ...    Previous IDs: OPN001.001
+    [Tags]    semiauto
     Power On
     Boot OPNsense Installer
     VAR    ${installer_message}=
@@ -43,16 +42,13 @@ OPN001.503 Install operating system on disk (OPNsense)
 
 OPN002.503 Boot operating system from disk (OPNsense)
     [Documentation]    Boot OPNsense (serial output) from disk.
-    ...    This test depends on semi-manual OS installation, thus it's
-    ...    marked as semiauto.
+    ...
     ...    Previous IDs: OPN001.002
     Power On
     Boot OPNsense
 
 OPN003.503 Boot operating system from disk after cold-boot (OPNsense)
     [Documentation]    Boot OPNsense (serial output) from disk after cold-boot
-    ...    This test depends on semi-manual OS installation, thus it's
-    ...    marked as semiauto.
     ...
     ...    Previous IDs: BOS001.001
     VAR    @{supported_power_ctrls}=    RteCtrl    sonoff
@@ -66,8 +62,6 @@ OPN003.503 Boot operating system from disk after cold-boot (OPNsense)
 
 OPN004.503 Boot operating system from disk after warm-boot (OPNsense)
     [Documentation]    Boot OPNsense (serial output) from disk after warm-boot
-    ...    This test depends on semi-manual OS installation, thus it's
-    ...    marked as semiauto.
     ...
     ...    Previous IDs: BOS002.001
     Power On
@@ -83,8 +77,6 @@ OPN004.503 Boot operating system from disk after warm-boot (OPNsense)
 
 OPN005.503 Boot operating system from disk after reboot (OPNsense)
     [Documentation]    Boot OPNsense (serial output) from disk after reboot
-    ...    This test depends on semi-manual OS installation, thus it's
-    ...    marked as semiauto.
     ...
     ...    Previous IDs: BOS003.001
     Power On

--- a/dasharo-compatibility/os-pfsense.robot
+++ b/dasharo-compatibility/os-pfsense.robot
@@ -13,6 +13,8 @@ Resource            ../keys.robot
 # Log Out And Close Connection - elementary teardown keyword for all tests.
 Suite Setup         Run Keywords
 ...                     Prepare Test Suite
+...                     AND
+...                     Skip If    '${ENV_ID_PFSENSE}' not in ${TESTED_LINUX_DISTROS}    pfSense tests not supported
 Suite Teardown      Run Keywords
 ...                     Log Out And Close Connection
 Test Setup          Run Keyword

--- a/dasharo-compatibility/os-pfsense.robot
+++ b/dasharo-compatibility/os-pfsense.robot
@@ -14,13 +14,11 @@ Resource            ../keys.robot
 Suite Setup         Run Keywords
 ...                     Prepare Test Suite
 ...                     AND
-...                     Skip If    '${ENV_ID_PFSENSE}' not in ${TESTED_LINUX_DISTROS}    pfSense tests not supported
+...                     Skip If    '${ENV_ID_PFSENSE}' not in ${TESTED_BSD_DISTROS}    pfSense tests not supported
 Suite Teardown      Run Keywords
 ...                     Log Out And Close Connection
 Test Setup          Run Keyword
 ...                     Restore Initial DUT Connection Method
-
-Default Tags        semiauto
 
 
 *** Test Cases ***
@@ -29,6 +27,7 @@ PFS001.502 Install operating system on disk (pfSense)
     ...    USB stick on disk. Refer to test case PFS006.502 for preseed.
     ...
     ...    Previous IDs: PFS001.001
+    [Tags]    semiauto
     Power On
     Boot PfSense Installer
     VAR    ${installer_message}=
@@ -39,8 +38,6 @@ PFS001.502 Install operating system on disk (pfSense)
 
 PFS002.502 Boot operating system from disk (pfSense)
     [Documentation]    Boot pfSense LTS CE (serial output) from disk.
-    ...    This test depends on semi-manual OS installation, thus it's
-    ...    marked as semiauto.
     ...
     ...    Previous IDs: PFS001.002
     Power On
@@ -48,8 +45,6 @@ PFS002.502 Boot operating system from disk (pfSense)
 
 PFS003.502 Boot operating system from disk after cold-boot (pfSense)
     [Documentation]    Boot pfSense LTS CE (serial output) from disk after cold-boot
-    ...    This test depends on semi-manual OS installation, thus it's
-    ...    marked as semiauto.
     ...
     ...    Previous IDs: BPS001.001
     VAR    @{supported_power_ctrls}=    RteCtrl    sonoff
@@ -63,8 +58,6 @@ PFS003.502 Boot operating system from disk after cold-boot (pfSense)
 
 PFS004.502 Boot operating system from disk after warm-boot (pfSense)
     [Documentation]    Boot pfSense LTS CE (serial output) from disk after warm-boot
-    ...    This test depends on semi-manual OS installation, thus it's
-    ...    marked as semiauto.
     ...
     ...    Previous IDs: BPS002.001
     Power On
@@ -80,8 +73,6 @@ PFS004.502 Boot operating system from disk after warm-boot (pfSense)
 
 PFS005.502 Boot operating system from disk after reboot (pfSense)
     [Documentation]    Boot pfSense LTS CE (serial output) from disk after reboot
-    ...    This test depends on semi-manual OS installation, thus it's
-    ...    marked as semiauto.
     ...
     ...    Previous IDs: BPS003.001
     Power On
@@ -99,6 +90,7 @@ PFS006.502 Preseed operating system installer (pfSense)
     ...    pfSense installer to PFEFI.
     ...    This test depends on semi-manual OS installatio media preparation,
     ...    thus it's marked as semiauto.
+    [Tags]    semiauto
     VAR    ${pfefi_message}=
     ...    Rename ESP partition of pfSense
     ...    serial installer to PFEFI.\nOn Linux: (sudo) fatlabel /dev/sdX1
@@ -127,8 +119,6 @@ PFS006.502 Preseed operating system installer (pfSense)
 
 PFS007.502 Boot operating system installer into rescue shell (pfSense)
     [Documentation]    Boot installer into rescue shell.
-    ...    This test depends on semi-manual OS installatio media preparation,
-    ...    thus it's marked as semiauto.
     Power On
     Boot PfSense Installer
     Enter PfSense Rescue Shell

--- a/platform-configs/include/default.robot
+++ b/platform-configs/include/default.robot
@@ -322,6 +322,7 @@ ${DCU_SUPPORTED_BOOLEAN_SMMSTORE_VARIABLE}=         NetworkBoot
 ${WINDOWS_SHUTDOWN_AWAITING_SECONDS}=               120
 
 @{TESTED_LINUX_DISTROS}=                            ${ENV_ID_UBUNTU}
+@{TESTED_BSD_DISTROS}=                              @{EMPTY}
 ${DEFAULT_BOOT_OS_ID}=                              ${ENV_ID_UBUNTU}
 ${BOOTED_OS_ID}=                                    ${DEFAULT_BOOT_OS_ID}
 

--- a/platform-configs/include/protectli-common.robot
+++ b/platform-configs/include/protectli-common.robot
@@ -43,6 +43,7 @@ ${TESTS_IN_UBUNTU_SUPPORT}=                     ${TRUE}
 ${TESTS_IN_WINDOWS_SUPPORT}=                    ${TRUE}
 ${TESTS_IN_ESXI_SUPPORT}=                       ${TRUE}
 ${TESTS_IN_OPENWRT_SUPPORT}=                    ${TRUE}
+@{TESTED_BSD_DISTROS}=                          ${ENV_ID_PFSENSE}    ${ENV_ID_OPNSENSE}
 
 # Regression test flags
 ${DASHARO_USB_MENU_SUPPORT}=                    ${TRUE}


### PR DESCRIPTION
dasharo-compatibility/os-opnsense.robot:
dasharo-compatibility/os-pfsense.robot:
Test suites are skipping in Suite Setup if BSD ENV IDs are not present in TESTED_LINUX_DISTROS variable.

[BSD_os-opnsense_2025_08_29_10_43_00_PASS.zip](https://github.com/user-attachments/files/22042007/BSD_os-opnsense_2025_08_29_10_43_00_PASS.zip)
[BSD_os-opnsense_2025_08_29_10_52_59_SKIP.zip](https://github.com/user-attachments/files/22042008/BSD_os-opnsense_2025_08_29_10_52_59_SKIP.zip)
[BSD_os-pfsense_2025_08_29_10_40_30_PASS.zip](https://github.com/user-attachments/files/22042009/BSD_os-pfsense_2025_08_29_10_40_30_PASS.zip)
[BSD_os-pfsense_2025_08_29_10_52_48_SKIP.zip](https://github.com/user-attachments/files/22042010/BSD_os-pfsense_2025_08_29_10_52_48_SKIP.zip)
