### PR TITLE
platform-configs/novacustom-*: Bump benchmark results for 155h platforms

### DIFF
--- a/platform-configs/include/cpu-perf-155h.robot
+++ b/platform-configs/include/cpu-perf-155h.robot
@@ -1,0 +1,45 @@
+*** Variables ***
+# Values obtained from https://openbenchmarking.org/vs/Processor/Intel+Core+Ultra+7+155H
+
+# Ubuntu
+${ZIP_MULTI_COMPRESSION}=       69245    # MIPS
+${ZIP_MULTI_DECOMPRESSION}=     47858    # MIPS
+${CRAY_5_K_RENDER}=             549    # sec
+${CRAY_4_K_RENDER}=             319    # sec
+${CRAY_1080_P_RENDER}=          79    # sec
+${COREMARK_SINGLE}=             387404    # iterations/s
+
+# Windows
+# reference score for 155H from https://openbenchmarking.org/result/2508216-NE-SKIBIDI6461
+&{UPP_SMALLPT_BENCHMARK}=
+...                             name=smallpt
+...                             score=19.02
+...                             scale=lower_is_better
+...                             dev=0.2
+...                             type=singlecore
+# reference score for 155H from https://openbenchmarking.org/test/pts/crafty
+&{UPP_CRAFTY_BENCHMARK}=
+...                             name=crafty
+...                             score=10919999
+...                             scale=higher_is_better
+...                             dev=0.2
+...                             type=singlecore
+# reference score for 155H from https://openbenchmarking.org/result/2508217-NE-AAAAAAA9714
+&{UPP_CACHEBENCH_BENCHMARK}=
+...                             name=cachebench
+...                             score=106987
+...                             scale=higher_is_better
+...                             dev=0.2
+...                             type=multicore
+# reference score for 155H from    https://openbenchmarking.org/result/2508292-NE-20250829131
+&{UPP_BLAKE2_BENCHMARK}=
+...                             name=blake2
+...                             score=4.06
+...                             scale=lower_is_better
+...                             dev=0.2
+...                             type=multicore
+@{UPP_BENCHMARKS}=
+...                             &{UPP_SMALLPT_BENCHMARK}
+...                             &{UPP_CRAFTY_BENCHMARK}
+...                             &{UPP_CACHEBENCH_BENCHMARK}
+...                             &{UPP_BLAKE2_BENCHMARK}

--- a/platform-configs/novacustom-nuc_box-155H.robot
+++ b/platform-configs/novacustom-nuc_box-155H.robot
@@ -24,11 +24,11 @@ ${USB_MODEL}=                           ${TBD}
 ${USB_DEVICE}=                          Linux
 
 # cpu performance Ubuntu
-${ZIP_MULTI_COMPRESSION}=               63476    # MIPS
-${ZIP_MULTI_DECOMPRESSION}=             39336    # MIPS
-${CRAY_5_K_RENDER}=                     654.5    # sec
-${CRAY_4_K_RENDER}=                     356.9    # sec
-${CRAY_1080_P_RENDER}=                  90.8    # sec
+${ZIP_MULTI_COMPRESSION}=               69245    # MIPS
+${ZIP_MULTI_DECOMPRESSION}=             47858    # MIPS
+${CRAY_5_K_RENDER}=                     549    # sec
+${CRAY_4_K_RENDER}=                     319    # sec
+${CRAY_1080_P_RENDER}=                  79    # sec
 ${COREMARK_SINGLE}=                     400079.5    # iterations/s
 
 # cpu performance Windows

--- a/platform-configs/novacustom-nuc_box-155H.robot
+++ b/platform-configs/novacustom-nuc_box-155H.robot
@@ -3,6 +3,7 @@ Resource    include/novacustom-nuc_box.robot
 Resource    include/novacustom-mtl.robot
 Resource    include/novacustom-common.robot
 Resource    include/default.robot
+Resource    include/cpu-perf-155h.robot
 
 
 *** Variables ***
@@ -22,44 +23,6 @@ ${CPU_MIN_FREQUENCY}=                   200
 ${DEVICE_NVME_DISK}=                    Non-Volatile memory controller
 ${USB_MODEL}=                           ${TBD}
 ${USB_DEVICE}=                          Linux
-
-# cpu performance Ubuntu
-${ZIP_MULTI_COMPRESSION}=               69245    # MIPS
-${ZIP_MULTI_DECOMPRESSION}=             47858    # MIPS
-${CRAY_5_K_RENDER}=                     549    # sec
-${CRAY_4_K_RENDER}=                     319    # sec
-${CRAY_1080_P_RENDER}=                  79    # sec
-${COREMARK_SINGLE}=                     400079.5    # iterations/s
-
-# cpu performance Windows
-# reference score for 155H from https://openbenchmarking.org/result/2508216-NE-SKIBIDI6461
-&{UPP_SMALLPT_BENCHMARK}=
-...                                     name=smallpt
-...                                     score=19.02
-...                                     scale=lower_is_better
-...                                     dev=0.2
-...                                     type=singlecore
-# reference score for 155H from https://openbenchmarking.org/test/pts/crafty
-&{UPP_CRAFTY_BENCHMARK}=
-...                                     name=crafty
-...                                     score=10919999
-...                                     scale=higher_is_better
-...                                     dev=0.2
-...                                     type=singlecore
-# reference score for 155H from https://openbenchmarking.org/result/2508217-NE-AAAAAAA9714
-&{UPP_CACHEBENCH_BENCHMARK}=
-...                                     name=cachebench
-...                                     score=106987
-...                                     scale=higher_is_better
-...                                     dev=0.2
-...                                     type=multicore
-# reference score for 155H from    https://openbenchmarking.org/result/2508292-NE-20250829131
-&{UPP_BLAKE2_BENCHMARK}=                name=blake2    score=4.06    scale=lower_is_better    dev=0.2    type=multicore
-@{UPP_BENCHMARKS}=
-...                                     &{UPP_SMALLPT_BENCHMARK}
-...                                     &{UPP_CRAFTY_BENCHMARK}
-...                                     &{UPP_CACHEBENCH_BENCHMARK}
-...                                     &{UPP_BLAKE2_BENCHMARK}
 
 # disk i-o
 ${UBU_SEQ_READ_QUEUED}=                 4677    # MB/s

--- a/platform-configs/novacustom-v540tnd.robot
+++ b/platform-configs/novacustom-v540tnd.robot
@@ -56,11 +56,11 @@ ${FAN_SPEED_MEASURE_SUPPORT}=                   ${TRUE}
 ${HDMI_AUDIO_SUPPORT}=                          ${TRUE}
 
 # cpu performance Ubuntu
-${ZIP_MULTI_COMPRESSION}=                       63476    # MIPS
-${ZIP_MULTI_DECOMPRESSION}=                     39336    # MIPS
-${CRAY_5_K_RENDER}=                             654.5    # sec
-${CRAY_4_K_RENDER}=                             356.9    # sec
-${CRAY_1080_P_RENDER}=                          90.8    # sec
+${ZIP_MULTI_COMPRESSION}=                       69245    # MIPS
+${ZIP_MULTI_DECOMPRESSION}=                     47858    # MIPS
+${CRAY_5_K_RENDER}=                             549    # sec
+${CRAY_4_K_RENDER}=                             319    # sec
+${CRAY_1080_P_RENDER}=                          79    # sec
 ${COREMARK_SINGLE}=                             400079.5    # iterations/s
 
 # cpu performance Windows

--- a/platform-configs/novacustom-v540tnd.robot
+++ b/platform-configs/novacustom-v540tnd.robot
@@ -1,6 +1,7 @@
 *** Settings ***
 Resource    include/novacustom-mtl.robot
 Resource    include/novacustom-common.robot
+Resource    include/cpu-perf-155h.robot
 
 
 *** Variables ***
@@ -54,49 +55,6 @@ ${CLEVO_BATTERY_CAPACITY}=
 ...                                             4636000
 ${FAN_SPEED_MEASURE_SUPPORT}=                   ${TRUE}
 ${HDMI_AUDIO_SUPPORT}=                          ${TRUE}
-
-# cpu performance Ubuntu
-${ZIP_MULTI_COMPRESSION}=                       69245    # MIPS
-${ZIP_MULTI_DECOMPRESSION}=                     47858    # MIPS
-${CRAY_5_K_RENDER}=                             549    # sec
-${CRAY_4_K_RENDER}=                             319    # sec
-${CRAY_1080_P_RENDER}=                          79    # sec
-${COREMARK_SINGLE}=                             400079.5    # iterations/s
-
-# cpu performance Windows
-# reference score for 155H from https://openbenchmarking.org/result/2508216-NE-SKIBIDI6461
-&{UPP_SMALLPT_BENCHMARK}=
-...                                             name=smallpt
-...                                             score=19.02
-...                                             scale=lower_is_better
-...                                             dev=0.2
-...                                             type=singlecore
-# reference score for 155H from https://openbenchmarking.org/test/pts/crafty
-&{UPP_CRAFTY_BENCHMARK}=
-...                                             name=crafty
-...                                             score=10919999
-...                                             scale=higher_is_better
-...                                             dev=0.2
-...                                             type=singlecore
-# reference score for 155H from https://openbenchmarking.org/result/2508217-NE-AAAAAAA9714
-&{UPP_CACHEBENCH_BENCHMARK}=
-...                                             name=cachebench
-...                                             score=106987
-...                                             scale=higher_is_better
-...                                             dev=0.2
-...                                             type=multicore
-# reference score for 155H from    https://openbenchmarking.org/result/2508292-NE-20250829131
-&{UPP_BLAKE2_BENCHMARK}=
-...                                             name=blake2
-...                                             score=4.06
-...                                             scale=lower_is_better
-...                                             dev=0.2
-...                                             type=multicore
-@{UPP_BENCHMARKS}=
-...                                             &{UPP_SMALLPT_BENCHMARK}
-...                                             &{UPP_CRAFTY_BENCHMARK}
-...                                             &{UPP_CACHEBENCH_BENCHMARK}
-...                                             &{UPP_BLAKE2_BENCHMARK}
 
 # disk i-o
 ${UBU_SEQ_READ_QUEUED}=                         4677    # MB/s

--- a/platform-configs/novacustom-v540tu.robot
+++ b/platform-configs/novacustom-v540tu.robot
@@ -1,6 +1,7 @@
 *** Settings ***
 Resource    include/novacustom-mtl.robot
 Resource    include/novacustom-common.robot
+Resource    include/cpu-perf-155h.robot
 
 
 *** Variables ***
@@ -38,49 +39,6 @@ ${TESTS_IN_WINDOWS_SUPPORT}=                ${TRUE}
 ${CLEVO_USB_C_HUB}=                         Billboard Device
 ${USB_DEVICE}=                              Linux
 ${MAX_CPU_TEMP_THRESHOLD}=                  110
-
-# cpu performance Ubuntu
-${ZIP_MULTI_COMPRESSION}=                   69245    # MIPS
-${ZIP_MULTI_DECOMPRESSION}=                 47858    # MIPS
-${CRAY_5_K_RENDER}=                         549    # sec
-${CRAY_4_K_RENDER}=                         319    # sec
-${CRAY_1080_P_RENDER}=                      79    # sec
-${COREMARK_SINGLE}=                         400079.5    # iterations/s
-
-# cpu performance Windows
-# reference score for 155H from https://openbenchmarking.org/result/2508216-NE-SKIBIDI6461
-&{UPP_SMALLPT_BENCHMARK}=
-...                                         name=smallpt
-...                                         score=19.02
-...                                         scale=lower_is_better
-...                                         dev=0.2
-...                                         type=singlecore
-# reference score for 155H from https://openbenchmarking.org/test/pts/crafty
-&{UPP_CRAFTY_BENCHMARK}=
-...                                         name=crafty
-...                                         score=10919999
-...                                         scale=higher_is_better
-...                                         dev=0.2
-...                                         type=singlecore
-# reference score for 155H from https://openbenchmarking.org/result/2508217-NE-AAAAAAA9714
-&{UPP_CACHEBENCH_BENCHMARK}=
-...                                         name=cachebench
-...                                         score=106987
-...                                         scale=higher_is_better
-...                                         dev=0.2
-...                                         type=multicore
-# reference score for 155H from    https://openbenchmarking.org/result/2508292-NE-20250829131
-&{UPP_BLAKE2_BENCHMARK}=
-...                                         name=blake2
-...                                         score=4.06
-...                                         scale=lower_is_better
-...                                         dev=0.2
-...                                         type=multicore
-@{UPP_BENCHMARKS}=
-...                                         &{UPP_SMALLPT_BENCHMARK}
-...                                         &{UPP_CRAFTY_BENCHMARK}
-...                                         &{UPP_CACHEBENCH_BENCHMARK}
-...                                         &{UPP_BLAKE2_BENCHMARK}
 
 # disk i-o
 ${UBU_SEQ_READ_QUEUED}=                     4677    # MB/s

--- a/platform-configs/novacustom-v540tu.robot
+++ b/platform-configs/novacustom-v540tu.robot
@@ -40,11 +40,11 @@ ${USB_DEVICE}=                              Linux
 ${MAX_CPU_TEMP_THRESHOLD}=                  110
 
 # cpu performance Ubuntu
-${ZIP_MULTI_COMPRESSION}=                   63476    # MIPS
-${ZIP_MULTI_DECOMPRESSION}=                 39336    # MIPS
-${CRAY_5_K_RENDER}=                         654.5    # sec
-${CRAY_4_K_RENDER}=                         356.9    # sec
-${CRAY_1080_P_RENDER}=                      90.8    # sec
+${ZIP_MULTI_COMPRESSION}=                   69245    # MIPS
+${ZIP_MULTI_DECOMPRESSION}=                 47858    # MIPS
+${CRAY_5_K_RENDER}=                         549    # sec
+${CRAY_4_K_RENDER}=                         319    # sec
+${CRAY_1080_P_RENDER}=                      79    # sec
 ${COREMARK_SINGLE}=                         400079.5    # iterations/s
 
 # cpu performance Windows

--- a/platform-configs/novacustom-v560tnd.robot
+++ b/platform-configs/novacustom-v560tnd.robot
@@ -1,6 +1,7 @@
 *** Settings ***
 Resource    include/novacustom-mtl.robot
 Resource    include/novacustom-common.robot
+Resource    include/cpu-perf-155h.robot
 
 
 *** Variables ***
@@ -51,44 +52,6 @@ ${USB_DEVICE}=                          SanDisk
 ${DGPU_ONLY_SUPPORT}=                   ${TRUE}
 
 ${DISK_IO_PERFORMANCE_TESTS}=           ${TRUE}
-
-# cpu performance Ubuntu
-${ZIP_MULTI_COMPRESSION}=               69245    # MIPS
-${ZIP_MULTI_DECOMPRESSION}=             47858    # MIPS
-${CRAY_5_K_RENDER}=                     549    # sec
-${CRAY_4_K_RENDER}=                     319    # sec
-${CRAY_1080_P_RENDER}=                  79    # sec
-${COREMARK_SINGLE}=                     407451.446    # iterations/s
-
-# cpu performance Windows
-# reference score for 155H from https://openbenchmarking.org/result/2508216-NE-SKIBIDI6461
-&{UPP_SMALLPT_BENCHMARK}=
-...                                     name=smallpt
-...                                     score=19.02
-...                                     scale=lower_is_better
-...                                     dev=0.2
-...                                     type=singlecore
-# reference score for 155H from https://openbenchmarking.org/test/pts/crafty
-&{UPP_CRAFTY_BENCHMARK}=
-...                                     name=crafty
-...                                     score=10919999
-...                                     scale=higher_is_better
-...                                     dev=0.2
-...                                     type=singlecore
-# reference score for 155H from https://openbenchmarking.org/result/2508217-NE-AAAAAAA9714
-&{UPP_CACHEBENCH_BENCHMARK}=
-...                                     name=cachebench
-...                                     score=106987
-...                                     scale=higher_is_better
-...                                     dev=0.2
-...                                     type=multicore
-# reference score for 155H from    https://openbenchmarking.org/result/2508292-NE-20250829131
-&{UPP_BLAKE2_BENCHMARK}=                name=blake2    score=4.06    scale=lower_is_better    dev=0.2    type=multicore
-@{UPP_BENCHMARKS}=
-...                                     &{UPP_SMALLPT_BENCHMARK}
-...                                     &{UPP_CRAFTY_BENCHMARK}
-...                                     &{UPP_CACHEBENCH_BENCHMARK}
-...                                     &{UPP_BLAKE2_BENCHMARK}
 
 # disk i-o
 ${UBU_SEQ_READ_QUEUED}=                 5953.5    # MB/s

--- a/platform-configs/novacustom-v560tnd.robot
+++ b/platform-configs/novacustom-v560tnd.robot
@@ -53,11 +53,11 @@ ${DGPU_ONLY_SUPPORT}=                   ${TRUE}
 ${DISK_IO_PERFORMANCE_TESTS}=           ${TRUE}
 
 # cpu performance Ubuntu
-${ZIP_MULTI_COMPRESSION}=               79729    # MIPS
-${ZIP_MULTI_DECOMPRESSION}=             52410    # MIPS
-${CRAY_5_K_RENDER}=                     585.333    # sec
-${CRAY_4_K_RENDER}=                     326.895    # sec
-${CRAY_1080_P_RENDER}=                  80.547    # sec
+${ZIP_MULTI_COMPRESSION}=               69245    # MIPS
+${ZIP_MULTI_DECOMPRESSION}=             47858    # MIPS
+${CRAY_5_K_RENDER}=                     549    # sec
+${CRAY_4_K_RENDER}=                     319    # sec
+${CRAY_1080_P_RENDER}=                  79    # sec
 ${COREMARK_SINGLE}=                     407451.446    # iterations/s
 
 # cpu performance Windows

--- a/platform-configs/novacustom-v560tne.robot
+++ b/platform-configs/novacustom-v560tne.robot
@@ -53,11 +53,11 @@ ${USB_DEVICE}=                                  SanDisk
 @{ATTACHED_USB}=                                SanDisk
 
 # performance
-${ZIP_MULTI_COMPRESSION}=                       79729    # MIPS
-${ZIP_MULTI_DECOMPRESSION}=                     52410    # MIPS
-${CRAY_5_K_RENDER}=                             585.333    # sec
-${CRAY_4_K_RENDER}=                             326.895    # sec
-${CRAY_1080_P_RENDER}=                          80.547    # sec
+${ZIP_MULTI_COMPRESSION}=                       69245    # MIPS
+${ZIP_MULTI_DECOMPRESSION}=                     47858    # MIPS
+${CRAY_5_K_RENDER}=                             549    # sec
+${CRAY_4_K_RENDER}=                             319    # sec
+${CRAY_1080_P_RENDER}=                          79    # sec
 ${COREMARK_SINGLE}=                             407451.446    # iterations/s
 
 # disk i-o


### PR DESCRIPTION
Update benchmark values with ones from https://openbenchmarking.org/vs/Processor/Intel+Core+Ultra+7+155H .
After recent performance fixes, the performance exceeds the previous values. Set the expected values to average 155h performance.

*ref: ncm-2109*