### PR TITLE
scripts: add FW_URI support for regression firmware download

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ Parameters should be defined as follows:
 * $FW_FILE - path to and name of the coreboot firmware file. This is usually
   not required when running single tests or suites, where flashing is not
   necessary.
+* $FW_URI - optional direct URL to firmware binary used by regression wrappers
+  when `$FW_FILE` is not set. Downloaded once and cached locally.
 * $CONFIG - platform config - see the `platform-configs` directory for
   available configurations.
 * $TEST_MODULE - name of the test module (i.e. `dasharo-compatibility`),
@@ -295,6 +297,12 @@ platform config file.
 
 ```bash
 FW_FILE=$FW_FILE DEVICE_IP=$DEVICE_IP RTE_IP=$RTE_IP CONFIG=$CONFIG ./scripts/regression.sh
+```
+
+Or provide a direct download URL instead of a local file:
+
+```bash
+FW_URI=https://dl.3mdeb.com/path/to/firmware.rom DEVICE_IP=$DEVICE_IP RTE_IP=$RTE_IP CONFIG=$CONFIG ./scripts/regression.sh
 ```
 
 Running regression tests without snipeit works the same way as

--- a/scripts/lib/robot.sh
+++ b/scripts/lib/robot.sh
@@ -19,6 +19,45 @@ check_env_variable() {
   fi
 }
 
+resolve_fw_file() {
+  # Accept either FW_FILE (local path) or FW_URI (remote URL downloaded to cache)
+  if [ -n "${FW_FILE}" ]; then
+    if [ ! -f "${FW_FILE}" ]; then
+      echo "Error: Environment variable FW_FILE doesn't point to a file."
+      exit 1
+    fi
+    return 0
+  fi
+
+  if [ -z "${FW_URI}" ]; then
+    echo "Error: provide FW_FILE (local path) or FW_URI (download URL)."
+    exit 1
+  fi
+
+  local cache_root="${FW_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/osfv/firmware}"
+  mkdir -p "${cache_root}"
+
+  local file_name="${FW_URI##*/}"
+  file_name="${file_name%%\?*}"
+  if [ -z "${file_name}" ]; then
+    file_name="firmware.rom"
+  fi
+
+  local dst="${cache_root}/${file_name}"
+  if [ ! -f "${dst}" ]; then
+    echo "Downloading firmware from FW_URI to cache: ${dst}"
+    if ! curl -fL --retry 3 --retry-delay 1 -o "${dst}" "${FW_URI}"; then
+      echo "Error: failed to download firmware from FW_URI=${FW_URI}"
+      exit 1
+    fi
+  else
+    echo "Using cached firmware: ${dst}"
+  fi
+
+  FW_FILE="${dst}"
+  export FW_FILE
+}
+
 check_test_station_variables() {
   if [[ $CONFIG != *"-ts"? ]]; then
     return

--- a/scripts/regression-rerun-failed.sh
+++ b/scripts/regression-rerun-failed.sh
@@ -7,14 +7,9 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib/robot.sh"
 
-# FW_FILE and DEVICE_IP are required for full regression
-check_env_variable "FW_FILE"
+# DEVICE_IP is required; firmware can be provided via FW_FILE or FW_URI
 check_env_variable "DEVICE_IP"
-
-if [ ! -f "$FW_FILE" ]; then
-    echo "Error: Environment variable FW_FILE doesn't point to a file."
-    exit 1
-fi
+resolve_fw_file
 
 _REGRESSION_RUN="True"
 export _REGRESSION_RUN

--- a/scripts/regression.sh
+++ b/scripts/regression.sh
@@ -7,14 +7,9 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib/robot.sh"
 
-# FW_FILE and DEVICE_IP are required for full regression
-check_env_variable "FW_FILE"
+# DEVICE_IP is required; firmware can be provided via FW_FILE or FW_URI
 check_env_variable "DEVICE_IP"
-
-if [ ! -f "$FW_FILE" ]; then
-    echo "Error: Environment variable FW_FILE doesn't point to a file."
-    exit 1
-fi
+resolve_fw_file
 
 _REGRESSION_RUN="True"
 export _REGRESSION_RUN


### PR DESCRIPTION
## Summary
Add `FW_URI` support to regression wrappers so testers can provide a direct firmware download URL instead of managing local binary paths manually.

## What changed
- added `resolve_fw_file` helper in `scripts/lib/robot.sh`
  - accepts either `FW_FILE` (existing behavior) or `FW_URI`
  - downloads from `FW_URI` to cache (`$FW_CACHE_DIR` or `~/.cache/osfv/firmware`)
  - reuses cached file on subsequent runs
  - exports resolved path as `FW_FILE`
- switched wrappers to use resolver:
  - `scripts/regression.sh`
  - `scripts/regression-rerun-failed.sh`
- updated README with `FW_URI` usage example

## Why
This addresses issue #980 goal of reducing manual firmware file handling and improving reproducibility while preserving `FW_FILE` for local debugging.

Closes #980
