### PR TITLE
dts: dts-e2e: Add FUM test fixes and E2E014.005 & E2E014.006

### DIFF
--- a/dts/dts-e2e.robot
+++ b/dts/dts-e2e.robot
@@ -430,12 +430,12 @@ E2E014.001 Verify that capsule update while in FUM stops if unsupported
     ...    message when trying to use capsule update on firmware version that
     ...    doesn't support this combination
     Export Shell Variables For Emulation
-    ...    Fuse Platform
+    ...    UEFI Update
     ...    DCR
     ...    ${DTS_PLATFORM_VARIABLES}[novacustom-v540tu]
     ...    ${DTS_CONFIG_REF}
     Execute Command In Terminal    export TEST_BIOS_VERSION="Dasharo (coreboot+UEFI) 1.0.0"
-    Execute Command In Terminal    export TEST_FUM="true"
+    Execute Command In Terminal    export TEST_FUM_ORIG="true"
     Write Into Terminal    dts-boot
 
     Wait For Checkpoint And Write    ${DTS_ASK_FOR_CHOICE_PROMPT}    ${DTS_FUM_UPDATE_OPT}
@@ -447,12 +447,12 @@ E2E014.002 Verify that fusing while in FUM stops if unsupported
     ...    error message when trying to do it on firmware version that doesn't
     ...    support this combination
     Export Shell Variables For Emulation
-    ...    UEFI Update
+    ...    Fuse Platform
     ...    DCR
     ...    ${DTS_PLATFORM_VARIABLES}[novacustom-v540tu]
     ...    ${DTS_CONFIG_REF}
     Execute Command In Terminal    export TEST_BIOS_VERSION="Dasharo (coreboot+UEFI) 1.0.0"
-    Execute Command In Terminal    export TEST_FUM="true"
+    Execute Command In Terminal    export TEST_FUM_ORIG="true"
     Write Into Terminal    dts-boot
 
     Wait For Checkpoint And Write    ${DTS_ASK_FOR_CHOICE_PROMPT}    ${DTS_FUM_MENU_OPT}
@@ -464,14 +464,14 @@ E2E014.003 Verify that capsule update while in FUM works if supported
     [Documentation]    Test that FUM capsule update works correctly when on
     ...    firmware version that supports this combination
     Export Shell Variables For Emulation
-    ...    Fuse Platform
+    ...    UEFI Update
     ...    DCR
     ...    ${DTS_PLATFORM_VARIABLES}[novacustom-v540tu]
     ...    ${DTS_CONFIG_REF}
     Execute Command In Terminal    export TEST_BIOS_VERSION="Dasharo (coreboot+UEFI) 1.0.1"
     Execute Command In Terminal    export TEST_SYSTEM_VENDOR="3mdeb_test_config"
     Execute Command In Terminal    export TEST_SYSTEM_MODEL="fum_cap_test"
-    Execute Command In Terminal    export TEST_FUM="true"
+    Execute Command In Terminal    export TEST_FUM_ORIG="true"
     Write Into Terminal    dts-boot
 
     Wait For Checkpoint And Write    ${DTS_ASK_FOR_CHOICE_PROMPT}    ${DTS_FUM_UPDATE_OPT}
@@ -489,6 +489,37 @@ E2E014.004 Verify that fusing while in FUM works if supported
     Execute Command In Terminal    export TEST_BIOS_VERSION="Dasharo (coreboot+UEFI) 1.0.1"
     Execute Command In Terminal    export TEST_SYSTEM_VENDOR="3mdeb_test_config"
     Execute Command In Terminal    export TEST_SYSTEM_MODEL="fum_cap_test"
+    Execute Command In Terminal    export TEST_FUM_ORIG="true"
+    Write Into Terminal    dts-boot
+
+    Wait For Checkpoint And Write    ${DTS_ASK_FOR_CHOICE_PROMPT}    ${DTS_FUM_MENU_OPT}
+    Go Through Fusing Platform
+
+E2E014.005 Verify that capsule update while in FUM with workaround works
+    [Documentation]    Test that FUM capsule update works correctly when using
+    ...    replace_fum_efivar.efi
+    Export Shell Variables For Emulation
+    ...    UEFI Update
+    ...    DCR
+    ...    ${DTS_PLATFORM_VARIABLES}[novacustom-v540tu]
+    ...    ${DTS_CONFIG_REF}
+    Execute Command In Terminal    export TEST_BIOS_VERSION="Dasharo (coreboot+UEFI) 1.0.0"
+    Execute Command In Terminal    export TEST_FUM="true"
+    Write Into Terminal    dts-boot
+
+    Wait For Checkpoint And Write    ${DTS_ASK_FOR_CHOICE_PROMPT}    ${DTS_FUM_UPDATE_OPT}
+    Wait For Checkpoint    Rebooting in
+    Wait For Checkpoint    Rebooting
+
+E2E014.006 Verify that fusing while in FUM with workaround works
+    [Documentation]    Test that fusing while in FUM works when using
+    ...    replace_fum_efivar.efi
+    Export Shell Variables For Emulation
+    ...    Fuse Platform
+    ...    DCR
+    ...    ${DTS_PLATFORM_VARIABLES}[novacustom-v540tu]
+    ...    ${DTS_CONFIG_REF}
+    Execute Command In Terminal    export TEST_BIOS_VERSION="Dasharo (coreboot+UEFI) 1.0.0"
     Execute Command In Terminal    export TEST_FUM="true"
     Write Into Terminal    dts-boot
 

--- a/dts/profiles/msi-pro-z690-a-ddr5 Initial Deployment - DPP.profile
+++ b/dts/profiles/msi-pro-z690-a-ddr5 Initial Deployment - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/msi-pro-z690-a-ddr5 UEFI Update - DPP.profile
+++ b/dts/profiles/msi-pro-z690-a-ddr5 UEFI Update - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/msi-pro-z690-a-ddr5 UEFI->Heads Transition - DPP.profile
+++ b/dts/profiles/msi-pro-z690-a-ddr5 UEFI->Heads Transition - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/msi-pro-z690-a-wifi-ddr4 Initial Deployment - DCR.profile
+++ b/dts/profiles/msi-pro-z690-a-wifi-ddr4 Initial Deployment - DCR.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/msi-pro-z690-a-wifi-ddr4 Initial Deployment - DPP.profile
+++ b/dts/profiles/msi-pro-z690-a-wifi-ddr4 Initial Deployment - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/msi-pro-z690-a-wifi-ddr4 UEFI Update - DCR.profile
+++ b/dts/profiles/msi-pro-z690-a-wifi-ddr4 UEFI Update - DCR.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/msi-pro-z690-a-wifi-ddr4 UEFI Update - DPP.profile
+++ b/dts/profiles/msi-pro-z690-a-wifi-ddr4 UEFI Update - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/msi-pro-z690-a-wifi-ddr4 UEFI->Heads Transition - DPP.profile
+++ b/dts/profiles/msi-pro-z690-a-wifi-ddr4 UEFI->Heads Transition - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/msi-pro-z790-p-ddr5 Initial Deployment - DPP.profile
+++ b/dts/profiles/msi-pro-z790-p-ddr5 Initial Deployment - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/msi-pro-z790-p-ddr5 UEFI Update - DPP.profile
+++ b/dts/profiles/msi-pro-z790-p-ddr5 UEFI Update - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/msi-pro-z790-p-ddr5 UEFI->Heads Transition - DPP.profile
+++ b/dts/profiles/msi-pro-z790-p-ddr5 UEFI->Heads Transition - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/novacustom-ns50mu UEFI Update - DCR.profile
+++ b/dts/profiles/novacustom-ns50mu UEFI Update - DCR.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/novacustom-ns50pu UEFI Update - DCR.profile
+++ b/dts/profiles/novacustom-ns50pu UEFI Update - DCR.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/novacustom-ns70mu UEFI Update - DCR.profile
+++ b/dts/profiles/novacustom-ns70mu UEFI Update - DCR.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/novacustom-ns70pu UEFI Update - DCR.profile
+++ b/dts/profiles/novacustom-ns70pu UEFI Update - DCR.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/novacustom-nuc_box-125H Initial Deployment - DCR.profile
+++ b/dts/profiles/novacustom-nuc_box-125H Initial Deployment - DCR.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/novacustom-nuc_box-155H Initial Deployment - DCR.profile
+++ b/dts/profiles/novacustom-nuc_box-155H Initial Deployment - DCR.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/novacustom-nv41mb UEFI Update - DCR.profile
+++ b/dts/profiles/novacustom-nv41mb UEFI Update - DCR.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/novacustom-nv41mz UEFI Update - DCR.profile
+++ b/dts/profiles/novacustom-nv41mz UEFI Update - DCR.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/novacustom-nv41pz UEFI Update - DCR.profile
+++ b/dts/profiles/novacustom-nv41pz UEFI Update - DCR.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/novacustom-nv41pz UEFI->Heads Transition - DPP.profile
+++ b/dts/profiles/novacustom-nv41pz UEFI->Heads Transition - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/novacustom-v540tnd Fuse Platform - DCR.profile
+++ b/dts/profiles/novacustom-v540tnd Fuse Platform - DCR.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/novacustom-v540tnd UEFI Update - DCR.profile
+++ b/dts/profiles/novacustom-v540tnd UEFI Update - DCR.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/novacustom-v540tu Fuse Platform - DCR.profile
+++ b/dts/profiles/novacustom-v540tu Fuse Platform - DCR.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/novacustom-v540tu UEFI Update - DCR.profile
+++ b/dts/profiles/novacustom-v540tu UEFI Update - DCR.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/novacustom-v540tu UEFI->Heads Transition - DPP.profile
+++ b/dts/profiles/novacustom-v540tu UEFI->Heads Transition - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/novacustom-v560tnd Fuse Platform - DCR.profile
+++ b/dts/profiles/novacustom-v560tnd Fuse Platform - DCR.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/novacustom-v560tnd UEFI Update - DCR.profile
+++ b/dts/profiles/novacustom-v560tnd UEFI Update - DCR.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/novacustom-v560tne UEFI Update - DCR.profile
+++ b/dts/profiles/novacustom-v560tne UEFI Update - DCR.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/novacustom-v560tu Fuse Platform - DCR.profile
+++ b/dts/profiles/novacustom-v560tu Fuse Platform - DCR.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/novacustom-v560tu UEFI Update - DCR.profile
+++ b/dts/profiles/novacustom-v560tu UEFI Update - DCR.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/novacustom-v560tu UEFI->Heads Transition - DPP.profile
+++ b/dts/profiles/novacustom-v560tu UEFI->Heads Transition - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/odroid-h4-plus Dasharo (Slim Bootloader+UEFI) Initial Deployment - DPP.profile
+++ b/dts/profiles/odroid-h4-plus Dasharo (Slim Bootloader+UEFI) Initial Deployment - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/odroid-h4-plus Dasharo (coreboot+UEFI) to Dasharo (Slim Bootloader+UEFI) Transition - DPP.profile
+++ b/dts/profiles/odroid-h4-plus Dasharo (coreboot+UEFI) to Dasharo (Slim Bootloader+UEFI) Transition - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/odroid-h4-plus Initial Deployment - DPP.profile
+++ b/dts/profiles/odroid-h4-plus Initial Deployment - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/odroid-h4-plus UEFI Update - DPP.profile
+++ b/dts/profiles/odroid-h4-plus UEFI Update - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/optiplex-7010 Initial Deployment - DPP.profile
+++ b/dts/profiles/optiplex-7010 Initial Deployment - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/optiplex-7010 UEFI Update - DPP.profile
+++ b/dts/profiles/optiplex-7010 UEFI Update - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/optiplex-9010 Initial Deployment - DPP.profile
+++ b/dts/profiles/optiplex-9010 Initial Deployment - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/optiplex-9010 UEFI Update - DPP.profile
+++ b/dts/profiles/optiplex-9010 UEFI Update - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/pcengines-apu2 SeaBIOS Update - DPP.profile
+++ b/dts/profiles/pcengines-apu2 SeaBIOS Update - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/pcengines-apu2 SeaBIOS->UEFI Transition - DPP.profile
+++ b/dts/profiles/pcengines-apu2 SeaBIOS->UEFI Transition - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/pcengines-apu2 UEFI Update - DPP.profile
+++ b/dts/profiles/pcengines-apu2 UEFI Update - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/pcengines-apu3 SeaBIOS Update - DPP.profile
+++ b/dts/profiles/pcengines-apu3 SeaBIOS Update - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/pcengines-apu3 SeaBIOS->UEFI Transition - DPP.profile
+++ b/dts/profiles/pcengines-apu3 SeaBIOS->UEFI Transition - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/pcengines-apu3 UEFI Update - DPP.profile
+++ b/dts/profiles/pcengines-apu3 UEFI Update - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/pcengines-apu4 SeaBIOS Update - DPP.profile
+++ b/dts/profiles/pcengines-apu4 SeaBIOS Update - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/pcengines-apu4 SeaBIOS->UEFI Transition - DPP.profile
+++ b/dts/profiles/pcengines-apu4 SeaBIOS->UEFI Transition - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/pcengines-apu4 UEFI Update - DPP.profile
+++ b/dts/profiles/pcengines-apu4 UEFI Update - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/pcengines-apu6 SeaBIOS Update - DPP.profile
+++ b/dts/profiles/pcengines-apu6 SeaBIOS Update - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/pcengines-apu6 SeaBIOS->UEFI Transition - DPP.profile
+++ b/dts/profiles/pcengines-apu6 SeaBIOS->UEFI Transition - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0

--- a/dts/profiles/pcengines-apu6 UEFI Update - DPP.profile
+++ b/dts/profiles/pcengines-apu6 UEFI Update - DPP.profile
@@ -4,6 +4,7 @@ dmidecode -s baseboard-product-name 0
 dmidecode -s processor-version 0
 dmidecode -s bios-vendor 0
 dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
 dmidecode -s system-manufacturer 0
 dmidecode -s system-product-name 0


### PR DESCRIPTION
```text
==============================================================================
Dts-E2E
==============================================================================
E2E013.001 Verify that FUM update doesn't start automatically :: T... | PASS |
------------------------------------------------------------------------------
E2E013.002 Verify that FUM update succeeds :: Test that FUM update... | PASS |
------------------------------------------------------------------------------
E2E013.003 Verify that entering DTS menu in FUM works :: Test that... | PASS |
------------------------------------------------------------------------------
E2E014.001 Verify that capsule update while in FUM stops if unsupp... | PASS |
------------------------------------------------------------------------------
E2E014.002 Verify that fusing while in FUM stops if unsupported ::... | PASS |
------------------------------------------------------------------------------
E2E014.003 Verify that capsule update while in FUM works if suppor... | PASS |
------------------------------------------------------------------------------
E2E014.004 Verify that fusing while in FUM works if supported :: T... | PASS |
------------------------------------------------------------------------------
E2E014.005 Verify that capsule update while in FUM with workaround... | PASS |
------------------------------------------------------------------------------
E2E014.006 Verify that fusing while in FUM with workaround works :... | PASS |
------------------------------------------------------------------------------
Dts-E2E                                                               | PASS |
9 tests, 9 passed, 0 failed
==============================================================================
```