### PR TITLE
dts: profiles: add profiles for MSIs after ROMHOLE fix

### DIFF
--- a/dts/dts-e2e.robot
+++ b/dts/dts-e2e.robot
@@ -476,6 +476,49 @@ E2E016.006 Verify that fuse workflow uses and verifies btg_key_validator
     Wait For Checkpoint    Firmware signature doesn't match expected hash
     Wait For Checkpoint    ${ERROR_LOGS_QUESTION}
 
+################################################################################
+# ROMHOLE migration tests
+################################################################################
+
+E2E017.001 Firmware installation should stop if ROMHOLE cannot be read for migration
+    [Documentation]    Test checks whether DTS logic prevents user from
+    ...    Overwriting ROMHOLE Region In Case There Was A Failure During Read
+    Export Shell Variables For Emulation
+    ...    UEFI->Heads Transition
+    ...    DPP
+    ...    ${DTS_PLATFORM_VARIABLES}[msi-pro-z790-p-ddr5]
+    ...    ${DTS_CONFIG_REF}
+    Execute Command In Terminal    export TEST_READ_ROMHOLE_FAIL="true"
+    Write Into Terminal    dts-boot
+
+    ${out}=    Provide DPP Credentials
+    Wait For Checkpoint And Write Bare    ${DTS_CHECKPOINT}    ${DTS_DEPLOY_OPT}
+    Wait For Checkpoint And Write    ${DTS_HEADS_SWITCH_QUESTION}    Y
+    Wait For Checkpoint And Write    ${DTS_SPECIFICATION_WARN}    Y
+    Wait For Checkpoint And Write    ${DTS_DEPLOY_WARN}    Y
+    Wait For Checkpoint    Failed to migrate ROMHOLE.
+    Wait For Checkpoint    ${ERROR_LOGS_QUESTION}
+
+E2E017.002 Firmware installation should stop if there is no place to migrate ROMHOLE to
+    [Documentation]    Test checks whether DTS logic prevents user from
+    ...    Overwriting ROMHOLE Region In Case There Is No Place To Migrate
+    ...    ROMHOLE To
+    Export Shell Variables For Emulation
+    ...    UEFI->Heads Transition
+    ...    DPP
+    ...    ${DTS_PLATFORM_VARIABLES}[msi-pro-z790-p-ddr5]
+    ...    ${DTS_CONFIG_REF}
+    Execute Command In Terminal    export TEST_ROMHOLE_MIGRATION_TO=""
+    Write Into Terminal    dts-boot
+
+    ${out}=    Provide DPP Credentials
+    Wait For Checkpoint And Write Bare    ${DTS_CHECKPOINT}    ${DTS_DEPLOY_OPT}
+    Wait For Checkpoint And Write    ${DTS_HEADS_SWITCH_QUESTION}    Y
+    Wait For Checkpoint And Write    ${DTS_SPECIFICATION_WARN}    Y
+    Wait For Checkpoint And Write    ${DTS_DEPLOY_WARN}    Y
+    Wait For Checkpoint    ROMHOLE not found in the firmware file to be flashed. Cannot migrate ROMHOLE.
+    Wait For Checkpoint    ${ERROR_LOGS_QUESTION}
+
 
 *** Keywords ***
 # robocop: disable:0919

--- a/dts/dts-e2e.robot
+++ b/dts/dts-e2e.robot
@@ -519,6 +519,48 @@ E2E017.002 Firmware installation should stop if there is no place to migrate ROM
     Wait For Checkpoint    ROMHOLE not found in the firmware file to be flashed. Cannot migrate ROMHOLE.
     Wait For Checkpoint    ${ERROR_LOGS_QUESTION}
 
+E2E017.003 Firmware installation should stop in case of ROMHOLE migration from CBFS to flashmap
+    [Documentation]    Test checks whether DTS logic prevents user from
+    ...    potential brick during migration from CBFS to flashmap which is not
+    ...    supported yet
+    Export Shell Variables For Emulation
+    ...    UEFI->Heads Transition
+    ...    DPP
+    ...    ${DTS_PLATFORM_VARIABLES}[msi-pro-z790-p-ddr5]
+    ...    ${DTS_CONFIG_REF}
+    Execute Command In Terminal    export TEST_ROMHOLE_MIGRATION_FROM="cbfs"
+    Execute Command In Terminal    export TEST_ROMHOLE_MIGRATION_TO="flashmap"
+    Write Into Terminal    dts-boot
+
+    ${out}=    Provide DPP Credentials
+    Wait For Checkpoint And Write Bare    ${DTS_CHECKPOINT}    ${DTS_DEPLOY_OPT}
+    Wait For Checkpoint And Write    ${DTS_HEADS_SWITCH_QUESTION}    Y
+    Wait For Checkpoint And Write    ${DTS_SPECIFICATION_WARN}    Y
+    Wait For Checkpoint And Write    ${DTS_DEPLOY_WARN}    Y
+    Wait For Checkpoint    ROMHOLE migration from CBFS is not supported yet. Cannot migrate ROMHOLE.
+    Wait For Checkpoint    ${ERROR_LOGS_QUESTION}
+
+E2E017.004 Firmware installation should stop in case of ROMHOLE migration from CBFS to CBFS
+    [Documentation]    Test checks whether DTS logic prevents user from
+    ...    potential brick during migration from CBFS to flashmap which is not
+    ...    supported yet
+    Export Shell Variables For Emulation
+    ...    UEFI->Heads Transition
+    ...    DPP
+    ...    ${DTS_PLATFORM_VARIABLES}[msi-pro-z790-p-ddr5]
+    ...    ${DTS_CONFIG_REF}
+    Execute Command In Terminal    export TEST_ROMHOLE_MIGRATION_FROM="cbfs"
+    Execute Command In Terminal    export TEST_ROMHOLE_MIGRATION_TO="cbfs"
+    Write Into Terminal    dts-boot
+
+    ${out}=    Provide DPP Credentials
+    Wait For Checkpoint And Write Bare    ${DTS_CHECKPOINT}    ${DTS_DEPLOY_OPT}
+    Wait For Checkpoint And Write    ${DTS_HEADS_SWITCH_QUESTION}    Y
+    Wait For Checkpoint And Write    ${DTS_SPECIFICATION_WARN}    Y
+    Wait For Checkpoint And Write    ${DTS_DEPLOY_WARN}    Y
+    Wait For Checkpoint    ROMHOLE migration from CBFS is not supported yet. Cannot migrate ROMHOLE.
+    Wait For Checkpoint    ${ERROR_LOGS_QUESTION}
+
 
 *** Keywords ***
 # robocop: disable:0919

--- a/dts/profiles/msi-pro-z690-a-ddr5 Initial Deployment - DPP.profile
+++ b/dts/profiles/msi-pro-z690-a-ddr5 Initial Deployment - DPP.profile
@@ -62,8 +62,6 @@ dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
 fsread_tool test -f /sys/class/mei/mei0/fw_status 0
 fsread_tool cat /sys/class/mei/mei0/fw_status 0
-rdmsr 0x13a -0 0
-rdmsr 0x13a -0 0
 flashrom -p internal --flash-name 0
 flashrom -p internal --flash-size 0
 fsread_tool test -e /sys/class/power_supply/AC/online 1

--- a/dts/profiles/msi-pro-z690-a-ddr5 Initial Deployment - DPP.profile
+++ b/dts/profiles/msi-pro-z690-a-ddr5 Initial Deployment - DPP.profile
@@ -81,6 +81,22 @@ flashrom -p internal -r /tmp/rom.bin --ifd -i bios 0
 cbfstool /tmp/biosupdate write -r ROMHOLE -f /tmp/romhole.bin -u 0
 flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 1
 cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
-flashrom -p internal -N --ifd -i bios -N -w /tmp/biosupdate 0
+dmidecode -s system-uuid 0
+dmidecode -s baseboard-serial-number 0
+cbfstool /tmp/biosupdate layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+cbfstool /tmp/biosupdate layout -w 0
+cbfstool /tmp/biosupdate add -f /tmp/serial_number.txt -n serial_number -t raw -r COREBOOT 0
+cbfstool /tmp/biosupdate add -f /tmp/system_uuid.txt -n system_uuid -t raw -r COREBOOT 0
+cbfstool /tmp/biosupdate expand -r FW_MAIN_A 0
+cbfstool /tmp/biosupdate add -f /tmp/serial_number.txt -n serial_number -t raw -r FW_MAIN_A 0
+cbfstool /tmp/biosupdate add -f /tmp/system_uuid.txt -n system_uuid -t raw -r FW_MAIN_A 0
+cbfstool /tmp/biosupdate truncate -r FW_MAIN_A 0
+cbfstool /tmp/biosupdate expand -r FW_MAIN_B 0
+cbfstool /tmp/biosupdate add -f /tmp/serial_number.txt -n serial_number -t raw -r FW_MAIN_B 0
+cbfstool /tmp/biosupdate add -f /tmp/system_uuid.txt -n system_uuid -t raw -r FW_MAIN_B 0
+cbfstool /tmp/biosupdate truncate -r FW_MAIN_B 0
+flashrom -p internal -N --ifd -i fd -w /tmp/biosupdate_resigned.rom 0
+flashrom -p internal -N --ifd -i bios -i fd -w /tmp/biosupdate_resigned.rom 0
 reboot  0
 dmidecode  0

--- a/dts/profiles/msi-pro-z690-a-ddr5 UEFI->Heads Transition - DPP.profile
+++ b/dts/profiles/msi-pro-z690-a-ddr5 UEFI->Heads Transition - DPP.profile
@@ -23,6 +23,13 @@ flashrom -p internal --flash-name 0
 flashrom -p internal --flash-size 0
 fsread_tool test -e /sys/class/power_supply/AC/online 1
 flashrom -p internal 0
+cbfstool /tmp/biosupdate layout -w 0
+cbfstool /tmp/biosupdate print -r COREBOOT 0
+flashrom -p internal -r /tmp/rom.bin --ifd -i bios 0
+cbfstool /tmp/rom.bin layout -w 0
+cbfstool /tmp/rom.bin read -r ROMHOLE -f /tmp/romhole.bin 0
+cbfstool /tmp/biosupdate remove -r COREBOOT -n msi_romhole.bin 0
+cbfstool /tmp/biosupdate add -r COREBOOT -n msi_romhole.bin -f /tmp/romhole.bin -b 0xff7c0000 -t raw 0
 flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 0
 cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
 cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0

--- a/dts/profiles/msi-pro-z790-p-ddr5 UEFI->Heads Transition - DPP.profile
+++ b/dts/profiles/msi-pro-z790-p-ddr5 UEFI->Heads Transition - DPP.profile
@@ -23,6 +23,13 @@ flashrom -p internal --flash-name 0
 flashrom -p internal --flash-size 0
 fsread_tool test -e /sys/class/power_supply/AC/online 1
 flashrom -p internal 0
+cbfstool /tmp/biosupdate layout -w 0
+cbfstool /tmp/biosupdate print -r COREBOOT 0
+flashrom -p internal -r /tmp/rom.bin --ifd -i bios 0
+cbfstool /tmp/rom.bin layout -w 0
+cbfstool /tmp/rom.bin read -r ROMHOLE -f /tmp/romhole.bin 0
+cbfstool /tmp/biosupdate remove -r COREBOOT -n msi_romhole.bin 0
+cbfstool /tmp/biosupdate add -r COREBOOT -n msi_romhole.bin -f /tmp/romhole.bin -b 0xff7c0000 -t raw 0
 flashrom -p internal -r /tmp/dasharo_dump.rom --fmap -i FMAP -i BOOTSPLASH 0
 cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp 1
 cbfstool /tmp/biosupdate extract -r COREBOOT -n config -f /tmp/biosupdate_config 0

--- a/platform-configs/include/msi-z690-common.robot
+++ b/platform-configs/include/msi-z690-common.robot
@@ -129,12 +129,6 @@ ${DTS_TEST_SYSTEM_VENDOR}=                      Micro-Star International Co., Lt
 ...                                             TEST_SOUND_CARD_PRESENT=false
 ...                                             TEST_BOARD_HAS_GBE_REGION=false
 
-&{DTS_TEST_EXPORTS_PER_WORKFLOW}=
-...                                             &{DTS_TEST_EXPORTS_PER_WORKFLOW_BASE}
-...                                             UEFI Update=&{{ {"TEST_IS_COREBOOT": "true"} }}
-...                                             UEFI->Heads Transition=&{{ { "TEST_IS_COREBOOT": "true", "TEST_ME_DISABLED": "false" } }}
-...                                             Initial Deployment=&{{ {"TEST_HCI_PRESENT": "true", "TEST_FMAP_REGIONS": ""} }}
-
 
 *** Keywords ***
 Power On

--- a/platform-configs/msi-pro-z690-a-ddr5.robot
+++ b/platform-configs/msi-pro-z690-a-ddr5.robot
@@ -40,3 +40,4 @@ ${DTS_TEST_BOARD_MODEL}=                    PRO Z690-A WIFI (MS-7D25)
 @{DTS_TEST_WORKFLOW_PROFILES}=
 ...                                         ${{ ("UEFI->Heads Transition", "DPP") }}
 ...                                         ${{ ("UEFI Update", "DPP") }}
+...                                         ${{ ("Initial Deployment", "DPP") }}

--- a/platform-configs/msi-pro-z690-a-ddr5.robot
+++ b/platform-configs/msi-pro-z690-a-ddr5.robot
@@ -28,14 +28,15 @@ ${DTS_TEST_BOARD_MODEL}=                    PRO Z690-A WIFI (MS-7D25)
 ...                                         &{DTS_TEST_VERSIONS_BASE}
 ...                                         UEFI->Heads Transition=Dasharo (coreboot+UEFI) 1.1.6
 ...                                         UEFI Update=Dasharo (coreboot+UEFI) 1.1.5
+# robocop: off=LEN08
 &{DTS_TEST_EXPORTS_PER_WORKFLOW}=
 ...                                         &{DTS_TEST_EXPORTS_PER_WORKFLOW_BASE}
 ...                                         UEFI Update=&{{ {"TEST_IS_COREBOOT": "true"} }}
-...                                         UEFI->Heads Transition=&{{ { "TEST_IS_COREBOOT": "true", "TEST_ME_DISABLED": "false", "TEST_ME_HAP_DISABLED": "true" } }}
-...                                         Initial Deployment=&{{ {"TEST_HCI_PRESENT": "true", "TEST_FMAP_REGIONS": ""} }}
+...                                         UEFI->Heads Transition=&{{ { "TEST_IS_COREBOOT": "true", "TEST_ME_DISABLED": "false", "TEST_ME_HAP_DISABLED": "true", "TEST_ROMHOLE_MIGRATION_FROM": "flashmap", "TEST_ROMHOLE_MIGRATION_TO": "cbfs"} }}
+...                                         Initial Deployment=&{{ {"TEST_HCI_PRESENT": "true", "TEST_FMAP_REGIONS": "", "TEST_ROMHOLE_MIGRATION_FROM": "flashmap", "TEST_ROMHOLE_MIGRATION_TO": "flashmap"} }}
 # robocop: off=LEN08
 &{DTS_TEST_EXPORTS_PER_FULL_WORKFLOW}=
-...                                         ${{ ("UEFI Update", "DCR") }}=${{ {"TEST_BIOS_VERSION": "Dasharo (coreboot+UEFI) 0.0.0", "TEST_FMAP_REGIONS": "", "TEST_ME_DISABLED": "false"} }}
+...                                         ${{ ("UEFI Update", "DCR") }}=${{ {"TEST_BIOS_VERSION": "Dasharo (coreboot+UEFI) 0.0.0", "TEST_FMAP_REGIONS": "", "TEST_ME_DISABLED": "false", "TEST_ROMHOLE_MIGRATION_FROM": "flashmap", "TEST_ROMHOLE_MIGRATION_TO": "flashmap" } }}
 ...                                         ${{ ("UEFI Update", "DPP") }}=${{ {"TEST_ME_OP_MODE": "2", "TEST_ME_HAP_DISABLED": "true"} }}
 @{DTS_TEST_WORKFLOW_PROFILES}=
 ...                                         ${{ ("UEFI->Heads Transition", "DPP") }}

--- a/platform-configs/msi-pro-z690-a-wifi-ddr4.robot
+++ b/platform-configs/msi-pro-z690-a-wifi-ddr4.robot
@@ -43,6 +43,12 @@ ${DTS_TEST_BOARD_MODEL}=                    PRO Z690-A WIFI DDR4(MS-7D25)
 ...                                         ${{ ("Initial Deployment", "DCR") }}
 ...                                         ${{ ("Initial Deployment", "DPP") }}
 # robocop: off=LEN08
+&{DTS_TEST_EXPORTS_PER_WORKFLOW}=
+...                                         &{DTS_TEST_EXPORTS_PER_WORKFLOW_BASE}
+...                                         UEFI Update=&{{ {"TEST_IS_COREBOOT": "true"} }}
+...                                         UEFI->Heads Transition=&{{ { "TEST_IS_COREBOOT": "true", "TEST_ME_DISABLED": "false", "TEST_ROMHOLE_MIGRATION_FROM": "flashmap", "TEST_ROMHOLE_MIGRATION_TO": "cbfs" } }}
+...                                         Initial Deployment=&{{ {"TEST_HCI_PRESENT": "true", "TEST_FMAP_REGIONS": "", "TEST_ROMHOLE_MIGRATION_FROM": "flashmap", "TEST_ROMHOLE_MIGRATION_TO": "flashmap"} }}
+# robocop: off=LEN08
 &{DTS_TEST_EXPORTS_PER_FULL_WORKFLOW}=
-...                                         ${{ ("UEFI Update", "DCR") }}=${{ {"TEST_BIOS_VERSION": "Dasharo (coreboot+UEFI) 0.0.0", "TEST_FMAP_REGIONS": "", "TEST_ME_DISABLED": "false"} }}
+...                                         ${{ ("UEFI Update", "DCR") }}=${{ {"TEST_BIOS_VERSION": "Dasharo (coreboot+UEFI) 0.0.0", "TEST_FMAP_REGIONS": "", "TEST_ME_DISABLED": "false", "TEST_ROMHOLE_MIGRATION_FROM": "flashmap", "TEST_ROMHOLE_MIGRATION_TO": "flashmap" } }}
 ...                                         ${{ ("UEFI Update", "DPP") }}=${{ {"TEST_ME_OP_MODE": "2", "TEST_ME_HAP_DISABLED": "true"} }}

--- a/platform-configs/msi-pro-z790-p-ddr5.robot
+++ b/platform-configs/msi-pro-z790-p-ddr5.robot
@@ -34,8 +34,11 @@ ${DTS_TEST_BOARD_MODEL}=                PRO Z790-P WIFI (MS-7E06)
 &{DTS_TEST_EXPORTS_PER_WORKFLOW}=
 ...                                     &{DTS_TEST_EXPORTS_PER_WORKFLOW_BASE}
 ...                                     UEFI Update=&{{ {"TEST_IS_COREBOOT": "true", "TEST_FMAP_REGIONS": "BOOTSPLASH", "TEST_HCI_PRESENT": "false", "TEST_BOARD_FD_REGION_RW": "true", "TEST_BOARD_ME_REGION_RW": "true", "TEST_ME_OP_MODE": "2"} }}
-...                                     UEFI->Heads Transition=&{{ {"TEST_IS_COREBOOT": "true", "TEST_FMAP_REGIONS": "BOOTSPLASH", "TEST_HCI_PRESENT": "false", "TEST_BOARD_FD_REGION_RW": "true", "TEST_BOARD_ME_REGION_RW": "true"} }}
+# robocop: off=LEN08
+...                                     UEFI->Heads Transition=&{{ {"TEST_IS_COREBOOT": "true", "TEST_FMAP_REGIONS": "BOOTSPLASH", "TEST_HCI_PRESENT": "false", "TEST_BOARD_FD_REGION_RW": "true", "TEST_BOARD_ME_REGION_RW": "true", "TEST_ROMHOLE_MIGRATION_FROM": "flashmap", "TEST_ROMHOLE_MIGRATION_TO": "cbfs"} }}
 # robocop: on=LEN08
+...                                     Initial Deployment=&{{ {"TEST_HCI_PRESENT": "true", "TEST_FMAP_REGIONS": "", "TEST_ROMHOLE_MIGRATION_FROM": "flashmap", "TEST_ROMHOLE_MIGRATION_TO": "flashmap"} }}
+
 @{DTS_TEST_WORKFLOW_PROFILES}=
 ...                                     ${{ ("UEFI->Heads Transition", "DPP") }}
 ...                                     ${{ ("UEFI Update", "DPP") }}


### PR DESCRIPTION
The ROMHOLE fix: dts/profiles/msi-pro-z790-p-ddr5 Initial Deployment - DPP.profile