### PR TITLE
platform-configs: dts-e2e: add nuc_box initial deployment

### DIFF
--- a/dts/profiles/novacustom-nuc_box-125H Initial Deployment - DCR.profile
+++ b/dts/profiles/novacustom-nuc_box-125H Initial Deployment - DCR.profile
@@ -1,0 +1,74 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+lspci -nnvvvxxxx 0
+lsusb -vvv 0
+superiotool -deV 0
+ectool -ip 0
+msrtool  1
+dmidecode  0
+dmesg  0
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+flashrom -p internal 0
+flashrom -V -p internal:laptop=force_I_want_a_brick -r logs/rom.bin --ifd -i fd -i bios -i me 0
+dmesg  0
+cbmem  1
+cbmem -1 1
+mei-amt-check  0
+intelmetool -m 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s bios-version 0
+dmidecode -s system-product-name 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+fsread_tool test -f /sys/class/mei/mei0/fw_status 0
+fsread_tool cat /sys/class/mei/mei0/fw_status 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 1
+flashrom -p internal 0
+flashrom -p internal -r /fw_backup/rom.bin --ifd -i fd -i bios -i me 0
+flashrom -p internal 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 0
+setpci -s 00:16.0 42.B 0
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal -N --ifd -i bios -i fd -w /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/novacustom-nuc_box-155H Initial Deployment - DCR.profile
+++ b/dts/profiles/novacustom-nuc_box-155H Initial Deployment - DCR.profile
@@ -1,0 +1,74 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+lspci -nnvvvxxxx 0
+lsusb -vvv 0
+superiotool -deV 0
+ectool -ip 0
+msrtool  1
+dmidecode  0
+dmesg  0
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+fsread_tool test -f /sys/class/sound/card0/hw*/init_pin_configs 1
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+flashrom -p internal 0
+flashrom -V -p internal:laptop=force_I_want_a_brick -r logs/rom.bin --ifd -i fd -i bios -i me 0
+dmesg  0
+cbmem  1
+cbmem -1 1
+mei-amt-check  0
+intelmetool -m 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s bios-version 0
+dmidecode -s system-product-name 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+fsread_tool test -f /sys/class/mei/mei0/fw_status 0
+fsread_tool cat /sys/class/mei/mei0/fw_status 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -e /sys/class/power_supply/AC/online 1
+flashrom -p internal 0
+flashrom -p internal -r /fw_backup/rom.bin --ifd -i fd -i bios -i me 0
+flashrom -p internal 0
+flashrom -p internal 0
+ifdtool -d /tmp/biosupdate 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 0
+setpci -s 00:16.0 42.B 0
+cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
+flashrom -p internal -N --ifd -i bios -i fd -w /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/platform-configs/include/novacustom-nuc_box.robot
+++ b/platform-configs/include/novacustom-nuc_box.robot
@@ -30,4 +30,7 @@ ${USB_KEYBOARD_DETECTION_SUPPORT}=      ${TRUE}
 ${FAN_SPEED_MEASURE_SUPPORT}=           ${TRUE}
 
 # DTS E2E test variables
-@{DTS_TEST_WORKFLOWS}=                  @{EMPTY}
+@{DTS_TEST_WORKFLOWS}=                  Initial Deployment
+${DTS_TEST_SYSTEM_VENDOR}=              NovaCustom
+&{DTS_TEST_EXPORTS}=
+...                                     &{DTS_TEST_BASE_EXPORTS}

--- a/platform-configs/include/novacustom-nuc_box.robot
+++ b/platform-configs/include/novacustom-nuc_box.robot
@@ -34,3 +34,14 @@ ${FAN_SPEED_MEASURE_SUPPORT}=           ${TRUE}
 ${DTS_TEST_SYSTEM_VENDOR}=              NovaCustom
 &{DTS_TEST_EXPORTS}=
 ...                                     &{DTS_TEST_BASE_EXPORTS}
+...                                     TEST_SOUND_CARD_PRESENT=false
+...                                     TEST_BOARD_HAS_GBE_REGION=false
+...                                     TEST_HCI_PRESENT=true
+...                                     TEST_MEI_AMT_CHECK=true
+# robocop: off=LEN08
+&{DTS_TEST_EXPORTS_PER_WORKFLOW}=
+...                                     &{DTS_TEST_EXPORTS_PER_WORKFLOW_BASE}
+...                                     Initial Deployment=&{{ {"TEST_SYSTEM_MODEL": "NUC BOX-125H", "TEST_SYSTEM_VENDOR": "ASRock Industrial", "TEST_BIOS_VENDOR": "proprietary", "TEST_USING_OPENSOURCE_EC_FIRM": "false"} }}
+# robocop: off=LEN08
+@{DTS_TEST_WORKFLOW_PROFILES}=
+...                                     ${{ ("Initial Deployment", "DCR") }}


### PR DESCRIPTION
```text
==============================================================================
Dts-E2E
==============================================================================
Create tests                                                          | PASS |
------------------------------------------------------------------------------
E2E001: novacustom-nuc_box-125H Initial Deployment - DCR              | PASS |
------------------------------------------------------------------------------
E2E002: novacustom-nuc_box-155H Initial Deployment - DCR              | PASS |
------------------------------------------------------------------------------
[ WARN ] Workflow isn't configured for profile verification.
E2E003: msi-pro-z690-a-ddr5 Initial Deployment - DCR                  | PASS |
------------------------------------------------------------------------------
(...)
```