### PR TITLE
platform-configs: vp66xx: add DTS E2E variables

### DIFF
--- a/dts/profiles/protectli-vp6650 Fuse Platform - DCR.profile
+++ b/dts/profiles/protectli-vp6650 Fuse Platform - DCR.profile
@@ -1,0 +1,39 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -f /sys/class/mei/mei0/fw_status 1
+flashrom -p internal 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 1
+cbmem -1 0
+cbmem -1 0
+fsread_tool test -e /sys/class/power_supply/AC/online 1
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+btg_key_validator --file /tmp/biosupdate --key-hash TODO_REPLACE_WITH_CORRECT_HASH 0
+cap_upd_tool /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/dts/profiles/protectli-vp6670 Fuse Platform - DCR.profile
+++ b/dts/profiles/protectli-vp6670 Fuse Platform - DCR.profile
@@ -1,0 +1,39 @@
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateModeRT-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
+fsread_tool test -f /sys/firmware/efi/efivars/FirmwareUpdateMode-d15b327e-ff2d-4fc1-abf6-c12bd08c1359 1
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+dmidecode  0
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+flashrom -p internal --flash-name 0
+flashrom -p internal --flash-size 0
+fsread_tool test -f /sys/class/mei/mei0/fw_status 1
+flashrom -p internal 0
+fsread_tool test -d /sys/class/pci_bus/0000:00/device/0000:00:16.0 1
+cbmem -1 0
+cbmem -1 0
+fsread_tool test -e /sys/class/power_supply/AC/online 1
+dmidecode -s system-manufacturer 0
+dmidecode -s system-product-name 0
+dmidecode -s baseboard-product-name 0
+dmidecode -s processor-version 0
+dmidecode -s bios-vendor 0
+dmidecode -s bios-version 0
+btg_key_validator --file /tmp/biosupdate --key-hash TODO_REPLACE_WITH_CORRECT_HASH 0
+cap_upd_tool /tmp/biosupdate 0
+reboot  0
+dmidecode  0

--- a/platform-configs/include/default.robot
+++ b/platform-configs/include/default.robot
@@ -465,7 +465,7 @@ ${DTS_TEST_HAS_EC}=                                 ${False}
 ...                                                 SeaBIOS->UEFI Transition=&{{ {"TEST_IS_COREBOOT": "true", "TEST_EFI_PRESENT": "false", "TEST_IS_SEABIOS": "true"} }}
 ...                                                 Dasharo (coreboot+UEFI) to Dasharo (Slim Bootloader+UEFI) Transition=&{{ {"TEST_IS_COREBOOT": "true"} }}
 ...                                                 Initial Deployment=&{{ {"TEST_BIOS_VENDOR": "proprietary", "TEST_USING_OPENSOURCE_EC_FIRM": "false"} }}
-...                                                 Fuse Platform=${{ {"TEST_MEI_CONF_PRESENT": "false"} }}
+...                                                 Fuse Platform=${{ {"TEST_MEI_CONF_PRESENT": "false", "TEST_IS_COREBOOT": "true"} }}
 # dict[workflow, dict[variable, value]]
 &{DTS_TEST_EXPORTS_PER_WORKFLOW}=                   &{DTS_TEST_EXPORTS_PER_WORKFLOW_BASE}
 # dict[tuple[workflow,release], dict[variable, value]]

--- a/platform-configs/include/protectli-vp66xx.robot
+++ b/platform-configs/include/protectli-vp66xx.robot
@@ -38,3 +38,17 @@ ${DASHARO_POWER_MGMT_MENU_SUPPORT}=                 ${TRUE}
 ${DASHARO_INTEL_ME_MENU_SUPPORT}=                   ${TRUE}
 ${INTEL_CBNT_SUPPORT}=                              ${TRUE}
 ${INTEL_CBNT_STATUS_MENU_SUPPORT}=                  ${TRUE}
+${DTS_SUPPORT}=                                     ${TRUE}
+
+# DTS E2E variables
+${DTS_TEST_SYSTEM_VENDOR}=                          Protectli
+@{DTS_TEST_WORKFLOWS}=                              Fuse Platform
+@{DTS_TEST_DEFAULT_RELEASES}=                       DCR
+@{DTS_TEST_WORKFLOW_PROFILES}=                      ${{ ("Fuse Platform", "DCR") }}
+&{DTS_TEST_VERSIONS}=
+...                                                 &{DTS_TEST_VERSIONS_BASE}
+...                                                 Fuse Platform=Dasharo (coreboot+UEFI) 0.9.3
+&{DTS_TEST_EXPORTS}=
+...                                                 &{DTS_TEST_BASE_EXPORTS}
+...                                                 TEST_ME_HAP_DISABLED=true
+...                                                 TEST_ME_OP_MODE=2


### PR DESCRIPTION
Tested with NovaCustom binary/hash to verify logic:

```
robot -b cmd_logs.txt -v rte_ip:127.0.0.1 -v config:qemu \
            -L TRACE -v snipeit:no -v dts_config_ref:refs/heads/protectli-test \
            -t "Create*" dts/dts-e2e.robot
==============================================================================
Dts-E2E
==============================================================================
Create tests                                                          | PASS |
------------------------------------------------------------------------------
E2E001: protectli-vp6650 Fuse Platform - DCR                          | PASS |
------------------------------------------------------------------------------
E2E002: protectli-vp6670 Fuse Platform - DCR                          | PASS |
------------------------------------------------------------------------------
Dts-E2E                                                               | PASS |
3 tests, 3 passed, 0 failed
==============================================================================
```

Both profiles will have to be modified so they contain correct key hash: https://github.com/Dasharo/open-source-firmware-validation/blob/5024e469233dc627465898accb8215fc33229ac7/dts/profiles/protectli-vp6650%20Fuse%20Platform%20-%20DCR.profile#L36