### PR TITLE
linux-packages-playbook.yaml: dont mask systemd suspend

### DIFF
--- a/os-config/ansible/linux-packages-playbook.yaml
+++ b/os-config/ansible/linux-packages-playbook.yaml
@@ -46,8 +46,6 @@
       ansible.builtin.command: gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-battery-timeout 0
     - name: Gnome turn off automatic screen lock
       ansible.builtin.command: gsettings set org.gnome.desktop.session idle-delay 0
-    - name: Systemd turn off suspend
-      ansible.builtin.command: systemctl mask suspend.target
 
 - name: OS specific tasks
   hosts: host


### PR DESCRIPTION
Masking it makes suspending in conventional ways impossible (like from the UI).