### PR TITLE
Add boot log error checking tests to coreboot base port suite

### DIFF
--- a/dasharo-compatibility/coreboot-base-port.robot
+++ b/dasharo-compatibility/coreboot-base-port.robot
@@ -73,3 +73,68 @@ CBP006.001 Resource allocator v4 - allocating resources
     Power On
     Set DUT Response Timeout    120s
     Read From Terminal Until    Pass 2 (allocating resources)
+
+CBP007.001 No ASSERTION ERROR in boot log
+    [Documentation]    Check that the coreboot boot log does not contain any
+    ...    ASSERTION ERROR messages, which indicate critical
+    ...    misconfigurations such as missing PMC GPE routes.
+    Skip If    not ${BASE_PORT_LOG_CHECK_SUPPORT}    CBP007.001 not supported
+    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    CBP007.001 not supported
+    Power On
+    Boot System Or From Connected Disk    ${ENV_ID_UBUNTU}
+    Login To Linux
+    Switch To Root User
+    ${output}=    Execute Command In Terminal    cbmem -1
+    Should Not Contain    ${output}    ASSERTION ERROR
+
+CBP008.001 No missing static PCI devices in boot log
+    [Documentation]    Check that the coreboot boot log does not contain messages
+    ...    about static PCI devices not being found, which indicate
+    ...    wrong device states in the devicetree.cb configuration.
+    Skip If    not ${BASE_PORT_LOG_CHECK_SUPPORT}    CBP008.001 not supported
+    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    CBP008.001 not supported
+    Power On
+    Boot System Or From Connected Disk    ${ENV_ID_UBUNTU}
+    Login To Linux
+    Switch To Root User
+    ${output}=    Execute Command In Terminal    cbmem -1
+    Should Not Contain    ${output}    not found, disabling it.
+
+CBP009.001 No resource allocation failures in boot log
+    [Documentation]    Check that the coreboot boot log does not contain resource
+    ...    allocation failure messages, which typically indicate PCI
+    ...    resource conflicts or misconfigured hotplug ports.
+    Skip If    not ${BASE_PORT_LOG_CHECK_SUPPORT}    CBP009.001 not supported
+    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    CBP009.001 not supported
+    Power On
+    Boot System Or From Connected Disk    ${ENV_ID_UBUNTU}
+    Login To Linux
+    Switch To Root User
+    ${output}=    Execute Command In Terminal    cbmem -1
+    Should Not Contain    ${output}    Resource didn't fit!!!
+
+CBP010.001 No BUG messages in boot log
+    [Documentation]    Check that the coreboot boot log does not contain any BUG
+    ...    messages, which indicate code-level problems such as
+    ...    requests for hidden devices.
+    Skip If    not ${BASE_PORT_LOG_CHECK_SUPPORT}    CBP010.001 not supported
+    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    CBP010.001 not supported
+    Power On
+    Boot System Or From Connected Disk    ${ENV_ID_UBUNTU}
+    Login To Linux
+    Switch To Root User
+    ${output}=    Execute Command In Terminal    cbmem -1
+    Should Not Contain    ${output}    BUG:
+
+CBP011.001 No devicetree.cb warnings in boot log
+    [Documentation]    Check that the coreboot boot log does not contain messages
+    ...    suggesting the devicetree.cb needs to be reviewed, which
+    ...    indicate leftover or misconfigured static device entries.
+    Skip If    not ${BASE_PORT_LOG_CHECK_SUPPORT}    CBP011.001 not supported
+    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    CBP011.001 not supported
+    Power On
+    Boot System Or From Connected Disk    ${ENV_ID_UBUNTU}
+    Login To Linux
+    Switch To Root User
+    ${output}=    Execute Command In Terminal    cbmem -1
+    Should Not Contain    ${output}    Check your devicetree.cb

--- a/platform-configs/include/default.robot
+++ b/platform-configs/include/default.robot
@@ -171,6 +171,7 @@ ${BASE_PORT_BOOTBLOCK_SUPPORT}=                     ${FALSE}
 ${BASE_PORT_ROMSTAGE_SUPPORT}=                      ${FALSE}
 ${BASE_PORT_POSTCAR_SUPPORT}=                       ${FALSE}
 ${BASE_PORT_RAMSTAGE_SUPPORT}=                      ${FALSE}
+${BASE_PORT_LOG_CHECK_SUPPORT}=                     ${FALSE}
 ${BOOT_BLOCKING_SUPPORT}=                           ${FALSE}
 ${FAN_SPEED_MEASURE_SUPPORT}=                       ${FALSE}
 ${DOCKING_STATION_AUDIO_SUPPORT}=                   ${FALSE}

--- a/platform-configs/qemu.robot
+++ b/platform-configs/qemu.robot
@@ -39,6 +39,7 @@ ${DASHARO_NETWORKING_MENU_SUPPORT}=         ${TRUE}
 ${DASHARO_CHIPSET_MENU_SUPPORT}=            ${TRUE}
 
 # Test module: dasharo-compatibility
+${BASE_PORT_LOG_CHECK_SUPPORT}=             ${TRUE}
 ${CUSTOM_BOOT_MENU_KEY_SUPPORT}=            ${TRUE}
 ${CUSTOM_SETUP_MENU_KEY_SUPPORT}=           ${TRUE}
 ${CUSTOM_NETWORK_BOOT_ENTRIES_SUPPORT}=     ${TRUE}


### PR DESCRIPTION
**Closes:** https://github.com/Dasharo/open-source-firmware-validation/issues/921

This PR adds 5 new Robot Framework test cases (CBP007-CBP011) to the coreboot base port test suite. It parses boot logs for common errors and warnings indicating firmware misconfiguration.

## Error patterns checked

Each test boots into Linux, reads the full coreboot log via `cbmem -1`, and checks for absence of a specific error pattern:

| Test | Description | Pattern | Reference |
|------|-------------|---------|-----------|
| CBP007.001 | No ASSERTION ERROR in boot log | `ASSERTION ERROR` | dasharo-issues#1409 |
| CBP008.001 | No missing static PCI devices | `not found, disabling it.` | dasharo-issues#1409 |
| CBP009.001 | No resource allocation failures | `Resource didn't fit!!!` | dasharo-issues#1364 |
| CBP010.001 | No BUG messages | `BUG:` | dasharo-issues#1364 |
| CBP011.001 | No devicetree.cb warnings | `Check your devicetree.cb` | dasharo-issues#1409 |

## Changes

### `dasharo-compatibility/coreboot-base-port.robot`

- Added 5 test cases following existing CBP001-CBP006 conventions
- Each test is gated by `${BASE_PORT_LOG_CHECK_SUPPORT}` and `${TESTS_IN_UBUNTU_SUPPORT}`
- Tests boot into Linux via `Boot System Or From Connected Disk`, then read the coreboot console log via `cbmem -1` and assert it does not contain the error pattern

### `platform-configs/include/default.robot`

- Added `${BASE_PORT_LOG_CHECK_SUPPORT}` flag (defaults to `${FALSE}`)

### `platform-configs/qemu.robot`

- Enabled `${BASE_PORT_LOG_CHECK_SUPPORT}` for QEMU testing
- Tests pass on QEMU when no errors/warnings are present (as specified in #921)

## Design decisions

1. **cbmem-based approach** rather than serial console reading. The coreboot boot log is read via `cbmem -1` after booting into Linux, which is the standard method used throughout the OSFV framework for reading coreboot logs (e.g., DMA protection tests, TPM tests, CBnT tests). This works on both real hardware and QEMU.

2. **Separate feature flag** (`BASE_PORT_LOG_CHECK_SUPPORT`) rather than reusing existing `BASE_PORT_*` flags.

## QEMU test results

```text
Coreboot-Base-Port
CBP001.001 Boot into coreboot stage bootblock    | SKIP | (not enabled)
CBP002.001 Boot into coreboot stage romstage     | SKIP | (not enabled)
CBP003.001 Boot into coreboot stage postcar      | SKIP | (not enabled)
CBP004.001 Boot into coreboot stage ramstage     | SKIP | (not enabled)
CBP005.001 Resource allocator v4 - gathering     | SKIP | (not enabled)
CBP006.001 Resource allocator v4 - allocating    | SKIP | (not enabled)
CBP007.001 No ASSERTION ERROR in boot log        | PASS |
CBP008.001 No missing static PCI devices         | PASS |
CBP009.001 No resource allocation failures       | PASS |
CBP010.001 No BUG messages in boot log           | PASS |
CBP011.001 No devicetree.cb warnings             | PASS |

11 tests, 5 passed, 0 failed, 6 skipped
```

## Open questions for maintainer

1. Should `CBP011` (devicetree.cb warnings / leftover static devices) be included? Per discussion in [dasharo-issues#1409](https://github.com/Dasharo/dasharo-issues#1409), this message is "present on almost all boards." It may be better as an informational/warning test rather than a hard failure. Happy to adjust.

2. Are there additional error patterns beyond those in [#1409](https://github.com/Dasharo/dasharo-issues#1409) and [#1364](https://github.com/Dasharo/dasharo-issues#1364) that should be included? (e.g., from coreboot's review system or other ticket sources as mentioned in the issue checklist)