### PR TITLE
Add capsule update while in Firmware Update Mode test

### DIFF
--- a/dasharo-stability/capsule-update.robot
+++ b/dasharo-stability/capsule-update.robot
@@ -225,7 +225,17 @@ CUP260.101 Capsule update in Firmware Update Mode works
     ${choice}=    Get Regexp Matches
     ...    ${fum_prompt}    .*Press \([0-9]\) to continue\..*    1
     Write Into Terminal    ${choice}[0]
+    # Stop iPXE from booting default option as it contains workaround for this
+    # issue
+    Read From Terminal Until    efi/FirmwareUpdateMode:hex = 01
+    Press Key N Times    1    ${CTRL_C}
+    Enter IPXE Shell Submenu
+    Execute Command In Terminal    dhcp
+    # Write Bare allows to set interval between each character which might be
+    # needed on slower platforms/serial connection
+    Write Bare Into Terminal    chain http://boot.dasharo.com/dts/dts-no-fum-fix.ipxe\n    interval=0.2
     # Boot into DTS shell
+    Set DUT Response Timeout    5m
     Read From Terminal Until    .cpio.gz...
     Read From Terminal Until    ok
     Wait For DTS To Boot    fum=${TRUE}

--- a/dasharo-stability/capsule-update.robot
+++ b/dasharo-stability/capsule-update.robot
@@ -221,10 +221,7 @@ CUP260.101 Capsule update in Firmware Update Mode works
     Enter Submenu From Snapshot    ${security_menu}    Enter Firmware Update Mode
     Read From Terminal Until    Press ENTER to continue and reboot
     Press Enter
-    ${fum_prompt}=    Read From Terminal Until Regexp    Press [0-9] to continue\.
-    ${choice}=    Get Regexp Matches
-    ...    ${fum_prompt}    .*Press \([0-9]\) to continue\..*    1
-    Write Into Terminal    ${choice}[0]
+    Wait For FUM Dialog And Confirm
     # Stop iPXE from booting default option as it contains workaround for this
     # issue
     Read From Terminal Until    efi/FirmwareUpdateMode:hex = 01
@@ -521,10 +518,7 @@ Perform Capsule Update
         Press Key N Times    1    ${ENTER}
 
         # Confirm update by following instructions of Firmware Update Mode dialog
-        Read From Terminal Until    ${FUM_DIALOG_TOP}
-        ${out}=    Read From Terminal Until    ${FUM_DIALOG_BOTTOM}
-        ${digit}=    Get Key To Press    ${out}
-        Write Bare Into Terminal    ${digit}
+        Wait For FUM Dialog And Confirm
     ELSE
         Power On
         Boot System Or From Connected Disk    ${BOOTED_OS_ID}
@@ -807,3 +801,11 @@ Get CUP Environment Variables
         Log To Console    Settning CAPSULE_UPDATE_DISK_MODEL to ${disk_model}
         VAR    ${CAPSULE_UPDATE_DISK_MODEL}=    ${disk_model}    scope=GLOBAL
     END
+
+Wait For FUM Dialog And Confirm
+    [Documentation]    Wait for FUM dialog to show and then confirm by pressing
+    ...    expected key
+    Read From Terminal Until    ${FUM_DIALOG_TOP}
+    ${out}=    Read From Terminal Until    ${FUM_DIALOG_BOTTOM}
+    ${digit}=    Get Key To Press    ${out}
+    Write Bare Into Terminal    ${digit}

--- a/dasharo-stability/capsule-update.robot
+++ b/dasharo-stability/capsule-update.robot
@@ -26,7 +26,7 @@ Suite Setup         Run Keywords
 ...                     AND    Prepare For ROMHOLE Persistence Test    # MSI Only
 ...                     AND    Run Keyword If    '${OPTIONS_LIB}' == 'options-lib_uefi-setup-menu'    Upload Required Files
 ...                     AND    Get System Values
-...                     AND    Set UEFI Option    MeMode    Disabled (HAP)
+...                     AND    Run Keyword If    '${MANUFACTURER}' != 'QEMU'    Set UEFI Option    MeMode    Disabled (HAP)
 ...                     AND    Run Keyword If    '${OPTIONS_LIB}' == 'options-lib_uefi-setup-menu'    Deploy Uefi Shell
 ...                     AND    Set DUT Response Timeout    90s    # a boot can last longer than default 30s
 Suite Teardown      Run Keywords

--- a/dasharo-stability/capsule-update.robot
+++ b/dasharo-stability/capsule-update.robot
@@ -209,6 +209,43 @@ CUP250.001 Capsule Update Progress Bar - Default Logo
     END
     Check The Update Screen For The Correct UX
 
+CUP260.101 Capsule update in Firmware Update Mode works
+    [Documentation]    Check if capsule update works when in Firmware Update
+    ...    Mode
+    Skip If    "${OPTIONS_LIB}" == "options-lib_dcu"
+    Power On
+    # Enable FUM
+    ${setup_menu}=    Enter Setup Menu Tianocore And Return Construction
+    ${dasharo_menu}=    Enter Dasharo System Features    ${setup_menu}
+    ${security_menu}=    Enter Dasharo Submenu    ${dasharo_menu}    Dasharo Security Options
+    Enter Submenu From Snapshot    ${security_menu}    Enter Firmware Update Mode
+    Read From Terminal Until    Press ENTER to continue and reboot
+    Press Enter
+    ${fum_prompt}=    Read From Terminal Until Regexp    Press [0-9] to continue\.
+    ${choice}=    Get Regexp Matches
+    ...    ${fum_prompt}    .*Press \([0-9]\) to continue\..*    1
+    Write Into Terminal    ${choice}[0]
+    # Boot into DTS shell
+    Read From Terminal Until    .cpio.gz...
+    Read From Terminal Until    ok
+    Wait For DTS To Boot    fum=${TRUE}
+    Write Into Terminal    ${DTS_FUM_MENU_OPT}
+    Enter Shell In DTS
+    # Upload capsule
+    Execute Command In Terminal    systemctl start sshd
+    VAR    ${DEVICE_OS_USERNAME}=    root    scope=Test
+    VAR    ${DEVICE_OS_PASSWORD}=    ${EMPTY}    scope=Test
+    Send File To DUT    ${CAPSULE_FW_FILE}    /valid_capsule.cap
+    Execute Command In Terminal Should Succeed
+    ...    cp /valid_capsule.cap /dev/efi_capsule_loader
+    ...    Failed to queue capsule update via /dev/efi_capsule_loader
+    # Verify
+    ${dmesg}=    Execute Command In Terminal    dmesg | tail
+    Should Contain    ${dmesg}    efi: Successfully uploaded capsule
+    Write Into Terminal    reboot
+    Set DUT Response Timeout    5m
+    Enter Setup Menu Tianocore
+
 
 *** Keywords ***
 Check Platform Fused

--- a/lib/bios/menus.robot
+++ b/lib/bios/menus.robot
@@ -991,10 +991,32 @@ Enter IPXE Inner
     # TODO:    problem with iPXE string (e.g. when 3 network interfaces are available)
     ${boot_menu}=    Enter Boot Menu Tianocore And Return Construction
     Enter Submenu From Snapshot    ${boot_menu}    ${IPXE_BOOT_ENTRY}
-    IF    ${NETBOOT_UTILITIES_SUPPORT} == ${TRUE}
-        ${ipxe_menu}=    Get IPXE Boot Menu Construction    lines_top=2
-    ELSE
-        ${ipxe_menu}=    Get IPXE Boot Menu Construction
+    Enter IPXE Shell Submenu
+
+Enter IPXE Shell Submenu
+    [Documentation]
+    ...    Enters iPXE Shell submenu
+    ...
+    ...    === Requirements ===
+    ...    - Must be called from a Network Boot menu
+    ...
+    ...    === Arguments ===
+    ...    - ``${ipxe_menu}``: str | None - Boot Menu Construction to parse. If
+    ...    \ None then read menu construction from terminal
+    ...
+    ...    === Return Value ===
+    ...    None
+    ...
+    ...    === Effects ===
+    ...    - Enters iPXE shell
+    ...    - Sets iPXE terminal prompt
+    [Arguments]    ${ipxe_menu}=${NONE}
+    IF    $ipxe_menu is ${NONE}
+        IF    ${NETBOOT_UTILITIES_SUPPORT} == ${TRUE}
+            ${ipxe_menu}=    Get IPXE Boot Menu Construction    lines_top=2
+        ELSE
+            ${ipxe_menu}=    Get IPXE Boot Menu Construction
+        END
     END
     Enter Submenu From Snapshot    ${ipxe_menu}    iPXE Shell
     Set Prompt For Terminal    iPXE>

--- a/lib/dts-lib.robot
+++ b/lib/dts-lib.robot
@@ -119,23 +119,40 @@ Boot Dasharo Tools Suite
         FAIL    Unknown DTS boot method: ${dts_booting_method}
     END
 
-    # For PiKVM devices, we have only input on serial, not output. The video and serial consoles are
-    # two different console in case of Linux, they are not in sync anymore as in case of firmware.
-    # We have to switch to SSH connection to continue test execution on such devices.
+    Wait For DTS To Boot
+
+Wait For DTS To Boot
+    [Documentation]    Wait for DTS to boot. If using pikvm, connect via SSH as
+    ...    a workaround for video/serial consoles being different.
+    [Arguments]    ${fum}=${FALSE}
+    # For PiKVM devices, we have only input on serial, not output. The video
+    # and serial consoles are two different console in case of Linux, they are
+    # not in sync anymore as in case of firmware. We have to switch to SSH
+    # connection to continue test execution on such devices.
+    IF    ${fum}
+        VAR    ${prompt}=    ${DTS_ASK_FOR_CHOICE_PROMPT}
+    ELSE
+        VAR    ${prompt}=    ${DTS_CHECKPOINT}
+    END
     IF    '${DUT_CONNECTION_METHOD}' == 'pikvm'
         # Should be long enough so that DTS can boot
         ${old_timeout}=    Set Timeout    20s
         Run Keyword And Ignore Error
-        ...    Read From Terminal Until    Enter an option:
+        ...    Read From Terminal Until    ${prompt}
         Set Timeout    ${old_timeout}
-        # Enable SSH server and switch to SSH connection by writing on video console "in blind"
+        IF    ${fum}
+            Write Into Terminal    ${DTS_FUM_MENU_OPT}
+            Sleep    5s
+        END
+        # Enable SSH server and switch to SSH connection by writing on video
+        # console "in blind"
         Write Bare Into Terminal    K
         VAR    ${DUT_CONNECTION_METHOD}=    SSH    scope=GLOBAL
         Login To Linux Via SSH Without Password    root    root@DasharoToolsSuite:~#
         # Spawn DTS menu on SSH console
         Write Into Terminal    dts-boot
     END
-    Read From Terminal Until    Enter an option:
+    Read From Terminal Until    ${prompt}
     Sleep    5s
 
 Check HCL Report Creation

--- a/test_cases.json
+++ b/test_cases.json
@@ -2425,6 +2425,13 @@
   },
   {
     "doc": {
+      "_id": "CUP260.101",
+      "name": "Capsule update in Firmware Update Mode works",
+      "module": "Dasharo Stability"
+    }
+  },
+  {
+    "doc": {
       "_id": "DCU001.001",
       "name": "Change the UUID",
       "module": "Dasharo Compatibility",


### PR DESCRIPTION
Quick test on QEMU. Commented out some preparation steps as I wanted to run only my test (I'll verify it fully again later):

```diff
diff --git a/dasharo-stability/capsule-update.robot b/dasharo-stability/capsule-update.robot
index 47805dcdba40..a21fd7d073a6 100644
--- a/dasharo-stability/capsule-update.robot
+++ b/dasharo-stability/capsule-update.robot
@@ -18,15 +18,15 @@ Resource            ../lib/options/options-lib_dcu.robot
 Suite Setup         Run Keywords
 ...                     Prepare Test Suite
 ...                     AND    Skip If    not ${CAPSULE_UPDATE_SUPPORT}    Capsule Update not supported
-...                     AND    Display Preparation Instructions
-...                     AND    Get CUP Environment Variables
-...                     AND    Ensure Capsule Files Are Present
-...                     AND    Prepare For Logo Persistence Test
-...                     AND    Prepare For ROMHOLE Persistence Test    # MSI Only
-...                     AND    Run Keyword If    '${OPTIONS_LIB}' == 'options-lib_uefi-setup-menu'    Upload Required Files
-...                     AND    Get System Values
+# ...                     AND    Display Preparation Instructions
+# ...                     AND    Get CUP Environment Variables
+# ...                     AND    Ensure Capsule Files Are Present
+# ...                     AND    Prepare For Logo Persistence Test
+# ...                     AND    Prepare For ROMHOLE Persistence Test    # MSI Only
+# ...                     AND    Run Keyword If    '${OPTIONS_LIB}' == 'options-lib_uefi-setup-menu'    Upload Required Files
+# ...                     AND    Get System Values
 ...                     AND    Run Keyword If    '${MANUFACTURER}' != 'QEMU'    Set UEFI Option    MeMode    Disabled (HAP)
-...                     AND    Run Keyword If    '${OPTIONS_LIB}' == 'options-lib_uefi-setup-menu'    Deploy Uefi Shell
+# ...                     AND    Run Keyword If    '${OPTIONS_LIB}' == 'options-lib_uefi-setup-menu'    Deploy Uefi Shell
 ...                     AND    Set DUT Response Timeout    90s    # a boot can last longer than default 30s
 Suite Teardown      Run Keywords
 ...                     Log Out And Close Connection
```

`emulation_qemu_q35_v0.2.1-rc1.cap` is capsule built from `dasharo/coreboot`. I also replaced `qemu_q35.rom` with https://github.com/Dasharo/coreboot/releases/download/qemu_q35_v0.2.1/qemu_q35.rom as `_all_menus` version downloaded by default doesn't work with capsules (https://github.com/Dasharo/dasharo-issues/issues/1760)

```sh
robot -b cmd_logs.txt -v rte_ip:127.0.0.1 -v config:qemu \
      -L TRACE -v snipeit:no -v capsule_fw_file:../dasharo/coreboot/emulation_qemu_q35_v0.2.1-rc1.cap \
      -t "CUP260.101*" dasharo-stability/capsule-update.robot
```

```
==============================================================================
Capsule-Update
==============================================================================
CUP260.101 Capsule update in Firmware Update Mode works :: Check i... | FAIL |
Failed to queue capsule update via /dev/efi_capsule_loader: 1 != 0
------------------------------------------------------------------------------
Capsule-Update                                                        | FAIL |
1 test, 0 passed, 1 failed
=============================================================================
```

Failed as expected, since this issue likely applies to every fw.

Also tested on hardware (ODROID-H4+), didn't manage to run test without modifying suite preparation steps (https://github.com/Dasharo/open-source-firmware-validation/issues/1234)

```sh
 robot -b cmd_logs.txt \
       -v rte_ip:192.168.10.168 \
       -v config:odroid-h4-plus \
       -L TRACE \
       -v snipeit:yes \
       -v capsule_fw_file:"$HOME/Downloads/dasharo-hardkernel-odroid_h4/coreboot.cap" \
       -v device_ip:192.168.10.42 \
       -v fw_file:"$(realpath ../yocto/dts/binaries/hardkernel_odroid_h4_v0.9.1.rom)" \
       -t "CUP260.101*" dasharo-stability/capsule-update.robot
```

```text
CUP260.101 Capsule update in Firmware Update Mode works :: Check i... | FAIL |
Failed to queue capsule update via /dev/efi_capsule_loader: 1 != 0
Capsule-Update                                                        | FAIL |
1 test, 0 passed, 1 failed
==============================================================================
```

---

To make sure this test works, I temporarily modified it to boot DTS which contains workaround for this issue,

```diff
     # needed on slower platforms/serial connection
-    Write Bare Into Terminal    chain http://boot.dasharo.com/dts/dts-no-fum-fix.ipxe\n    interval=0.2
+    Write Bare Into Terminal    chain http://boot.dasharo.com/dts/dts.ipxe\n    interval=0.2
     # Boot into DTS shell
```

Result:

```
==============================================================================
Capsule-Update
==============================================================================
CUP260.101 Capsule update in Firmware Update Mode works :: Check i... | PASS |
------------------------------------------------------------------------------
Capsule-Update                                                        | PASS |
1 test, 1 passed, 0 failed
==============================================================================
```

As this test boots DTS without this workaround it'll only succeed if the issue is fixed in the firmware.