### PR TITLE
disk-io.robot: Fix test IDs

### DIFF
--- a/dasharo-performance/disk-io.robot
+++ b/dasharo-performance/disk-io.robot
@@ -190,7 +190,7 @@ DIO008.201 Random Write Performance (Ubuntu) (Battery)
     ...    ${rand_write_nonque} >= ${UBU_RAND_WRITE_NONQUE}*0.85
     ...    Random Write BW Non-Queued is below expected
 
-DIO001.003 Sequential Read Performance (Windows) (AC)
+DIO001.301 Sequential Read Performance (Windows) (AC)
     [Documentation]    Check various scenarios of single threaded read
     ...    performance, while connected to power supply unit. (Windows)
     Skip If    not ${TESTS_IN_WINDOWS_SUPPORT}
@@ -203,7 +203,7 @@ DIO001.003 Sequential Read Performance (Windows) (AC)
     Run FIO On Windows    sequential_with_queues_mt
     ...    --rw=read --bs=1M --iodepth=32 --numjobs=${DEF_THREADS_TOTAL} --size=4G
 
-DIO001.004 Sequential Read Performance (Windows) (Battery)
+DIO002.301 Sequential Read Performance (Windows) (Battery)
     [Documentation]    Check various scenarios of single threaded read
     ...    performance, while powered by inbuilt battery. (Windows)
     Skip If    not ${TESTS_IN_WINDOWS_SUPPORT}
@@ -218,7 +218,7 @@ DIO001.004 Sequential Read Performance (Windows) (Battery)
     Run FIO On Windows    sequential_with_queues_mt
     ...    --rw=read --bs=1M --iodepth=32 --numjobs=${DEF_THREADS_TOTAL} --size=4G
 
-DIO002.003 Sequential Write Performance (Windows) (AC)
+DIO003.301 Sequential Write Performance (Windows) (AC)
     [Documentation]    Check various scenarios of multi threaded write
     ...    performance, while connected to power supply unit. (Windows)
     Skip If    not ${TESTS_IN_WINDOWS_SUPPORT}
@@ -233,7 +233,7 @@ DIO002.003 Sequential Write Performance (Windows) (AC)
     Power Cycle Into Ubuntu    # as of march 4 2025, running tests on novacustom is rather
     # primitive and default starting point is ubuntu
 
-DIO002.004 Sequential Write Performance (Windows) (Battery)
+DIO004.301 Sequential Write Performance (Windows) (Battery)
     [Documentation]    Check various scenarios of multi threaded write
     ...    performance, while powered by inbuilt battery. (Windows)
     Skip If    not ${TESTS_IN_WINDOWS_SUPPORT}
@@ -249,7 +249,7 @@ DIO002.004 Sequential Write Performance (Windows) (Battery)
     ...    --rw=write --bs=1M --iodepth=32 --numjobs=${DEF_THREADS_TOTAL} --size=4G
     Power Cycle Into Ubuntu
 
-DIO003.003 Random Read Performance (Windows) (AC)
+DIO005.301 Random Read Performance (Windows) (AC)
     [Documentation]    Check various scenarios of single threaded write
     ...    performance, while connected to power supply unit. (Windows)
     Skip If    not ${TESTS_IN_WINDOWS_SUPPORT}
@@ -259,7 +259,7 @@ DIO003.003 Random Read Performance (Windows) (AC)
     ...    --rw=randread --bs=4K --iodepth=32 --numjobs=1 --size=10G
     Power Cycle Into Ubuntu
 
-DIO003.004 Random Read Performance (Windows) (Battery)
+DIO006.301 Random Read Performance (Windows) (Battery)
     [Documentation]    Check various scenarios of single threaded write
     ...    performance, while powered by inbuilt battery. (Windows)
     Skip If    not ${TESTS_IN_WINDOWS_SUPPORT}
@@ -271,7 +271,7 @@ DIO003.004 Random Read Performance (Windows) (Battery)
     ...    --rw=randread --bs=4K --iodepth=32 --numjobs=1 --size=10G
     Power Cycle Into Ubuntu
 
-DIO004.003 Random Write Performance (Windows) (AC)
+DIO007.301 Random Write Performance (Windows) (AC)
     [Documentation]    Check various scenarios of multi threaded write
     ...    performance, while connected to power supply unit. (Windows)
     Skip If    not ${TESTS_IN_WINDOWS_SUPPORT}
@@ -281,7 +281,7 @@ DIO004.003 Random Write Performance (Windows) (AC)
     ...    --rw=randwrite --bs=4K --iodepth=32 --numjobs=4 --size=10G
     Power Cycle Into Ubuntu
 
-DIO004.004 Random Write Performance (Windows) (Battery)
+DIO008.301 Random Write Performance (Windows) (Battery)
     [Documentation]    Check various scenarios of multi threaded write
     ...    performance, while powered by inbuilt battery.(Windows)
     Skip If    not ${TESTS_IN_WINDOWS_SUPPORT}

--- a/test_cases.json
+++ b/test_cases.json
@@ -2410,48 +2410,111 @@
     "doc": {
       "_id": "DIO001.202",
       "name": "Sequential Read Performance (Ubuntu) (Battery)",
-      "module": "Dasharo Performance"
+      "module": "Dasharo Performance",
+      "changed_to": "DIO002.201"
     }
   },
   {
     "doc": {
       "_id": "DIO002.201",
       "name": "Sequential Write Performance (Ubuntu) (AC)",
-      "module": "Dasharo Performance"
+      "module": "Dasharo Performance",
+      "changed_to": "DIO003.201"
     }
   },
   {
     "doc": {
       "_id": "DIO002.202",
       "name": "Sequential Write Performance (Ubuntu) (Battery)",
-      "module": "Dasharo Performance"
+      "module": "Dasharo Performance",
+      "changed_to": "DIO004.201"
     }
   },
   {
     "doc": {
       "_id": "DIO003.201",
       "name": "Random Read Performance (Ubuntu) (AC)",
-      "module": "Dasharo Performance"
+      "module": "Dasharo Performance",
+      "changed_to": "DIO005.201"
     }
   },
   {
     "doc": {
       "_id": "DIO003.202",
       "name": "Random Read Performance (Ubuntu) (Battery)",
-      "module": "Dasharo Performance"
+      "module": "Dasharo Performance",
+      "changed_to": "DIO006.201"
     }
   },
   {
     "doc": {
       "_id": "DIO004.201",
       "name": "Random Write Performance (Ubuntu) (AC)",
-      "module": "Dasharo Performance"
+      "module": "Dasharo Performance",
+      "changed_to": "DIO007.201"
     }
   },
   {
     "doc": {
       "_id": "DIO004.202",
       "name": "Random Write Performance (Ubuntu) (Battery)",
+      "module": "Dasharo Performance",
+      "changed_to": "DIO008.201"
+    }
+  },
+  {
+    "doc": {
+      "_id": "DIO001.301",
+      "name": "Sequential Read Performance (Windows) (AC)",
+      "module": "Dasharo Performance"
+    }
+  },
+  {
+    "doc": {
+      "_id": "DIO002.301",
+      "name": "Sequential Read Performance (Windows) (Battery)",
+      "module": "Dasharo Performance"
+    }
+  },
+  {
+    "doc": {
+      "_id": "DIO003.301",
+      "name": "Sequential Write Performance (Windows) (AC)",
+      "module": "Dasharo Performance"
+    }
+  },
+  {
+    "doc": {
+      "_id": "DIO004.301",
+      "name": "Sequential Write Performance (Windows) (Battery)",
+      "module": "Dasharo Performance"
+    }
+  },
+  {
+    "doc": {
+      "_id": "DIO005.301",
+      "name": "Random Read Performance (Windows) (AC)",
+      "module": "Dasharo Performance"
+    }
+  },
+  {
+    "doc": {
+      "_id": "DIO006.301",
+      "name": "Random Read Performance (Windows) (Battery)",
+      "module": "Dasharo Performance"
+    }
+  },
+  {
+    "doc": {
+      "_id": "DIO007.301",
+      "name": "Random Write Performance (Windows) (AC)",
+      "module": "Dasharo Performance"
+    }
+  },
+  {
+    "doc": {
+      "_id": "DIO008.301",
+      "name": "Random Write Performance (Windows) (Battery)",
       "module": "Dasharo Performance"
     }
   },

--- a/test_cases.json
+++ b/test_cases.json
@@ -2416,6 +2416,13 @@
   },
   {
     "doc": {
+      "_id": "DIO001.301",
+      "name": "Sequential Read Performance (Windows) (AC)",
+      "module": "Dasharo Performance"
+    }
+  },
+  {
+    "doc": {
       "_id": "DIO002.201",
       "name": "Sequential Write Performance (Ubuntu) (AC)",
       "module": "Dasharo Performance",
@@ -2428,6 +2435,13 @@
       "name": "Sequential Write Performance (Ubuntu) (Battery)",
       "module": "Dasharo Performance",
       "changed_to": "DIO004.201"
+    }
+  },
+  {
+    "doc": {
+      "_id": "DIO002.301",
+      "name": "Sequential Read Performance (Windows) (Battery)",
+      "module": "Dasharo Performance"
     }
   },
   {
@@ -2448,6 +2462,13 @@
   },
   {
     "doc": {
+      "_id": "DIO003.301",
+      "name": "Sequential Write Performance (Windows) (AC)",
+      "module": "Dasharo Performance"
+    }
+  },
+  {
+    "doc": {
       "_id": "DIO004.201",
       "name": "Random Write Performance (Ubuntu) (AC)",
       "module": "Dasharo Performance",
@@ -2460,27 +2481,6 @@
       "name": "Random Write Performance (Ubuntu) (Battery)",
       "module": "Dasharo Performance",
       "changed_to": "DIO008.201"
-    }
-  },
-  {
-    "doc": {
-      "_id": "DIO001.301",
-      "name": "Sequential Read Performance (Windows) (AC)",
-      "module": "Dasharo Performance"
-    }
-  },
-  {
-    "doc": {
-      "_id": "DIO002.301",
-      "name": "Sequential Read Performance (Windows) (Battery)",
-      "module": "Dasharo Performance"
-    }
-  },
-  {
-    "doc": {
-      "_id": "DIO003.301",
-      "name": "Sequential Write Performance (Windows) (AC)",
-      "module": "Dasharo Performance"
     }
   },
   {


### PR DESCRIPTION
The IDs were not correct according to  https://github.com/Dasharo/open-source-firmware-validation/blob/develop/docs/adding-and-naming-test-cases.md#tests-naming-convention  and were uploaded to the dashboard that way. Not all test cases were documented in `test_cases.json`. This PR hopefully fixes that if the database accepts such interwoven changes