### PR TITLE
keywords.robot: Firmware Version Verification From Binary fixed.

### DIFF
--- a/dasharo-compatibility/wifi-bluetooth-support.robot
+++ b/dasharo-compatibility/wifi-bluetooth-support.robot
@@ -190,7 +190,7 @@ Wi-Fi Scanning
     IF    "${BOOTED_OS_ID}"=="${ENV_ID_UBUNTU}"
         Detect Or Install Package    pciutils
     END
-    ${current_card}=    Execute Command In Terminal    lspci | grep "Network controller: | awk -F": " '{print $2}"
+    ${current_card}=    Execute Command In Terminal    lspci | grep "Network controller:"
     Exit From Root User
     Log To Console    The test passed for the ${current_card} wireless card
     Log    The test passed for the ${current_card} wireless card    WARN

--- a/keywords.robot
+++ b/keywords.robot
@@ -1281,7 +1281,7 @@ Firmware Version Verification From Binary
     [Documentation]    Check whether the DUT firmware version is the same as it
     ...    is expected by checking it with dmidecode and comparing
     ...    with a value get from binary.
-    Read Firmware    ${TEMPDIR}${/}coreboot.rom    ${FLASHROM_FLAGS}
+    Read Firmware    ${TEMPDIR}${/}coreboot.rom
     Power Cycle On
     ${version}=    Get Firmware Version
     ${coreboot_version}=    Get Firmware Version From Binary    ${TEMPDIR}${/}coreboot.rom

--- a/lib/flash.robot
+++ b/lib/flash.robot
@@ -173,6 +173,7 @@ Read Firmware
     [Arguments]    ${file}
 
     IF    '${FLASHING_METHOD}' == 'external'
+        Rte Gpio Set    1    low
         Rte Flash Read    ${file}
     ELSE IF    '${FLASHING_METHOD}' == 'internal'
         # TODO

--- a/lib/flash.robot
+++ b/lib/flash.robot
@@ -177,6 +177,9 @@ Read Firmware
             Rte Gpio Set    ${APU_FLASH_WP_GPIO}    low
         END
         Rte Flash Read    ${file}
+        IF    '${MANUFACTURER}' == 'PC Engines' and '${APU_FLASH_WP_GPIO}' != '${TBD}'
+            Rte Gpio Set    ${APU_FLASH_WP_GPIO}    high-z
+        END
     ELSE IF    '${FLASHING_METHOD}' == 'internal'
         # TODO
         Power On

--- a/lib/flash.robot
+++ b/lib/flash.robot
@@ -173,7 +173,9 @@ Read Firmware
     [Arguments]    ${file}
 
     IF    '${FLASHING_METHOD}' == 'external'
-        Rte Gpio Set    1    low
+        IF    '${MANUFACTURER}' == 'PC Engines' and '${APU_FLASH_WP_GPIO}' != '${TBD}'
+            Rte Gpio Set    ${APU_FLASH_WP_GPIO}    low
+        END
         Rte Flash Read    ${file}
     ELSE IF    '${FLASHING_METHOD}' == 'internal'
         # TODO

--- a/platform-configs/include/default.robot
+++ b/platform-configs/include/default.robot
@@ -428,6 +428,7 @@ ${ZIP_MULTI_COMPRESSION}=                           ${TBD}
 ${ZIP_MULTI_DECOMPRESSION}=                         ${TBD}
 ${FAN_RPM_MEASUREMENT_SENSOR_MODULE}=               ${TBD}
 ${DEVICE_DETECT_TEST_IN_SCOPE}=                     ${FALSE}
+${APU_FLASH_WP_GPIO}=                               ${TBD}
 
 #### DTS E2E variables, should start with DTS_TEST_ ####
 # Base fw version set for every workflow

--- a/platform-configs/pcengines-apu2.robot
+++ b/platform-configs/pcengines-apu2.robot
@@ -3,12 +3,13 @@ Resource    include/pcengines.robot
 
 
 *** Variables ***
-${DMIDECODE_PRODUCT_NAME}=      apu2
-${FLASH_VERIFY_METHOD}=         none
-${PLATFORM_CPU_SPEED}=          1.0
-${PLATFORM_RAM_SPEED}=          1333
-${PLATFORM_RAM_SIZE}=           4096
-${BIOS_LOCK_SUPPORT}=           ${True}
+${DMIDECODE_PRODUCT_NAME}=          apu2
+${DMIDECODE_FIRMWARE_VERSION}=      Dasharo (coreboot+UEFI) v0.9.1-rc3
+${FLASH_VERIFY_METHOD}=             none
+${PLATFORM_CPU_SPEED}=              1.0
+${PLATFORM_RAM_SPEED}=              1333
+${PLATFORM_RAM_SIZE}=               4096
+${BIOS_LOCK_SUPPORT}=               ${True}
 
 # DTS E2E variables
 

--- a/platform-configs/pcengines-apu3.robot
+++ b/platform-configs/pcengines-apu3.robot
@@ -3,6 +3,8 @@ Resource    include/pcengines.robot
 
 
 *** Variables ***
-${DMIDECODE_PRODUCT_NAME}=      apu3
+${DMIDECODE_PRODUCT_NAME}=          apu3
+${DMIDECODE_FIRMWARE_VERSION}=      Dasharo (coreboot+UEFI) v0.9.1-rc3
+${FLASH_VERIFY_METHOD}=             none
 
 # DTS E2E variables

--- a/platform-configs/pcengines-apu4.robot
+++ b/platform-configs/pcengines-apu4.robot
@@ -3,6 +3,8 @@ Resource    include/pcengines.robot
 
 
 *** Variables ***
-${DMIDECODE_PRODUCT_NAME}=      apu4
+${DMIDECODE_PRODUCT_NAME}=          apu4
+${DMIDECODE_FIRMWARE_VERSION}=      Dasharo (coreboot+UEFI) v0.9.1-rc3
+${FLASH_VERIFY_METHOD}=             none
 
 # DTS E2E variables

--- a/platform-configs/pcengines-apu6.robot
+++ b/platform-configs/pcengines-apu6.robot
@@ -3,6 +3,8 @@ Resource    include/pcengines.robot
 
 
 *** Variables ***
-${DMIDECODE_PRODUCT_NAME}=      apu6
+${DMIDECODE_PRODUCT_NAME}=          apu6
+${DMIDECODE_FIRMWARE_VERSION}=      Dasharo (coreboot+UEFI) v0.9.1-rc3
+${FLASH_VERIFY_METHOD}=             none
 
 # DTS E2E variables

--- a/platform-configs/pcengines-apu6.robot
+++ b/platform-configs/pcengines-apu6.robot
@@ -6,5 +6,6 @@ Resource    include/pcengines.robot
 ${DMIDECODE_PRODUCT_NAME}=          apu6
 ${DMIDECODE_FIRMWARE_VERSION}=      Dasharo (coreboot+UEFI) v0.9.1-rc3
 ${FLASH_VERIFY_METHOD}=             none
+${APU_FLASH_WP_GPIO}=               1
 
 # DTS E2E variables

--- a/variables.robot
+++ b/variables.robot
@@ -45,7 +45,7 @@ ${OS_UBUNTU}=               ubuntu
 &{RTE12}=                   ip=192.168.10.175
 ...                         platform=apu5
 ...                         platform_vendor=PC Engines
-&{RTE13}=                   ip=192.168.10.176
+&{RTE13}=                   ip=192.168.10.249
 ...                         platform=apu6
 ...                         platform_vendor=PC Engines
 &{RTE14}=                   ip=192.168.10.200


### PR DESCRIPTION
${FLASHROM_FLAGS} removed from Firmware Version Verification From Binary

PC Engines APU2, 3, 4, 6 platforms configs expanded.