### PR TITLE
Btg key validator test

### DIFF
--- a/dts/dts-e2e.robot
+++ b/dts/dts-e2e.robot
@@ -414,6 +414,68 @@ E2E015.001 Verify that entering DTS menu in FUM works
     Wait For Checkpoint And Write    ${DTS_ASK_FOR_CHOICE_PROMPT}    ${DTS_FUM_MENU_OPT}
     Wait For Checkpoint    ${DTS_CHECKPOINT}
 
+################################################################################
+# IBG signature tests
+################################################################################
+
+E2E016.001 Verify that btg_key_validator prints expected error on unknown platform
+    [Documentation]    Call btg_key_validator on platform that doesn't support
+    ...    fusing
+    ${out}    ${rc}=    Execute Command In Terminal And Return Output And RC
+    ...    btg_key_validator
+    Should Contain    ${out}    Platform configuration is missing expected key hash
+    Should Not Be Equal As Integers    ${rc}    0
+
+E2E016.002 Verify that btg_key_validator prints expected error on failure to read flash
+    [Documentation]    Call btg_key_validator on platform that doesn't support
+    ...    reading flash
+    ${out}    ${rc}=    Execute Command In Terminal And Return Output And RC
+    ...    btg_key_validator --key-hash z
+    Should Contain    ${out}    Failed to read flash
+    Should Not Be Equal As Integers    ${rc}    0
+
+E2E016.003 Verify that btg_key_validator prints expected error on failure to export manifest
+    [Documentation]    Call btg_key_validator on malformed binary
+    ${out}    ${rc}=    Execute Command In Terminal And Return Output And RC
+    ...    touch /tmp/test_binary && btg_key_validator --key-hash z --file /tmp/test_binary
+    Should Contain    ${out}    Failed to export key manifest
+    Should Not Be Equal As Integers    ${rc}    0
+
+E2E016.004 Verify that btg_key_validator prints expected error if hashes don't match
+    [Documentation]    Call btg_key_validator on binary signed with unexpected key
+    Execute Command In Terminal Should Succeed
+    ...    wget -O /tmp/test_binary https://dl.3mdeb.com/open-source-firmware/Dasharo/novacustom_v5x0_mtl/novacustom_mtl_igpu/novacustom_v540tu_mtl/uefi/v1.0.0/novacustom_v54x_mtl_igpu_v1.0.0_btg_provisioned.cap
+    ${out}    ${rc}=    Execute Command In Terminal And Return Output And RC
+    ...    btg_key_validator --key-hash z --file /tmp/test_binary
+    Should Contain    ${out}    Firmware signature doesn't match expected hash
+    Should Not Be Equal As Integers    ${rc}    0
+
+E2E016.005 Verify that btg_key_validator prints expected message if hashes match
+    [Documentation]    Call btg_key_validator on binary signed with expected key
+    Execute Command In Terminal Should Succeed
+    ...    wget -O /tmp/test_binary https://dl.3mdeb.com/open-source-firmware/Dasharo/novacustom_v5x0_mtl/novacustom_mtl_igpu/novacustom_v540tu_mtl/uefi/v1.0.0/novacustom_v54x_mtl_igpu_v1.0.0_btg_provisioned.cap
+    ${out}    ${rc}=    Execute Command In Terminal And Return Output And RC
+    ...    btg_key_validator --key-hash e64b6b0e82c68fecc58f750d3696c26e1c98bf9e3149c81f3b2ed775eb9d2c157a99c103c62c44c0cdc61be971caeae1 --file /tmp/test_binary
+    Should Contain    ${out}    Firmware is signed with expected key hash
+    Should Be Equal As Integers    ${rc}    0
+
+E2E016.006 Verify that fuse workflow uses and verifies btg_key_validator
+    [Documentation]    Run fuse workflow and simulate btg_key_validator failure
+    Export Shell Variables For Emulation
+    ...    Fuse Platform
+    ...    DCR
+    ...    ${DTS_PLATFORM_VARIABLES}[novacustom-v540tu]
+    ...    ${DTS_CONFIG_REF}
+    Execute Command In Terminal    export TEST_KEY_VALIDATOR_RESULT="fail_hash"
+    Write Into Terminal    dts-boot
+
+    Set DUT Response Timeout    120s
+
+    Wait For Checkpoint And Write Bare    ${DTS_CHECKPOINT}    ${DTS_FUSE_OPT}
+    Wait For Checkpoint And Write    ${DTS_FUSE_WARN}    Y
+    Wait For Checkpoint    Firmware signature doesn't match expected hash
+    Wait For Checkpoint    ${ERROR_LOGS_QUESTION}
+
 
 *** Keywords ***
 # robocop: disable:0919

--- a/dts/profiles/novacustom-v540tnd Fuse Platform - DCR.profile
+++ b/dts/profiles/novacustom-v540tnd Fuse Platform - DCR.profile
@@ -27,6 +27,13 @@ fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 0
 setpci -s 00:16.0 42.B 0
 fsread_tool test -e /sys/class/power_supply/AC/online 0
 fsread_tool cat /sys/class/power_supply/AC/online 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+btg_key_validator --file /tmp/biosupdate --key-hash e64b6b0e82c68fecc58f750d3696c26e1c98bf9e3149c81f3b2ed775eb9d2c157a99c103c62c44c0cdc61be971caeae1 0
 cap_upd_tool /tmp/biosupdate 0
 reboot  0
 dmidecode  0

--- a/dts/profiles/novacustom-v540tu Fuse Platform - DCR.profile
+++ b/dts/profiles/novacustom-v540tu Fuse Platform - DCR.profile
@@ -27,6 +27,13 @@ fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 0
 setpci -s 00:16.0 42.B 0
 fsread_tool test -e /sys/class/power_supply/AC/online 0
 fsread_tool cat /sys/class/power_supply/AC/online 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+btg_key_validator --file /tmp/biosupdate --key-hash e64b6b0e82c68fecc58f750d3696c26e1c98bf9e3149c81f3b2ed775eb9d2c157a99c103c62c44c0cdc61be971caeae1 0
 cap_upd_tool /tmp/biosupdate 0
 reboot  0
 dmidecode  0

--- a/dts/profiles/novacustom-v560tnd Fuse Platform - DCR.profile
+++ b/dts/profiles/novacustom-v560tnd Fuse Platform - DCR.profile
@@ -27,6 +27,13 @@ fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 0
 setpci -s 00:16.0 42.B 0
 fsread_tool test -e /sys/class/power_supply/AC/online 0
 fsread_tool cat /sys/class/power_supply/AC/online 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+btg_key_validator --file /tmp/biosupdate --key-hash e64b6b0e82c68fecc58f750d3696c26e1c98bf9e3149c81f3b2ed775eb9d2c157a99c103c62c44c0cdc61be971caeae1 0
 cap_upd_tool /tmp/biosupdate 0
 reboot  0
 dmidecode  0

--- a/dts/profiles/novacustom-v560tu Fuse Platform - DCR.profile
+++ b/dts/profiles/novacustom-v560tu Fuse Platform - DCR.profile
@@ -27,6 +27,13 @@ fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 0
 setpci -s 00:16.0 42.B 0
 fsread_tool test -e /sys/class/power_supply/AC/online 0
 fsread_tool cat /sys/class/power_supply/AC/online 0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+btg_key_validator --file /tmp/biosupdate --key-hash e64b6b0e82c68fecc58f750d3696c26e1c98bf9e3149c81f3b2ed775eb9d2c157a99c103c62c44c0cdc61be971caeae1 0
 cap_upd_tool /tmp/biosupdate 0
 reboot  0
 dmidecode  0

--- a/lib/terminal.robot
+++ b/lib/terminal.robot
@@ -332,6 +332,32 @@ Execute Command In Terminal And Return RC
     ${rc}=    Execute Command In Terminal    echo $?    ${timeout}
     RETURN    ${rc}
 
+Execute Command In Terminal And Return Output And RC
+    [Documentation]    Universal keyword to execute command regardless of the
+    ...    used method of connection to the DUT (Telnet or SSH). The DUT Response
+    ...    Timeout is changed to ``${timeout}`` and not restored.
+    ...
+    ...    === Requirements ===
+    ...    The command prompt has to be set using ``Set Prompt For Terminal``
+    ...
+    ...    === Arguments ===
+    ...    - ``${command}``: ``string`` - The command to execute
+    ...    - ``${timeout}``: ``string`` = ``30s`` - The DUT Response Timeout for
+    ...    \ executing the command
+    ...
+    ...    === Return Value ===
+    ...    ``string`` - The full command output, or up to the time ``${timeout}``
+    ...    passes.
+    ...    ``string`` - Return code of the executed function (as returned by $?)
+    ...
+    ...    === Effects ===
+    ...    The ``${command}`` is written to the terminal and the keyword waits
+    ...    until the execution ends or ``${timeout}`` passes.
+    [Arguments]    ${command}    ${timeout}=30s
+    ${out}=    Execute Command In Terminal    ${command}    ${timeout}
+    ${rc}=    Execute Command In Terminal    echo $?    ${timeout}
+    RETURN    ${out}    ${rc}
+
 Execute Command In Terminal Should Succeed
     [Documentation]    Universal keyword to execute command regardless of the
     ...    used method of connection to the DUT (Telnet or SSH). The DUT Response


### PR DESCRIPTION
Related to: https://github.com/Dasharo/dts-scripts/pull/140

```
$ robot -b cmd_logs.txt -v rte_ip:127.0.0.1 -v config:qemu \
      -L TRACE -v boot_dts_from_ipxe_shell:True \
      -v dts_ipxe_link:http://192.168.4.48:4321/dts.ipxe \
      -v snipeit:no -v dts_config_ref:refs/heads/add-intel-btg-hash-test \
      -t "Create Tests" -t "E2E016.0*" dts/dts-e2e.robot
==============================================================================
Dts-E2E
==============================================================================
Create tests                                                          | PASS |
------------------------------------------------------------------------------
E2E016.001 Verify that btg_key_validator prints expected error on ... | PASS |
------------------------------------------------------------------------------
E2E016.002 Verify that btg_key_validator prints expected error on ... | PASS |
------------------------------------------------------------------------------
E2E016.003 Verify that btg_key_validator prints expected error on ... | PASS |
------------------------------------------------------------------------------
E2E016.004 Verify that btg_key_validator prints expected error if ... | PASS |
------------------------------------------------------------------------------
E2E016.005 Verify that btg_key_validator prints expected message i... | PASS |
------------------------------------------------------------------------------
E2E016.006 Verify that fuse workflow uses and verifies btg_key_val... | PASS |
------------------------------------------------------------------------------
E2E001: novacustom-v540tu Fuse Platform - DCR                         | PASS |
------------------------------------------------------------------------------
E2E002: novacustom-v560tu Fuse Platform - DCR                         | PASS |
------------------------------------------------------------------------------
Dts-E2E                                                               | PASS |
==============================================================================
```