### PR TITLE
Add DTS E2E `fuse platform` workflow

### DIFF
--- a/dts/dts-e2e.robot
+++ b/dts/dts-e2e.robot
@@ -418,6 +418,13 @@ ${platform} Dasharo (Slim Bootloader+UEFI) Initial Deployment - DPP
     Wait For Checkpoint And Press Enter    ${DTS_CONFIRM_CHECKPOINT}
     Wait For Checkpoint    ${DTS_CHECKPOINT}
 
+${platform} Fuse Platform - DCR
+    [Documentation]    Platform fusing workflow for DCR release
+    Prepare E2E Test
+    Go Through Fusing Platform
+    Wait For Checkpoint And Press Enter    ${DTS_CONFIRM_CHECKPOINT}
+    Wait For Checkpoint    ${DTS_CHECKPOINT}
+
 Prepare E2E Test
     [Documentation]    Prepare everything needed for platform and workflow
     ...    emulation. Keyword has to be run in shell. After keyword ends we

--- a/dts/profiles/novacustom-v540tnd Fuse Platform - DCR.profile
+++ b/dts/profiles/novacustom-v540tnd Fuse Platform - DCR.profile
@@ -1,0 +1,31 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+dmidecode -s baseboard-version 0
+fsread_tool test -f /sys/class/mei/mei0/fw_status 1
+flashrom -p internal:boardmismatch=force 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 0
+setpci -s 00:16.0 42.B 0
+fsread_tool test -e /sys/class/power_supply/AC/online 0
+fsread_tool cat /sys/class/power_supply/AC/online 0
+cap_upd_tool /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/novacustom-v540tu Fuse Platform - DCR.profile
+++ b/dts/profiles/novacustom-v540tu Fuse Platform - DCR.profile
@@ -1,0 +1,31 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+dmidecode -s baseboard-version 0
+fsread_tool test -f /sys/class/mei/mei0/fw_status 1
+flashrom -p internal:boardmismatch=force 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 0
+setpci -s 00:16.0 42.B 0
+fsread_tool test -e /sys/class/power_supply/AC/online 0
+fsread_tool cat /sys/class/power_supply/AC/online 0
+cap_upd_tool /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/novacustom-v560tnd Fuse Platform - DCR.profile
+++ b/dts/profiles/novacustom-v560tnd Fuse Platform - DCR.profile
@@ -1,0 +1,31 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+dmidecode -s baseboard-version 0
+fsread_tool test -f /sys/class/mei/mei0/fw_status 1
+flashrom -p internal:boardmismatch=force 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 0
+setpci -s 00:16.0 42.B 0
+fsread_tool test -e /sys/class/power_supply/AC/online 0
+fsread_tool cat /sys/class/power_supply/AC/online 0
+cap_upd_tool /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/novacustom-v560tu Fuse Platform - DCR.profile
+++ b/dts/profiles/novacustom-v560tu Fuse Platform - DCR.profile
@@ -1,0 +1,31 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+dmidecode -s baseboard-version 0
+fsread_tool test -f /sys/class/mei/mei0/fw_status 1
+flashrom -p internal:boardmismatch=force 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 0
+setpci -s 00:16.0 42.B 0
+fsread_tool test -e /sys/class/power_supply/AC/online 0
+fsread_tool cat /sys/class/power_supply/AC/online 0
+cap_upd_tool /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/lib/dts-lib.robot
+++ b/lib/dts-lib.robot
@@ -22,6 +22,7 @@ ${DTS_HEADS_SWITCH_QUESTION}=                   Would you like to switch to Dash
 ${DTS_ME_WARN}=
 ...                                             Skip ME flashing and proceed with BIOS/firmware flashing/updating? (Y|n)
 ${DTS_BOARD_QUESTION}=                          Choose your board model:
+${DTS_FUSE_WARN}=                               Fusing is irreversible. Are you sure you want to continue? [n/y]
 ${DTS_13_GEN_REGRESSION}=                       Aborting deployment...
 ${DPP_EMAIL_CHECKPOINT}=                        Enter DPP email:
 ${DPP_PASSWORD_CHECKPOINT}=                     Enter password:
@@ -37,6 +38,7 @@ ${DTS_HCL_OPT}=                                 1
 ${DTS_DEPLOY_OPT}=                              2
 ${DTS_CREDENTIALS_OPT}=                         4
 ${DTS_TRANSITION_OPT}=                          6
+${DTS_FUSE_OPT}=                                7
 ${DTS_DCR_UEFI_OPT}=                            c
 ${DTS_DPP_UEFI_OPT}=                            d
 ${DTS_DPP_SEA_OPT}=                             s
@@ -477,6 +479,20 @@ Go Through Heads Transition
         END
     END
     Wait For Checkpoint And Press Enter    ${DTS_CONFIRM_CHECKPOINT}
+    Wait For Checkpoint    Rebooting in
+    Wait For Checkpoint    Rebooting
+
+Go Through Fusing Platform
+    [Documentation]    This KW goes through standard Dasharo workflow which
+    ...    deploys binary that'll fuse platform, choosing all needed menu
+    ...    options and answering all questions.
+    Set DUT Response Timeout    120s
+
+    Wait For Checkpoint And Write Bare    ${DTS_CHECKPOINT}    ${DTS_FUSE_OPT}
+    Wait For Checkpoint And Write    ${DTS_FUSE_WARN}    Y
+    Wait For Checkpoint And Write    ${DTS_SPECIFICATION_WARN}    Y
+    Wait For Checkpoint And Write    ${DTS_DEPLOY_WARN}    Y
+
     Wait For Checkpoint    Rebooting in
     Wait For Checkpoint    Rebooting
 

--- a/lib/dts-lib.robot
+++ b/lib/dts-lib.robot
@@ -254,14 +254,23 @@ Wait For Checkpoint
     Log    ${out}
     RETURN    ${out}
 
-Wait For Checkpoint And Write
+Wait For Checkpoint And Write Bare
     [Documentation]    This KW waits for checkpoint (first argument)
     ...    and writes specified answer (second argument), with logging all
     ...    output before the checkpoint.
     [Arguments]    ${checkpoint}    ${to_write}    ${regexp}=${FALSE}
     ${out}=    Wait For Checkpoint    ${checkpoint}    ${regexp}
     Sleep    1s
-    Write Into Terminal    ${to_write}
+    Write Bare Into Terminal    ${to_write}
+    RETURN    ${out}
+
+Wait For Checkpoint And Write
+    [Documentation]    This KW waits for checkpoint (first argument)
+    ...    and writes specified answer (second argument), with logging all
+    ...    output before the checkpoint.
+    [Arguments]    ${checkpoint}    ${to_write}    ${regexp}=${FALSE}
+    ${out}=    Wait For Checkpoint And Write Bare
+    ...    ${checkpoint}    ${to_write}${ENTER}    ${regexp}
     RETURN    ${out}
 
 Wait For Either Checkpoint And Write

--- a/platform-configs/include/default.robot
+++ b/platform-configs/include/default.robot
@@ -407,6 +407,7 @@ ${DTS_TEST_VERSION_BASE}=                           v0.0.0
 ...                                                 UEFI Update=Dasharo (coreboot+UEFI) ${DTS_TEST_VERSION_BASE}
 ...                                                 UEFI->Heads Transition=Dasharo (coreboot+UEFI) ${DTS_TEST_VERSION_BASE}
 ...                                                 Dasharo (coreboot+UEFI) to Dasharo (Slim Bootloader+UEFI) Transition=Dasharo (coreboot+UEFI) ${DTS_TEST_VERSION_BASE}
+...                                                 Fuse Platform=Dasharo (coreboot+UEFI) ${DTS_TEST_VERSION_BASE}
 &{DTS_TEST_VERSIONS}=                               &{DTS_TEST_VERSIONS_BASE}
 # TEST_SYSTEM_MODEL, TEST_BOARD_MODEL, TEST_SYSTEM_VENDOR variables to export
 ${DTS_TEST_BOARD_MODEL}=                            ${EMPTY}
@@ -449,6 +450,7 @@ ${DTS_TEST_HAS_EC}=                                 ${False}
 ...                                                 SeaBIOS->UEFI Transition
 ...                                                 Dasharo (coreboot+UEFI) to Dasharo (Slim Bootloader+UEFI) Transition
 ...                                                 Dasharo (Slim Bootloader+UEFI) Initial Deployment
+...                                                 Fuse Platform
 # Set to e.g. DPP for platforms where only DPP workflows work
 @{DTS_TEST_DEFAULT_RELEASES}=                       DCR    DPP
 &{DTS_TEST_WORKFLOW_RELEASES_BASE}=
@@ -460,6 +462,7 @@ ${DTS_TEST_HAS_EC}=                                 ${False}
 ...                                                 UEFI->Heads Transition=@{{["DPP"]}}
 ...                                                 Dasharo (coreboot+UEFI) to Dasharo (Slim Bootloader+UEFI) Transition=@{{["DPP"]}}
 ...                                                 Dasharo (Slim Bootloader+UEFI) Initial Deployment=@{{["DPP"]}}
+...                                                 Fuse Platform=@{{["DCR"]}}
 # List of workflows which require profile comparison in the format:
 # list[tuple[workflow, release]] e.g.:
 # @{DTS_TEST_WORKFLOW_PROFILES}=

--- a/platform-configs/include/default.robot
+++ b/platform-configs/include/default.robot
@@ -430,6 +430,7 @@ ${DTS_TEST_HAS_EC}=                                 ${False}
 ...                                                 SeaBIOS->UEFI Transition=&{{ {"TEST_IS_COREBOOT": "true", "TEST_EFI_PRESENT": "false", "TEST_IS_SEABIOS": "true"} }}
 ...                                                 Dasharo (coreboot+UEFI) to Dasharo (Slim Bootloader+UEFI) Transition=&{{ {"TEST_IS_COREBOOT": "true"} }}
 ...                                                 Initial Deployment=&{{ {"TEST_BIOS_VENDOR": "proprietary", "TEST_USING_OPENSOURCE_EC_FIRM": "false"} }}
+...                                                 Fuse Platform=${{ {"TEST_MEI_CONF_PRESENT": "false"} }}
 # dict[workflow, dict[variable, value]]
 &{DTS_TEST_EXPORTS_PER_WORKFLOW}=                   &{DTS_TEST_EXPORTS_PER_WORKFLOW_BASE}
 # dict[tuple[workflow,release], dict[variable, value]]

--- a/platform-configs/novacustom-v540tnd.robot
+++ b/platform-configs/novacustom-v540tnd.robot
@@ -113,7 +113,9 @@ ${OPTIONS_LIB}=                                 options-lib_dcu
 &{DTS_TEST_VERSIONS}=
 ...                                             &{DTS_TEST_VERSIONS_BASE}
 ...                                             UEFI->Heads Transition=Dasharo (coreboot+UEFI) 0.9.0
+...                                             Fuse Platform=Dasharo (coreboot+UEFI) 1.0.0
 ${DTS_TEST_BOARD_MODEL}=                        V540TNx
-@{DTS_TEST_WORKFLOWS}=                          Initial Deployment    UEFI Update
+@{DTS_TEST_WORKFLOWS}=                          Initial Deployment
+...                                             UEFI Update    Fuse Platform
 @{DTS_TEST_WORKFLOW_PROFILES}=
 ...                                             ${{ ("UEFI Update", "DCR") }}

--- a/platform-configs/novacustom-v540tnd.robot
+++ b/platform-configs/novacustom-v540tnd.robot
@@ -119,3 +119,4 @@ ${DTS_TEST_BOARD_MODEL}=                        V540TNx
 ...                                             UEFI Update    Fuse Platform
 @{DTS_TEST_WORKFLOW_PROFILES}=
 ...                                             ${{ ("UEFI Update", "DCR") }}
+...                                             ${{ ("Fuse Platform", "DCR") }}

--- a/platform-configs/novacustom-v540tu.robot
+++ b/platform-configs/novacustom-v540tu.robot
@@ -121,6 +121,7 @@ ${DTS_TEST_BOARD_MODEL}=                V540TU
 @{DTS_TEST_WORKFLOW_PROFILES}=
 ...                                     ${{ ("UEFI->Heads Transition", "DPP") }}
 ...                                     ${{ ("UEFI Update", "DCR") }}
+...                                     ${{ ("Fuse Platform", "DCR") }}
 
 
 *** Keywords ***

--- a/platform-configs/novacustom-v540tu.robot
+++ b/platform-configs/novacustom-v540tu.robot
@@ -114,8 +114,10 @@ ${UNIGINE_SUPERPOSITION_RESULT_BAT}=    20.3    # FPS
 ...                                     &{DTS_TEST_VERSIONS_BASE}
 ...                                     UEFI->Heads Transition=Dasharo (coreboot+UEFI) 0.9.0
 ...                                     UEFI Update=Dasharo (coreboot+UEFI) 0.9.0
+...                                     Fuse Platform=Dasharo (coreboot+UEFI) 1.0.0
 ${DTS_TEST_BOARD_MODEL}=                V540TU
-@{DTS_TEST_WORKFLOWS}=                  Initial Deployment    UEFI Update    UEFI->Heads Transition
+@{DTS_TEST_WORKFLOWS}=                  Initial Deployment    UEFI Update
+...                                     UEFI->Heads Transition    Fuse Platform
 @{DTS_TEST_WORKFLOW_PROFILES}=
 ...                                     ${{ ("UEFI->Heads Transition", "DPP") }}
 ...                                     ${{ ("UEFI Update", "DCR") }}

--- a/platform-configs/novacustom-v560tnd.robot
+++ b/platform-configs/novacustom-v560tnd.robot
@@ -126,3 +126,4 @@ ${DTS_TEST_BOARD_MODEL}=                V560TNx
 ...                                     Fuse Platform
 @{DTS_TEST_WORKFLOW_PROFILES}=
 ...                                     ${{ ("UEFI Update", "DCR") }}
+...                                     ${{ ("Fuse Platform", "DCR") }}

--- a/platform-configs/novacustom-v560tnd.robot
+++ b/platform-configs/novacustom-v560tnd.robot
@@ -119,7 +119,10 @@ ${UNIGINE_SUPERPOSITION_RESULT_BAT}=    24.0    # FPS
 &{DTS_TEST_VERSIONS}=
 ...                                     &{DTS_TEST_VERSIONS_BASE}
 ...                                     UEFI->Heads Transition=Dasharo (coreboot+UEFI) 0.9.0
+...                                     Fuse Platform=Dasharo (coreboot+UEFI) 1.0.0
 ${DTS_TEST_BOARD_MODEL}=                V560TNx
-@{DTS_TEST_WORKFLOWS}=                  Initial Deployment    UEFI Update
+@{DTS_TEST_WORKFLOWS}=
+...                                     Initial Deployment    UEFI Update
+...                                     Fuse Platform
 @{DTS_TEST_WORKFLOW_PROFILES}=
 ...                                     ${{ ("UEFI Update", "DCR") }}

--- a/platform-configs/novacustom-v560tne.robot
+++ b/platform-configs/novacustom-v560tne.robot
@@ -91,7 +91,11 @@ ${UNIGINE_SUPERPOSITION_RESULT_BAT}=    26.2    # FPS
 ${OPTIONS_LIB}=                         options-lib_dcu
 
 # DTS E2E variables
+&{DTS_TEST_VERSIONS}=
+...                                     &{DTS_TEST_VERSIONS_BASE}
+...                                     Fuse Platform=Dasharo (coreboot+UEFI) 1.0.0
 ${DTS_TEST_BOARD_MODEL}=                V560TNx
 @{DTS_TEST_WORKFLOWS}=                  Initial Deployment    UEFI Update
+...                                     Fuse Platform
 @{DTS_TEST_WORKFLOW_PROFILES}=
 ...                                     ${{ ("UEFI Update", "DCR") }}

--- a/platform-configs/novacustom-v560tu.robot
+++ b/platform-configs/novacustom-v560tu.robot
@@ -100,8 +100,10 @@ ${OPTIONS_LIB}=                         options-lib_dcu
 ...                                     &{DTS_TEST_VERSIONS_BASE}
 ...                                     UEFI->Heads Transition=Dasharo (coreboot+UEFI) 0.9.0
 ...                                     UEFI Update=Dasharo (coreboot+UEFI) 0.9.0
+...                                     Fuse Platform=Dasharo (coreboot+UEFI) 1.0.0
 ${DTS_TEST_BOARD_MODEL}=                V560TU
-@{DTS_TEST_WORKFLOWS}=                  Initial Deployment    UEFI Update    UEFI->Heads Transition
+@{DTS_TEST_WORKFLOWS}=                  Initial Deployment    UEFI Update
+...                                     UEFI->Heads Transition    Fuse Platform
 @{DTS_TEST_WORKFLOW_PROFILES}=
 ...                                     ${{ ("UEFI->Heads Transition", "DPP") }}
 ...                                     ${{ ("UEFI Update", "DCR") }}

--- a/platform-configs/novacustom-v560tu.robot
+++ b/platform-configs/novacustom-v560tu.robot
@@ -107,3 +107,4 @@ ${DTS_TEST_BOARD_MODEL}=                V560TU
 @{DTS_TEST_WORKFLOW_PROFILES}=
 ...                                     ${{ ("UEFI->Heads Transition", "DPP") }}
 ...                                     ${{ ("UEFI Update", "DCR") }}
+...                                     ${{ ("Fuse Platform", "DCR") }}


### PR DESCRIPTION
To run tests:

```sh
robot -b cmd_logs.txt -v rte_ip:127.0.0.1 -v config:qemu \
            -L TRACE -v boot_dts_from_ipxe_shell:True \
            -v dts_ipxe_link:http://192.168.4.48:4321/dts.ipxe \
            -v snipeit:no \
            -v dts_config_ref:refs/heads/mtl-fuse-no-signature \
            -t "Create tests" dts/dts-e2e.robot
```

Results (`v560tne` has no profile as no platform is currently available for testing):

```text
==============================================================================
Dts-E2E
==============================================================================
Create tests                                                          | PASS |
------------------------------------------------------------------------------
E2E001: novacustom-v540tnd Fuse Platform - DCR                        | PASS |
------------------------------------------------------------------------------
E2E002: novacustom-v540tu Fuse Platform - DCR                         | PASS |
------------------------------------------------------------------------------
E2E003: novacustom-v560tnd Fuse Platform - DCR                        | PASS |
------------------------------------------------------------------------------
[ WARN ] Workflow isn't configured for profile verification.
E2E004: novacustom-v560tne Fuse Platform - DCR                        | PASS |
------------------------------------------------------------------------------
E2E005: novacustom-v560tu Fuse Platform - DCR                         | PASS |
------------------------------------------------------------------------------
Dts-E2E                                                               | PASS |
6 tests, 6 passed, 0 failed
==============================================================================
```

Logs: [log.html](https://github.com/user-attachments/files/22333457/log.html)


As of now we don't have way to set `FW_STORE_URL_DEV` from cmdline so you need to modify exports when running those those particular tests e.g.:

```diff
diff --git a/dts/dts-e2e.robot b/dts/dts-e2e.robot
index 7945ee069bcd..7e404ac24095 100644
--- a/dts/dts-e2e.robot
+++ b/dts/dts-e2e.robot
@@ -25,7 +25,9 @@ Create tests
     FOR    ${platform}    ${platform_variables}    IN    &{DTS_PLATFORM_VARIABLES}
         FOR    ${workflow}    IN    @{platform_variables}[DTS_TEST_WORKFLOWS]
             FOR    ${release}    IN    @{platform_variables}[DTS_TEST_WORKFLOW_RELEASES][${workflow}]
-                ${platform}    ${workflow}    ${release}
+                IF    "${workflow}" == "Fuse Platform"
+                    ${platform}    ${workflow}    ${release}
+                END
             END
         END
     END
diff --git a/platform-configs/include/default.robot b/platform-configs/include/default.robot
index a95bfef13f22..6066aee5c00a 100644
--- a/platform-configs/include/default.robot
+++ b/platform-configs/include/default.robot
@@ -421,6 +421,7 @@ ${DTS_TEST_HAS_EC}=                                 ${False}
 ...                                                 TEST_CPU_VERSION=${CPU}
 ...                                                 TEST_INTERNAL_PROGRAMMER_CHIPNAME=${INTERNAL_PROGRAMMER_CHIPNAME}
 ...                                                 TEST_USING_OPENSOURCE_EC_FIRM=${{"true" if ${DTS_TEST_HAS_EC} else "false" }}
+...                                                 FW_STORE_URL_DEV=192.168.4.48:8000
```

Or add it to `DTS_TEST_EXPORTS_PER_WORKFLOW_BASE` to use local `FW_STORE` only for `Fuse Platform` workflow if you want to run every test.
`mtl-fuse-no-signature` branch of dts-configs ref has only one difference and that is empty `platform_sign_key` as `rc` binaries available on cloud don't have signature files:

```diff
diff --git a/configs/notebook.json b/configs/notebook.json
index 2fd2492bb620..180183c432f2 100644
--- a/configs/notebook.json
+++ b/configs/notebook.json
@@ -5 +5 @@
-  "platform_sign_key": "customer-keys/novacustom/novacustom-open-source-firmware-release-1.x-key.asc customer-keys/novacustom/dasharo-release-0.9.x-for-novacustom-signing-key.asc",
+  "platform_sign_key": "",
```