### PR TITLE
test(dts): align workflow naming with Dasharo conventions

### DIFF
--- a/platform-configs/include/default.robot
+++ b/platform-configs/include/default.robot
@@ -441,7 +441,7 @@ ${DTS_TEST_VERSION_BASE}=                           v0.0.0
 ...                                                 &{{ {workflow: "${DTS_TEST_VERSION_BASE}" for workflow in ${DTS_TEST_POSSIBLE_WORKFLOWS} } }}
 ...                                                 UEFI Update=Dasharo (coreboot+UEFI) ${DTS_TEST_VERSION_BASE}
 ...                                                 UEFI->Heads Transition=Dasharo (coreboot+UEFI) ${DTS_TEST_VERSION_BASE}
-...                                                 Dasharo (coreboot+UEFI) to Dasharo (Slim Bootloader+UEFI) Transition=Dasharo (coreboot+UEFI) ${DTS_TEST_VERSION_BASE}
+...                                                 Dasharo (coreboot+UEFI)->Dasharo (Slim Bootloader+UEFI) Transition=Dasharo (coreboot+UEFI) ${DTS_TEST_VERSION_BASE}
 ...                                                 Fuse Platform=Dasharo (coreboot+UEFI) ${DTS_TEST_VERSION_BASE}
 &{DTS_TEST_VERSIONS}=                               &{DTS_TEST_VERSIONS_BASE}
 # TEST_SYSTEM_MODEL, TEST_BOARD_MODEL, TEST_SYSTEM_VENDOR variables to export
@@ -463,7 +463,7 @@ ${DTS_TEST_HAS_EC}=                                 ${False}
 ...                                                 SeaBIOS Update=&{{ {"TEST_IS_COREBOOT": "true", "TEST_EFI_PRESENT": "false", "TEST_IS_SEABIOS": "true"} }}
 ...                                                 UEFI->Heads Transition=&{{ {"TEST_IS_COREBOOT": "true"} }}
 ...                                                 SeaBIOS->UEFI Transition=&{{ {"TEST_IS_COREBOOT": "true", "TEST_EFI_PRESENT": "false", "TEST_IS_SEABIOS": "true"} }}
-...                                                 Dasharo (coreboot+UEFI) to Dasharo (Slim Bootloader+UEFI) Transition=&{{ {"TEST_IS_COREBOOT": "true"} }}
+...                                                 Dasharo (coreboot+UEFI)->Dasharo (Slim Bootloader+UEFI) Transition=&{{ {"TEST_IS_COREBOOT": "true"} }}
 ...                                                 Initial Deployment=&{{ {"TEST_BIOS_VENDOR": "proprietary", "TEST_USING_OPENSOURCE_EC_FIRM": "false"} }}
 ...                                                 Fuse Platform=${{ {"TEST_MEI_CONF_PRESENT": "false"} }}
 # dict[workflow, dict[variable, value]]
@@ -484,7 +484,7 @@ ${DTS_TEST_HAS_EC}=                                 ${False}
 ...                                                 SeaBIOS Update
 ...                                                 UEFI->Heads Transition
 ...                                                 SeaBIOS->UEFI Transition
-...                                                 Dasharo (coreboot+UEFI) to Dasharo (Slim Bootloader+UEFI) Transition
+...                                                 Dasharo (coreboot+UEFI)->Dasharo (Slim Bootloader+UEFI) Transition
 ...                                                 Dasharo (Slim Bootloader+UEFI) Initial Deployment
 ...                                                 Fuse Platform
 # Set to e.g. DPP for platforms where only DPP workflows work
@@ -496,7 +496,7 @@ ${DTS_TEST_HAS_EC}=                                 ${False}
 &{DTS_TEST_WORKFLOW_RELEASES}=
 ...                                                 &{DTS_TEST_WORKFLOW_RELEASES_BASE}
 ...                                                 UEFI->Heads Transition=@{{["DPP"]}}
-...                                                 Dasharo (coreboot+UEFI) to Dasharo (Slim Bootloader+UEFI) Transition=@{{["DPP"]}}
+...                                                 Dasharo (coreboot+UEFI)->Dasharo (Slim Bootloader+UEFI) Transition=@{{["DPP"]}}
 ...                                                 Dasharo (Slim Bootloader+UEFI) Initial Deployment=@{{["DPP"]}}
 ...                                                 Fuse Platform=@{{["DCR"]}}
 # List of workflows which require profile comparison in the format:

--- a/platform-configs/odroid-h4-plus.robot
+++ b/platform-configs/odroid-h4-plus.robot
@@ -131,7 +131,7 @@ ${DTS_SUPPORT}=                                 ${TRUE}
 ${DTS_TEST_SYSTEM_VENDOR}=                      HARDKERNEL
 ${DTS_TEST_BOARD_MODEL}=                        ODROID-H4
 @{DTS_TEST_WORKFLOWS}=                          Initial Deployment    UEFI Update
-...                                             Dasharo (coreboot+UEFI) to Dasharo (Slim Bootloader+UEFI) Transition
+...                                             Dasharo (coreboot+UEFI)->Dasharo (Slim Bootloader+UEFI) Transition
 ...                                             Dasharo (Slim Bootloader+UEFI) Initial Deployment
 @{DTS_TEST_DEFAULT_RELEASES}=                   DPP
 &{DTS_TEST_EXPORTS}=                            &{DTS_TEST_BASE_EXPORTS}
@@ -147,7 +147,7 @@ ${DTS_TEST_BOARD_MODEL}=                        ODROID-H4
 ...                                             UEFI Update=&{{ {"TEST_VBOOT_KEYS": "true", "TEST_IS_COREBOOT": "true"} }}
 @{DTS_TEST_WORKFLOW_PROFILES}=
 ...                                             ${{ ("Initial Deployment", "DPP") }}
-...                                             ${{ ("Dasharo (coreboot+UEFI) to Dasharo (Slim Bootloader+UEFI) Transition", "DPP") }}
+...                                             ${{ ("Dasharo (coreboot+UEFI)->Dasharo (Slim Bootloader+UEFI) Transition", "DPP") }}
 ...                                             ${{ ("Dasharo (Slim Bootloader+UEFI) Initial Deployment", "DPP") }}
 ...                                             ${{ ("UEFI Update", "DPP") }}
 


### PR DESCRIPTION
## Summary
Align DTS workflow naming with Dasharo naming conventions by replacing:

- `Dasharo (coreboot+UEFI) to Dasharo (Slim Bootloader+UEFI) Transition`

with:

- `Dasharo (coreboot+UEFI)->Dasharo (Slim Bootloader+UEFI) Transition`

## Changes
- updated workflow key in shared DTS defaults:
  - `platform-configs/include/default.robot`
- updated platform-specific workflow/profile references:
  - `platform-configs/odroid-h4-plus.robot`

## Why
Issue #991 asks to follow Dasharo naming conventions consistently in DTS tests/workflow labels.

## Validation
- Verified all touched workflow keys/profiles are renamed consistently in modified files.
- Kept scope intentionally minimal to this naming fix.

Closes #991
