### PR TITLE
dts: msi-pro-z690-a-wifi-ddr4: regenerate profiles

### DIFF
--- a/dts/profiles/msi-pro-z690-a-wifi-ddr4 Initial Deployment - DCR.profile
+++ b/dts/profiles/msi-pro-z690-a-wifi-ddr4 Initial Deployment - DCR.profile
@@ -73,6 +73,9 @@ fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 0
 setpci -s 00:16.0 42.B 0
 cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
 cbfstool /tmp/biosupdate layout -w 0
+cbfstool /tmp/biosupdate print -r COREBOOT 0
+flashrom -p internal -r /tmp/rom.bin --ifd -i bios 0
+cbfstool /tmp/biosupdate write -r ROMHOLE -f /tmp/romhole.bin -u 0
 flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 1
 cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
 dmidecode -s system-uuid 0

--- a/dts/profiles/msi-pro-z690-a-wifi-ddr4 Initial Deployment - DPP.profile
+++ b/dts/profiles/msi-pro-z690-a-wifi-ddr4 Initial Deployment - DPP.profile
@@ -74,6 +74,7 @@ fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 0
 setpci -s 00:16.0 42.B 0
 cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
 cbfstool /tmp/biosupdate layout -w 0
+cbfstool /tmp/biosupdate print -r COREBOOT 0
 flashrom -p internal -r /tmp/rom.bin --ifd -i bios 0
 cbfstool /tmp/biosupdate write -r ROMHOLE -f /tmp/romhole.bin -u 0
 flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 1

--- a/dts/profiles/msi-pro-z690-a-wifi-ddr4 UEFI Update - DCR.profile
+++ b/dts/profiles/msi-pro-z690-a-wifi-ddr4 UEFI Update - DCR.profile
@@ -22,6 +22,12 @@ flashrom -p internal --flash-name 0
 flashrom -p internal --flash-size 0
 fsread_tool test -e /sys/class/power_supply/AC/online 1
 flashrom -p internal 0
+cbfstool /tmp/biosupdate layout -w 0
+cbfstool /tmp/biosupdate print -r COREBOOT 0
+flashrom -p internal -r /tmp/rom.bin --ifd -i bios 0
+cbfstool /tmp/rom.bin layout -w 0
+cbfstool /tmp/rom.bin read -r ROMHOLE -f /tmp/romhole.bin 0
+cbfstool /tmp/biosupdate write -r ROMHOLE -f /tmp/romhole.bin -u 0
 flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
 cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
 cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 0
@@ -31,7 +37,6 @@ cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config
 flashrom -p internal 0
 ifdtool -d /tmp/biosupdate 1
 fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 1
-cbmem -1 0
 cbmem -1 0
 flashrom -p internal -N --ifd -i bios -r /tmp/bios.bin 0
 cbfstool /tmp/bios.bin layout -w 0

--- a/dts/profiles/msi-pro-z690-a-wifi-ddr4 UEFI Update - DPP.profile
+++ b/dts/profiles/msi-pro-z690-a-wifi-ddr4 UEFI Update - DPP.profile
@@ -1,4 +1,3 @@
-https://github.com/Dasharo/open-source-firmware-validation/pull/1166#issuecomment-3626438373
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0
 dmidecode -s baseboard-product-name 0
@@ -23,26 +22,6 @@ dmidecode -s bios-version 0
 flashrom -p internal --flash-name 0
 flashrom -p internal --flash-size 0
 fsread_tool test -e /sys/class/power_supply/AC/online 1
-flashrom -p internal 0
-flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i SMMSTORE 0
-cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin 0
-cbfstool /tmp/biosupdate write -r SMMSTORE -f /tmp/smmstore.bin -u 0
-flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 0
-cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
-cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0
-flashrom -p internal 0
-ifdtool -d /tmp/biosupdate 0
-fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 1
-cbmem -1 0
-cbmem -1 0
-flashrom -p internal -N --ifd -i bios -r /tmp/bios.bin 0
-cbfstool /tmp/bios.bin layout -w 0
-cbfstool /tmp/biosupdate layout -w 0
-futility show /tmp/biosupdate 0
-flashrom -p internal --ifd -i bios -r /tmp/bios.bin 0
-futility show /tmp/bios.bin 0
-flashrom -p internal -N --ifd -i fd -w /tmp/biosupdate 0
-flashrom -p internal --ifd -i bios -i fd -i me -w /tmp/biosupdate 0
-flashrom -p internal --ifd -i bios -i fd -i me -w /tmp/biosupdate 0
+cap_upd_tool /tmp/biosupdate 0
 reboot  0
 dmidecode  0

--- a/dts/profiles/msi-pro-z690-a-wifi-ddr4 UEFI->Heads Transition - DPP.profile
+++ b/dts/profiles/msi-pro-z690-a-wifi-ddr4 UEFI->Heads Transition - DPP.profile
@@ -1,4 +1,3 @@
-# Couldn't verify: https://github.com/Dasharo/dasharo-issues/issues/1533
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0
 dmidecode -s baseboard-product-name 0
@@ -31,12 +30,11 @@ flashrom -p internal 0
 ifdtool -d /tmp/biosupdate 0
 fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 1
 cbmem -1 0
-cbmem -1 0
 flashrom -p internal -N --ifd -i bios -r /tmp/bios.bin 0
 cbfstool /tmp/bios.bin layout -w 0
 cbfstool /tmp/biosupdate layout -w 0
 flashrom -p internal -N --ifd -i fd -w /tmp/biosupdate 0
-flashrom -p internal --ifd -i bios -i fd -w /tmp/biosupdate 0
-flashrom -p internal --ifd -i bios -i fd -w /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -i fd -i me -w /tmp/biosupdate 0
+flashrom -p internal --ifd -i bios -i fd -i me -w /tmp/biosupdate 0
 reboot  0
 dmidecode  0

--- a/dts/profiles/msi-pro-z690-a-wifi-ddr4 UEFI->Heads Transition - DPP.profile
+++ b/dts/profiles/msi-pro-z690-a-wifi-ddr4 UEFI->Heads Transition - DPP.profile
@@ -23,6 +23,13 @@ flashrom -p internal --flash-name 0
 flashrom -p internal --flash-size 0
 fsread_tool test -e /sys/class/power_supply/AC/online 1
 flashrom -p internal 0
+cbfstool /tmp/biosupdate layout -w 0
+cbfstool /tmp/biosupdate print -r COREBOOT 0
+flashrom -p internal -r /tmp/rom.bin --ifd -i bios 0
+cbfstool /tmp/rom.bin layout -w 0
+cbfstool /tmp/rom.bin read -r ROMHOLE -f /tmp/romhole.bin 0
+cbfstool /tmp/biosupdate remove -r COREBOOT -n msi_romhole.bin 0
+cbfstool /tmp/biosupdate add -r COREBOOT -n msi_romhole.bin -f /tmp/romhole.bin -b 0xff7c0000 -t raw 0
 flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 0
 cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
 cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0

--- a/platform-configs/msi-pro-z690-a-wifi-ddr4.robot
+++ b/platform-configs/msi-pro-z690-a-wifi-ddr4.robot
@@ -46,7 +46,7 @@ ${DTS_TEST_BOARD_MODEL}=                    PRO Z690-A WIFI DDR4(MS-7D25)
 &{DTS_TEST_EXPORTS_PER_WORKFLOW}=
 ...                                         &{DTS_TEST_EXPORTS_PER_WORKFLOW_BASE}
 ...                                         UEFI Update=&{{ {"TEST_IS_COREBOOT": "true"} }}
-...                                         UEFI->Heads Transition=&{{ { "TEST_IS_COREBOOT": "true", "TEST_ME_DISABLED": "false", "TEST_ROMHOLE_MIGRATION_FROM": "flashmap", "TEST_ROMHOLE_MIGRATION_TO": "cbfs" } }}
+...                                         UEFI->Heads Transition=&{{ { "TEST_IS_COREBOOT": "true", "TEST_ME_HAP_DISABLED": "false", "TEST_ME_DISABLED": "true", "TEST_ROMHOLE_MIGRATION_FROM": "flashmap", "TEST_ROMHOLE_MIGRATION_TO": "cbfs" } }}
 ...                                         Initial Deployment=&{{ {"TEST_HCI_PRESENT": "true", "TEST_FMAP_REGIONS": "", "TEST_ROMHOLE_MIGRATION_FROM": "flashmap", "TEST_ROMHOLE_MIGRATION_TO": "flashmap"} }}
 # robocop: off=LEN08
 &{DTS_TEST_EXPORTS_PER_FULL_WORKFLOW}=

--- a/platform-configs/msi-pro-z690-a-wifi-ddr4.robot
+++ b/platform-configs/msi-pro-z690-a-wifi-ddr4.robot
@@ -50,5 +50,5 @@ ${DTS_TEST_BOARD_MODEL}=                    PRO Z690-A WIFI DDR4(MS-7D25)
 ...                                         Initial Deployment=&{{ {"TEST_HCI_PRESENT": "true", "TEST_FMAP_REGIONS": "", "TEST_ROMHOLE_MIGRATION_FROM": "flashmap", "TEST_ROMHOLE_MIGRATION_TO": "flashmap"} }}
 # robocop: off=LEN08
 &{DTS_TEST_EXPORTS_PER_FULL_WORKFLOW}=
-...                                         ${{ ("UEFI Update", "DCR") }}=${{ {"TEST_BIOS_VERSION": "Dasharo (coreboot+UEFI) 0.0.0", "TEST_FMAP_REGIONS": "", "TEST_ME_DISABLED": "false", "TEST_ROMHOLE_MIGRATION_FROM": "flashmap", "TEST_ROMHOLE_MIGRATION_TO": "flashmap" } }}
+...                                         ${{ ("UEFI Update", "DCR") }}=${{ {"TEST_BIOS_VERSION": "Dasharo (coreboot+UEFI) 0.0.0", "TEST_FMAP_REGIONS": "", "TEST_ME_HAP_DISABLED": "false", "TEST_ME_DISABLED": "true", "TEST_ROMHOLE_MIGRATION_FROM": "flashmap", "TEST_ROMHOLE_MIGRATION_TO": "flashmap" } }}
 ...                                         ${{ ("UEFI Update", "DPP") }}=${{ {"TEST_ME_OP_MODE": "2", "TEST_ME_HAP_DISABLED": "true"} }}


### PR DESCRIPTION
These profiles have been regenerated without testing on hardware as 3mdeb does not have hardware for testing currently. As it is not the correct way to regenerate profiles as described in
https://blog.3mdeb.com/2025/2025-10-29-maintaining-and-testing-dts/ it needs some reasoning to be written down.

The reasoning behind trusting a profile without verification on hardware:

1. The same MSI boards but for different DDR types have similar mocking configurations, that differ only by the MSI model in dmidecode variables.
2. The same MSI boards but for different DDR types have the same profiles for the same mocking configurations.
3. Apart from the above two facts the "msi-pro-z690-a-wifi-ddr4 UEFI->Heads Transition - DPP.profile" will be verified by senior Dasharo firmware developer to make sure all commands that modify the firmware state are expected and correct for this DTS workflow on this platform.