### PR TITLE
fwupd-support: Add a dynamic semiauto skip

### DIFF
--- a/dasharo-compatibility/fwupd-support.robot
+++ b/dasharo-compatibility/fwupd-support.robot
@@ -108,6 +108,9 @@ Fwupd Devices Detected Linux
     Should Contain All    ${out}    @{devices}
 
 Fwupd Local Firmware Update Linux
+    IF    "${POWER_CTRL}"=="none" and @{TEST_TAGS} and "semiauto" not in @{TEST_TAGS}
+        Skip    Skipping semiauto test
+    END
     ${cabinet_given}=    Run Keyword And Return Status
     ...    Get Environment Variable    ${CABINET_ENVVAR}
     IF    not ${cabinet_given}
@@ -127,6 +130,7 @@ Fwupd Local Firmware Update Linux
     ...    AC power
     ...    AC is disconnected, connect AC. (Or its a bug - AC it not detected if internal battery is full. Discharge the battery a bit and try again.)\n\n
     Should Contain    ${out}    Successfully installed firmware
+    # fwupd will automatically reboot the system
     IF    "${POWER_CTRL}"=="none"
         Execute Manual Step    The laptop might stay powered off after update. Power it back on.
     END


### PR DESCRIPTION
~~Otherwise after a reboot a capsule update will be run and it can take a while~~
The essence of the original change was already merged in some other PR.
What's missing is dynamically skipping the test which could turn into semiauto based on the platform configs. This PR now adds that