### PR TITLE
lib: dts-lib: update DTS_FUSE_WARN message

### DIFF
--- a/dts/dts-e2e.robot
+++ b/dts/dts-e2e.robot
@@ -322,6 +322,7 @@ E2E010.001 Failure to read flash during update should stop workflow
     ...    DCR
     ...    ${DTS_PLATFORM_VARIABLES}[novacustom-v540tu]
     ...    ${DTS_CONFIG_REF}
+    Execute Command In Terminal    export TEST_BIOS_VERSION="Dasharo (coreboot+UEFI) 0.9.0"
     Execute Command In Terminal    export TEST_LAYOUT_READ_SHOULD_FAIL="true"
     Write Into Terminal    dts-boot
 
@@ -342,6 +343,7 @@ E2E011.001 Aborting update after smmstore migration failure should stop workflow
     ...    DCR
     ...    ${DTS_PLATFORM_VARIABLES}[novacustom-v540tu]
     ...    ${DTS_CONFIG_REF}
+    Execute Command In Terminal    export TEST_BIOS_VERSION="Dasharo (coreboot+UEFI) 0.9.0"
     Execute Command In Terminal    export TEST_BOARD_HAS_SMMSTORE="false"
     Write Into Terminal    dts-boot
 
@@ -364,6 +366,7 @@ E2E012.001 Continuing update after smmstore migration failure should succeed
     ...    DCR
     ...    ${DTS_PLATFORM_VARIABLES}[novacustom-v540tu]
     ...    ${DTS_CONFIG_REF}
+    Execute Command In Terminal    export TEST_BIOS_VERSION="Dasharo (coreboot+UEFI) 0.9.0"
     Execute Command In Terminal    export TEST_BOARD_HAS_SMMSTORE="false"
     Write Into Terminal    dts-boot
 

--- a/dts/dts-e2e.robot
+++ b/dts/dts-e2e.robot
@@ -379,6 +379,10 @@ E2E012.001 Continuing update after smmstore migration failure should succeed
     Wait For Checkpoint    Rebooting in
     Wait For Checkpoint    Rebooting
 
+################################################################################
+# FUM tests
+################################################################################
+
 E2E013.001 Verify that FUM update doesn't start automatically
     [Documentation]    Test that booting via FUM doesn't start update without
     ...    user input
@@ -389,13 +393,14 @@ E2E013.001 Verify that FUM update doesn't start automatically
     Wait For Checkpoint    You have entered Firmware Update Mode
     Wait For Checkpoint    ${DTS_ASK_FOR_CHOICE_PROMPT}
 
-E2E014.001 Verify that FUM update succeeds
+E2E013.002 Verify that FUM update succeeds
     [Documentation]    Test that FUM update succeeds without user input
     Export Shell Variables For Emulation
     ...    UEFI Update
     ...    DCR
     ...    ${DTS_PLATFORM_VARIABLES}[novacustom-v540tu]
     ...    ${DTS_CONFIG_REF}
+    Execute Command In Terminal    export TEST_BIOS_VERSION="Dasharo (coreboot+UEFI) 0.9.0"
     Execute Command In Terminal    export TEST_FUM="true"
     Write Into Terminal    dts-boot
 
@@ -403,7 +408,7 @@ E2E014.001 Verify that FUM update succeeds
     Wait For Checkpoint    Rebooting in
     Wait For Checkpoint    Rebooting
 
-E2E015.001 Verify that entering DTS menu in FUM works
+E2E013.003 Verify that entering DTS menu in FUM works
     [Documentation]    Test that booting via FUM doesn't start update without
     ...    user input
     Execute Command In Terminal    export DTS_TESTING="true"
@@ -412,6 +417,80 @@ E2E015.001 Verify that entering DTS menu in FUM works
 
     Wait For Checkpoint And Write    ${DTS_ASK_FOR_CHOICE_PROMPT}    ${DTS_FUM_MENU_OPT}
     Wait For Checkpoint    ${DTS_CHECKPOINT}
+
+################################################################################
+# https://github.com/Dasharo/dasharo-issues/issues/1759 tests
+################################################################################
+
+E2E014.001 Verify that capsule update while in FUM stops if unsupported
+    [Documentation]    Test that FUM update is stopped with expected error
+    ...    message when trying to use capsule update on firmware version that
+    ...    doesn't support this combination
+    Export Shell Variables For Emulation
+    ...    Fuse Platform
+    ...    DCR
+    ...    ${DTS_PLATFORM_VARIABLES}[novacustom-v540tu]
+    ...    ${DTS_CONFIG_REF}
+    Execute Command In Terminal    export TEST_BIOS_VERSION="Dasharo (coreboot+UEFI) 1.0.0"
+    Execute Command In Terminal    export TEST_FUM="true"
+    Write Into Terminal    dts-boot
+
+    Wait For Checkpoint And Write    ${DTS_ASK_FOR_CHOICE_PROMPT}    ${DTS_FUM_UPDATE_OPT}
+    Wait For Checkpoint    ${CAP_FUM_ERROR}
+    Wait For Checkpoint    ${ERROR_LOGS_QUESTION}
+
+E2E014.002 Verify that fusing while in FUM stops if unsupported
+    [Documentation]    Test that fusing while in FUM is stopped with expected
+    ...    error message when trying to do it on firmware version that doesn't
+    ...    support this combination
+    Export Shell Variables For Emulation
+    ...    UEFI Update
+    ...    DCR
+    ...    ${DTS_PLATFORM_VARIABLES}[novacustom-v540tu]
+    ...    ${DTS_CONFIG_REF}
+    Execute Command In Terminal    export TEST_BIOS_VERSION="Dasharo (coreboot+UEFI) 1.0.0"
+    Execute Command In Terminal    export TEST_FUM="true"
+    Write Into Terminal    dts-boot
+
+    Wait For Checkpoint And Write    ${DTS_ASK_FOR_CHOICE_PROMPT}    ${DTS_FUM_MENU_OPT}
+    Wait For Checkpoint And Write Bare    ${DTS_CHECKPOINT}    ${DTS_FUSE_OPT}
+    Wait For Checkpoint    ${CAP_FUM_ERROR}
+    Wait For Checkpoint    ${ERROR_LOGS_QUESTION}
+
+E2E014.003 Verify that capsule update while in FUM works if supported
+    [Documentation]    Test that FUM capsule update works correctly when on
+    ...    firmware version that supports this combination
+    Export Shell Variables For Emulation
+    ...    Fuse Platform
+    ...    DCR
+    ...    ${DTS_PLATFORM_VARIABLES}[novacustom-v540tu]
+    ...    ${DTS_CONFIG_REF}
+    Execute Command In Terminal    export TEST_BIOS_VERSION="Dasharo (coreboot+UEFI) 1.0.1"
+    Execute Command In Terminal    export TEST_SYSTEM_VENDOR="3mdeb_test_config"
+    Execute Command In Terminal    export TEST_SYSTEM_MODEL="fum_cap_test"
+    Execute Command In Terminal    export TEST_FUM="true"
+    Write Into Terminal    dts-boot
+
+    Wait For Checkpoint And Write    ${DTS_ASK_FOR_CHOICE_PROMPT}    ${DTS_FUM_UPDATE_OPT}
+    Wait For Checkpoint    Rebooting in
+    Wait For Checkpoint    Rebooting
+
+E2E014.004 Verify that fusing while in FUM works if supported
+    [Documentation]    Test that fusing while in FUM works if done on firmware
+    ...    version that supports this combination
+    Export Shell Variables For Emulation
+    ...    Fuse Platform
+    ...    DCR
+    ...    ${DTS_PLATFORM_VARIABLES}[novacustom-v540tu]
+    ...    ${DTS_CONFIG_REF}
+    Execute Command In Terminal    export TEST_BIOS_VERSION="Dasharo (coreboot+UEFI) 1.0.1"
+    Execute Command In Terminal    export TEST_SYSTEM_VENDOR="3mdeb_test_config"
+    Execute Command In Terminal    export TEST_SYSTEM_MODEL="fum_cap_test"
+    Execute Command In Terminal    export TEST_FUM="true"
+    Write Into Terminal    dts-boot
+
+    Wait For Checkpoint And Write    ${DTS_ASK_FOR_CHOICE_PROMPT}    ${DTS_FUM_MENU_OPT}
+    Go Through Fusing Platform
 
 ################################################################################
 # IBG signature tests

--- a/lib/dts-lib.robot
+++ b/lib/dts-lib.robot
@@ -24,7 +24,7 @@ ${DTS_HEADS_SWITCH_QUESTION}=                   Would you like to switch to Dash
 ${DTS_ME_WARN}=
 ...                                             Skip ME flashing and proceed with BIOS/firmware flashing/updating? [y|n]
 ${DTS_BOARD_QUESTION}=                          Choose your board model:
-${DTS_FUSE_WARN}=                               Fusing is irreversible. Are you sure you want to continue? [y|n]
+${DTS_FUSE_WARN}=                               Are you sure you want to continue? [y|n]
 ${DTS_13_GEN_REGRESSION}=                       Aborting deployment...
 ${DPP_EMAIL_CHECKPOINT}=                        Enter DPP email:
 ${DPP_PASSWORD_CHECKPOINT}=                     Enter password:

--- a/lib/dts-lib.robot
+++ b/lib/dts-lib.robot
@@ -29,6 +29,7 @@ ${DTS_13_GEN_REGRESSION}=                       Aborting deployment...
 ${DPP_EMAIL_CHECKPOINT}=                        Enter DPP email:
 ${DPP_PASSWORD_CHECKPOINT}=                     Enter password:
 ${DTS_ASK_FOR_CHOICE_PROMPT}=                   Select an option:
+${CAP_FUM_ERROR}=                               Current firmware doesn't support capsules while in Firmware Update Mode
 # DTS initial deployment menupoints:
 ${DTS_DCR_UEFI_MENUPOINT}=                      Community version
 ${DTS_DPP_UEFI_MENUPOINT}=                      DPP version (coreboot + UEFI)


### PR DESCRIPTION
https://github.com/Dasharo/dts-scripts/pull/145

Results:

<details><summary>Details</summary>
<p>

```text
==============================================================================
Dts-E2E
==============================================================================
Create tests                                                          | PASS |
------------------------------------------------------------------------------
E2E001.001 HCL Report test :: Verify that HCL Report is being exec... | PASS |
------------------------------------------------------------------------------
E2E002.001 DCR Initial Deployment On Msi-pro-z690-a-ddr5 With 13th... | PASS |
------------------------------------------------------------------------------
E2E002.002 DCR Initial Deployment On Msi-pro-z690-a-wifi-ddr4 With... | PASS |
------------------------------------------------------------------------------
E2E003.001 DCR UEFI Update On Msi-pro-z690-a-ddr5 With 13th Gen CP... | PASS |
------------------------------------------------------------------------------
E2E003.002 DCR UEFI Update On Msi-pro-z690-a-wifi-ddr4 With 13th G... | PASS |
------------------------------------------------------------------------------
E2E007.001 Check credentials are being saved correctly :: Check th... | PASS |
------------------------------------------------------------------------------
E2E007.002 Check old credentials are being overwritten by new :: M... | FAIL |
------------------------------------------------------------------------------
E2E007.003 Check wrong credentials should not allow to log into DP... | FAIL |
------------------------------------------------------------------------------
E2E007.004 Check correct credentials should allow to log into DPP ... | PASS |
------------------------------------------------------------------------------
E2E007.005 Check empty e-mail should not pass :: Entering empty e-... | FAIL |
------------------------------------------------------------------------------
E2E007.006 Check empty password should not pass :: Entering empty ... | FAIL |
------------------------------------------------------------------------------
E2E007.008 Check DPP credentials with access to only firmware :: T... | PASS |
------------------------------------------------------------------------------
E2E007.009 Check DPP credentials with access to only extensions ::... | FAIL |
------------------------------------------------------------------------------
E2E007.010 Check DPP credentials without DPP access :: Those crede... | PASS |
------------------------------------------------------------------------------
E2E007.011 Check DPP credentials with both DPP firmware and DTS ex... | PASS |
------------------------------------------------------------------------------
E2E008.001 Reboot UI Option Calls Reboot Command :: Reboot (R) UI ... | PASS |
------------------------------------------------------------------------------
E2E008.002 Poweroff UI Option Calls Poweroff Command :: Poweroff (... | PASS |
------------------------------------------------------------------------------
E2E008.003 Launch SSH Server UI Option Enables SSH Server Command ... | PASS |
------------------------------------------------------------------------------
E2E008.004 Enable Sending Logs UI Option Should Enable DTS Log Sen... | PASS |
------------------------------------------------------------------------------
E2E009.001 DTS extensions are installed and can be used :: Test th... | PASS |
------------------------------------------------------------------------------
E2E010.001 Failure to read flash during update should stop workflo... | FAIL |
------------------------------------------------------------------------------
E2E011.001 Aborting update after smmstore migration failure should... | FAIL |
------------------------------------------------------------------------------
E2E012.001 Continuing update after smmstore migration failure shou... | FAIL |
------------------------------------------------------------------------------
E2E013.001 Verify that FUM update doesn't start automatically :: T... | PASS |
------------------------------------------------------------------------------
E2E014.001 Verify that FUM update succeeds :: Test that FUM update... | PASS |
------------------------------------------------------------------------------
E2E014.002 Verify that entering DTS menu in FUM works :: Test that... | PASS |
------------------------------------------------------------------------------
E2E015.001 Verify that capsule update while in FUM stops if unsupp... | PASS |
------------------------------------------------------------------------------
E2E015.002 Verify that fusing while in FUM stops if unsupported ::... | PASS |
------------------------------------------------------------------------------
E2E015.003 Verify that capsule update while in FUM works if suppor... | PASS |
------------------------------------------------------------------------------
E2E015.004 Verify that fusing while in FUM works if supported :: T... | PASS |
------------------------------------------------------------------------------
E2E016.001 Verify that btg_key_validator prints expected error on ... | PASS |
------------------------------------------------------------------------------
E2E016.002 Verify that btg_key_validator prints expected error on ... | PASS |
------------------------------------------------------------------------------
E2E016.003 Verify that btg_key_validator prints expected error on ... | PASS |
------------------------------------------------------------------------------
E2E016.004 Verify that btg_key_validator prints expected error if ... | PASS |
------------------------------------------------------------------------------
E2E016.005 Verify that btg_key_validator prints expected message i... | PASS |
------------------------------------------------------------------------------
E2E016.006 Verify that fuse workflow uses and verifies btg_key_val... | PASS |
------------------------------------------------------------------------------
E2E017.001 Firmware installation should stop if ROMHOLE cannot be ... | PASS |
------------------------------------------------------------------------------
E2E017.002 Firmware installation should stop if there is no place ... | PASS |
------------------------------------------------------------------------------
E2E017.003 Firmware installation should stop in case of ROMHOLE mi... | PASS |
------------------------------------------------------------------------------
E2E017.004 Firmware installation should stop in case of ROMHOLE mi... | PASS |
------------------------------------------------------------------------------
E2E018.001 Failure to pass capsule to /dev/efi_capsule_loader is d... | PASS |
------------------------------------------------------------------------------
E2E001: optiplex-7010 Initial Deployment - DPP                        | PASS |
------------------------------------------------------------------------------
E2E002: optiplex-7010 UEFI Update - DPP                               | PASS |
------------------------------------------------------------------------------
E2E003: optiplex-9010 Initial Deployment - DPP                        | PASS |
------------------------------------------------------------------------------
E2E004: optiplex-9010 UEFI Update - DPP                               | PASS |
------------------------------------------------------------------------------
E2E005: novacustom-nuc_box-125H Initial Deployment - DCR              | PASS |
------------------------------------------------------------------------------
E2E006: novacustom-nuc_box-155H Initial Deployment - DCR              | PASS |
------------------------------------------------------------------------------
E2E007: novacustom-ns50mu Initial Deployment - DCR                    | PASS |
------------------------------------------------------------------------------
E2E008: novacustom-ns50mu UEFI Update - DCR                           | PASS |
------------------------------------------------------------------------------
E2E009: novacustom-ns50pu Initial Deployment - DCR                    | PASS |
------------------------------------------------------------------------------
E2E010: novacustom-ns50pu UEFI Update - DCR                           | PASS |
------------------------------------------------------------------------------
E2E011: novacustom-ns70mu Initial Deployment - DCR                    | PASS |
------------------------------------------------------------------------------
E2E012: novacustom-ns70mu UEFI Update - DCR                           | PASS |
------------------------------------------------------------------------------
E2E013: novacustom-ns70pu Initial Deployment - DCR                    | PASS |
------------------------------------------------------------------------------
E2E014: novacustom-ns70pu UEFI Update - DCR                           | PASS |
------------------------------------------------------------------------------
E2E015: novacustom-nv41mb Initial Deployment - DCR                    | PASS |
------------------------------------------------------------------------------
E2E016: novacustom-nv41mb UEFI Update - DCR                           | PASS |
------------------------------------------------------------------------------
E2E017: novacustom-nv41mz Initial Deployment - DCR                    | PASS |
------------------------------------------------------------------------------
E2E018: novacustom-nv41mz UEFI Update - DCR                           | PASS |
------------------------------------------------------------------------------
E2E019: novacustom-v560tne Initial Deployment - DCR                   | PASS |
------------------------------------------------------------------------------
E2E020: novacustom-v560tne UEFI Update - DCR                          | PASS |
------------------------------------------------------------------------------
E2E021: odroid-h4-plus Initial Deployment - DPP                       | PASS |
------------------------------------------------------------------------------
E2E022: odroid-h4-plus UEFI Update - DPP                              | PASS |
------------------------------------------------------------------------------
E2E023: odroid-h4-plus Dasharo (coreboot+UEFI) to Dasharo (Slim Bo... | PASS |
------------------------------------------------------------------------------
E2E024: odroid-h4-plus Dasharo (Slim Bootloader+UEFI) Initial Depl... | PASS |
------------------------------------------------------------------------------
E2E025: novacustom-v540tnd Initial Deployment - DCR                   | PASS |
------------------------------------------------------------------------------
E2E026: novacustom-v540tnd UEFI Update - DCR                          | PASS |
------------------------------------------------------------------------------
E2E027: novacustom-v560tnd Initial Deployment - DCR                   | PASS |
------------------------------------------------------------------------------
E2E028: novacustom-v560tnd UEFI Update - DCR                          | PASS |
------------------------------------------------------------------------------
E2E029: pcengines-apu2 UEFI Update - DPP                              | PASS |
------------------------------------------------------------------------------
E2E030: pcengines-apu2 SeaBIOS Update - DPP                           | PASS |
------------------------------------------------------------------------------
E2E031: pcengines-apu2 SeaBIOS->UEFI Transition - DPP                 | PASS |
------------------------------------------------------------------------------
E2E032: pcengines-apu3 UEFI Update - DPP                              | PASS |
------------------------------------------------------------------------------
E2E033: pcengines-apu3 SeaBIOS Update - DPP                           | PASS |
------------------------------------------------------------------------------
E2E034: pcengines-apu3 SeaBIOS->UEFI Transition - DPP                 | PASS |
------------------------------------------------------------------------------
E2E035: pcengines-apu4 UEFI Update - DPP                              | PASS |
------------------------------------------------------------------------------
E2E036: pcengines-apu4 SeaBIOS Update - DPP                           | PASS |
------------------------------------------------------------------------------
E2E037: pcengines-apu4 SeaBIOS->UEFI Transition - DPP                 | PASS |
------------------------------------------------------------------------------
E2E038: pcengines-apu6 UEFI Update - DPP                              | PASS |
------------------------------------------------------------------------------
E2E039: pcengines-apu6 SeaBIOS Update - DPP                           | PASS |
------------------------------------------------------------------------------
E2E040: pcengines-apu6 SeaBIOS->UEFI Transition - DPP                 | PASS |
------------------------------------------------------------------------------
E2E041: novacustom-nv41pz Initial Deployment - DCR                    | PASS |
------------------------------------------------------------------------------
E2E042: novacustom-nv41pz UEFI Update - DCR                           | PASS |
------------------------------------------------------------------------------
E2E043: novacustom-nv41pz UEFI->Heads Transition - DPP                | PASS |
------------------------------------------------------------------------------
E2E044: msi-pro-z690-a-ddr5 Initial Deployment - DCR                  | PASS |
------------------------------------------------------------------------------
E2E045: msi-pro-z690-a-ddr5 Initial Deployment - DPP                  | PASS |
------------------------------------------------------------------------------
E2E046: msi-pro-z690-a-ddr5 UEFI Update - DCR                         | PASS |
------------------------------------------------------------------------------
E2E047: msi-pro-z690-a-ddr5 UEFI Update - DPP                         | PASS |
------------------------------------------------------------------------------
E2E048: msi-pro-z690-a-ddr5 UEFI->Heads Transition - DPP              | PASS |
------------------------------------------------------------------------------
E2E049: msi-pro-z690-a-wifi-ddr4 Initial Deployment - DCR             | PASS |
------------------------------------------------------------------------------
E2E050: msi-pro-z690-a-wifi-ddr4 Initial Deployment - DPP             | PASS |
------------------------------------------------------------------------------
E2E051: msi-pro-z690-a-wifi-ddr4 UEFI Update - DCR                    | PASS |
------------------------------------------------------------------------------
E2E052: msi-pro-z690-a-wifi-ddr4 UEFI Update - DPP                    | PASS |
------------------------------------------------------------------------------
E2E053: msi-pro-z690-a-wifi-ddr4 UEFI->Heads Transition - DPP         | PASS |
------------------------------------------------------------------------------
E2E054: msi-pro-z790-p-ddr5 Initial Deployment - DPP                  | PASS |
------------------------------------------------------------------------------
E2E055: msi-pro-z790-p-ddr5 UEFI Update - DPP                         | PASS |
------------------------------------------------------------------------------
E2E056: msi-pro-z790-p-ddr5 UEFI->Heads Transition - DPP              | PASS |
------------------------------------------------------------------------------
E2E057: novacustom-v560tu Initial Deployment - DCR                    | PASS |
------------------------------------------------------------------------------
E2E058: novacustom-v560tu UEFI Update - DCR                           | PASS |
------------------------------------------------------------------------------
E2E059: novacustom-v560tu UEFI->Heads Transition - DPP                | PASS |
------------------------------------------------------------------------------
E2E060: novacustom-v560tu Fuse Platform - DCR                         | PASS |
------------------------------------------------------------------------------
E2E061: novacustom-v540tu Initial Deployment - DCR                    | PASS |
------------------------------------------------------------------------------
E2E062: novacustom-v540tu UEFI Update - DCR                           | FAIL |
No match found for 'Does\ it\ match\ your\ actual\ specification\?\ \[y\|n\]|Would\ you\ like\ to\ switch\ to\ Dasharo\ heads\ firmware\?\ \[y\|n\]' in 2 minutes
Output:

2
Gathering flash chip and chipset information...
Flash information: Opaque flash chip
Flash size: 2M
Waiting for network connection ...
Network connection have been established!
Downloading board configs repository...
Failed to download configs.
Waiting for system clock to be synced ...
AC adapter is connected. Continuing with firmware update.
No update available for your machine
Do you want to send console logs to 3mdeb? [y|n]: .
------------------------------------------------------------------------------
E2E063: novacustom-v540tu UEFI->Heads Transition - DPP                | PASS |
------------------------------------------------------------------------------
E2E064: novacustom-v540tu Fuse Platform - DCR                         | PASS |
------------------------------------------------------------------------------
Dts-E2E                                                               | FAIL |
106 tests, 97 passed, 9 failed
==============================================================================
```

</p>
</details>

E2E010, E2E011, E2E012 failed due to https://github.com/Dasharo/open-source-firmware-validation/pull/1223, fixed in 930d4edd559d:

<details><summary>Details</summary>
<p>

```text
==============================================================================
Dts-E2E
==============================================================================
E2E010.001 Failure to read flash during update should stop workflo... | PASS |
------------------------------------------------------------------------------
E2E011.001 Aborting update after smmstore migration failure should... | PASS |
------------------------------------------------------------------------------
E2E012.001 Continuing update after smmstore migration failure shou... | PASS |
------------------------------------------------------------------------------
Dts-E2E                                                               | PASS |
3 tests, 3 passed, 0 failed
==============================================================================
```

</p>
</details> 

E2E062:

```
Downloading board configs repository...
Failed to download configs.
```

Likely temporary issue with e.g. FTP. Ran the test again and it worked:

```
==============================================================================
Dts-E2E
==============================================================================
Create tests                                                          | PASS |
------------------------------------------------------------------------------
E2E001: novacustom-v540tu UEFI Update - DCR                           | PASS |
------------------------------------------------------------------------------
Dts-E2E                                                               | PASS |
2 tests, 2 passed, 0 failed
==============================================================================
```