### PR TITLE
zarhus-x86: provisioning: add 'zarhus provision' checksum tests

### DIFF
--- a/docs/zarhus-tests.md
+++ b/docs/zarhus-tests.md
@@ -154,7 +154,7 @@ but we could:
 
 ### QEMU
 
-Zarhus Provisioning Box tests don't support QEMU. For Zarhus OS:
+Zarhus OS tests:
 
 1. Run QEMU
 
@@ -227,6 +227,11 @@ sudo cp <path/to/>zarhus-base-image-genericx86-64.rootfs.wic.{gz,bmap} /mnt/
 sudo umount /mnt
 sudo losetup -d "${loop_dev}"
 ```
+
+##### QEMU
+
+`zarhus-provisioning-preparation` suite doesn't support QEMU tests as it
+tests platform preparation, and it's state after.
 
 ### Test Variables
 

--- a/lib/terminal.robot
+++ b/lib/terminal.robot
@@ -346,9 +346,9 @@ Execute Command In Terminal And Return Output And RC
     ...    \ executing the command
     ...
     ...    === Return Value ===
-    ...    ``string`` - The full command output, or up to the time ``${timeout}``
+    ...    - ``string`` - The full command output, or up to the time ``${timeout}``
     ...    passes.
-    ...    ``string`` - Return code of the executed function (as returned by $?)
+    ...    - ``string`` - Return code of the executed function (as returned by $?)
     ...
     ...    === Effects ===
     ...    The ``${command}`` is written to the terminal and the keyword waits

--- a/lib/zarhus-provision-lib.robot
+++ b/lib/zarhus-provision-lib.robot
@@ -5,6 +5,9 @@ Resource    zarhus-lib.robot
 *** Variables ***
 ${ENCRYPTED_STORAGE_PASSWORD}=      1234567
 ${ENCRYPTED_STORAGE_PROMPT}=        Enter password for encrypted storage:
+${ZPB_IBG_KEY_NAME}=                ZPB_IBG
+${KEY_CHOICE_PROMPT}=               Your choice:
+${ZPB_FW_BOOTSTRAP_FILE}=           zarhus-dtrpb-fw.cap
 
 
 *** Keywords ***
@@ -144,19 +147,18 @@ Prepare ZPB OS
     [Arguments]    ${disk}=nvme0n1
     IF    '${MANUFACTURER}' == 'QEMU'
         VAR    ${disk}=    sda
-        VAR    ${STORAGE_1}=    ${EMPTY}    scope=Suite
-        VAR    ${STORAGE_2}=    ${EMPTY}    scope=Suite
-        ${storage_1}=    Run    mktemp -p ${TEMPDIR} encrypted_storage.XXXXXXXX
-        ${storage_2}=    Run    mktemp -p ${TEMPDIR} encrypted_storage.XXXXXXXX
-        Run    dd if=/dev/zero of="${storage_1}" bs=1 count=0 seek=300M
-        Run    dd if=/dev/zero of="${storage_2}" bs=1 count=0 seek=300M
+        ${st_1}=    Run    mktemp -p ${TEMPDIR} encrypted_storage.XXXXXXXX
+        ${st_2}=    Run    mktemp -p ${TEMPDIR} encrypted_storage.XXXXXXXX
+        Run    dd if=/dev/zero of="${st_1}" bs=1 count=0 seek=300M
+        Run    dd if=/dev/zero of="${st_2}" bs=1 count=0 seek=300M
         Add USB To Qemu
         ...    ${ZARHUS_BOOTSTRAP_FILE}    bootstrap    read_only=${FALSE}    removable=${TRUE}
         Add USB To Qemu
-        ...    ${storage_1}    storage_1    read_only=${FALSE}    removable=${TRUE}
+        ...    ${st_1}    storage_1    read_only=${FALSE}    removable=${TRUE}
         Add USB To Qemu
-        ...    ${storage_2}    storage_2    read_only=${FALSE}    removable=${TRUE}
-
+        ...    ${st_2}    storage_2    read_only=${FALSE}    removable=${TRUE}
+        VAR    ${STORAGE_1}=    ${st_1}    scope=Suite
+        VAR    ${STORAGE_2}=    ${st_2}    scope=Suite
         # On hardware this'll be done by configuring firmware binary before
         # flashing it
         Power On
@@ -210,16 +212,24 @@ Setup ZPB
     ...    - Ends up in BIOS Setup Menu
     Boot Zarhus OS
     Create Encrypted Storage
+    Set DUT Response Timeout    5m
+    # Provision Intel BtG
     IF    '${MANUFACTURER}' != 'QEMU'
-        # Provision Intel BtG
         Write Into Terminal    zarhus prepare --no-eom
-        Set DUT Response Timeout    5m
-        Wait For Checkpoint And Write    ${ENCRYPTED_STORAGE_PROMPT}    ${ENCRYPTED_STORAGE_PASSWORD}
-        Wait For Checkpoint And Write
-        ...    Choose your Intel BootGuard keys name (without spaces)    ZPB_IBG
+    ELSE
+        Execute Command In Terminal Should Succeed    sudo mount /dev/disk/by-label/zarhus-dtrpb /mnt
+        Write Into Terminal    zarhus provision --provisioning-box /mnt/zarhus-dtrpb-fw.cap
+    END
+    Wait For Checkpoint And Write    ${ENCRYPTED_STORAGE_PROMPT}    ${ENCRYPTED_STORAGE_PASSWORD}
+    Wait For Checkpoint And Write
+    ...    Choose your Intel BootGuard keys name (without spaces)    ${ZPB_IBG_KEY_NAME}
+    IF    '${MANUFACTURER}' != 'QEMU'
         Wait For Checkpoint And Press Enter    Press Enter to reboot
         # Wait for update to finish
         Login To Zarhus OS
+    ELSE
+        ${out}=    Read From Terminal Until Prompt
+        Should Contain    ${out}    was provisioned successfully
     END
     Set UEFI Option    MeMode    Enabled
     Boot Zarhus OS
@@ -269,7 +279,7 @@ Create Encrypted Storage
     ...    \ bootstrap one (unless ``${allow_bootstrap}`` is true)
     [Arguments]    ${allow_bootstrap}=${FALSE}
     Write Into Terminal    zarhus storage create
-    ${choices}=    Read From Terminal Until    Your choice:
+    ${choices}=    Read From Terminal Until    ${KEY_CHOICE_PROMPT}
 
     ${choices}=    Get Lines Containing String    ${choices}    /dev/
     @{choices_list}=    Split To Lines    ${choices}
@@ -303,10 +313,10 @@ Teardown ZPB Test Suite
         Remove USB From Qemu    storage_1
         Remove USB From Qemu    storage_2
         ${status}=    Run Keyword And Return Status
-        ...    Variable Should Exist    STORAGE_1
+        ...    Variable Should Exist    $STORAGE_1
         IF    ${status}    Run    test -f "${STORAGE_1}" && rm ${STORAGE_1}
         ${status}=    Run Keyword And Return Status
-        ...    Variable Should Exist    STORAGE_2
+        ...    Variable Should Exist    $STORAGE_2
         IF    ${status}    Run    test -f "${STORAGE_2}" && rm ${STORAGE_2}
     END
 

--- a/zarhus-x86/zarhus-provisioning.robot
+++ b/zarhus-x86/zarhus-provisioning.robot
@@ -28,5 +28,48 @@ Test Setup          Run Keyword If    ${TESTS_IN_FIRMWARE_SUPPORT}
 
 *** Test Cases ***
 ZPB001.206 Make sure that cukinia tests pass
+    [Documentation]    Run cukinia tests in ZPB OS
     Boot Zarhus OS
     Execute Command In Terminal With Sudo    cukinia
+
+ZPB002.206 Make sure 'zarhus provision' verifies and creates checksum
+    [Documentation]    Make sure that 'zarhus provision' verifies checksum of
+    ...    file to be provisioned and creates checksum for provisioned firmware
+    Boot Zarhus OS
+    Execute Command In Terminal Should Succeed    sudo mount /dev/disk/by-label/zarhus-dtrpb /mnt
+    Write Into Terminal    zarhus provision /mnt/${ZPB_FW_BOOTSTRAP_FILE}
+    ${out}=    Wait For Checkpoint And Write    ${ENCRYPTED_STORAGE_PROMPT}    ${ENCRYPTED_STORAGE_PASSWORD}
+    Should Contain    ${out}    checksum verified
+    ${out}=    Wait For Checkpoint    ${KEY_CHOICE_PROMPT}
+    ${choice}=    Get Regexp Matches
+    ...    ${out}    .*\(\\d+\): ZPB_IBG.*    1
+    Write Into Terminal    ${choice}[0]
+    ${out}=    Read From Terminal Until Prompt
+
+    Should Contain    ${out}    was provisioned successfully
+    Should Contain    ${out}    Binary checksum:
+    Execute Command In Terminal Should Succeed
+    ...    diff <(sha256sum </mnt/${ZPB_FW_BOOTSTRAP_FILE}.provisioned) /mnt/${ZPB_FW_BOOTSTRAP_FILE}.provisioned.sha256
+
+ZPB003.206 Make sure 'zarhus provision' fails if checksum is wrong
+    [Documentation]    Make sure that 'zarhus provision' fails if file checksum
+    ...    doesn't match
+    Boot Zarhus OS
+    Execute Command In Terminal Should Succeed    sudo mount /dev/disk/by-label/zarhus-dtrpb /mnt
+    Execute Command In Terminal Should Succeed    cp /mnt/${ZPB_FW_BOOTSTRAP_FILE} /tmp/
+    Execute Command In Terminal Should Succeed    sha256sum <<<"1" >/tmp/${ZPB_FW_BOOTSTRAP_FILE}.sha256
+    ${out}    ${rc}=    Execute Command In Terminal And Return Output And RC
+    ...    zarhus provision /tmp/${ZPB_FW_BOOTSTRAP_FILE}
+    Should Contain    ${out}    checksum doesn't match
+    Should Not Be Equal As Integers    ${rc}    0
+
+ZPB004.206 Make sure 'zarhus provision' asks for checksum confirmation if it's missing
+    [Documentation]    Make sure that 'zarhus provision' asks for checksum
+    ...    confirmation if checksum file is missing
+    Boot Zarhus OS
+    Execute Command In Terminal Should Succeed    sudo mount /dev/disk/by-label/zarhus-dtrpb /mnt
+    Execute Command In Terminal Should Succeed    cp /mnt/${ZPB_FW_BOOTSTRAP_FILE} /tmp/
+    Write Into Terminal    zarhus provision /tmp/${ZPB_FW_BOOTSTRAP_FILE}
+    ${out}=    Wait For Checkpoint And Write    [y|n]:    y
+    Should Contain    ${out}    Please confirm that
+    Should Contain    ${out}    checksum is correct


### PR DESCRIPTION
Command:

```
robot -L TRACE -b command_log.txt -v rte_ip:127.0.0.1 -v config:qemu -v snipeit:no -v boot_dts_from_ipxe_shell:True \
    -v dts_ipxe_link:https://boot.dasharo.com/dts/dts-rc.ipxe \
    -v features:encryption,otab \
    -v zarhus_bootstrap_file:../bootstrap.img \
    zarhus-x86/zarhus-provisioning.robot
```

Results:

```sh
==============================================================================
Zarhus-Provisioning
==============================================================================
ZPB001.206 Make sure that cukinia tests pass :: Run cukinia tests ... | PASS |
------------------------------------------------------------------------------
ZPB002.206 Make sure 'zarhus provision' verifies and creates check... | PASS |
------------------------------------------------------------------------------
ZPB003.206 Make sure 'zarhus provision' fails if checksum is wrong... | PASS |
------------------------------------------------------------------------------
ZPB004.206 Make sure 'zarhus provision' asks for checksum confirma... | PASS |
------------------------------------------------------------------------------
Zarhus-Provisioning                                                   | PASS |
4 tests, 4 passed, 0 failed
==============================================================================
```