### PR TITLE
dts: allow booting ipxe-dtsx64.efi via iPXE

### DIFF
--- a/dasharo-stability/capsule-update.robot
+++ b/dasharo-stability/capsule-update.robot
@@ -214,7 +214,7 @@ CUP260.101 Capsule update in Firmware Update Mode works
     Write Bare Into Terminal    chain http://boot.dasharo.com/dts/dts-no-fum-fix.ipxe\n    interval=0.2
     # Boot into DTS shell
     Set DUT Response Timeout    5m
-    Read From Terminal Until    .cpio.gz...
+    Read From Terminal Until Regexp    \.cpio\.gz\.\.\.|\.efi
     Read From Terminal Until    ok
     Wait For DTS To Boot    fum=${TRUE}
     Write Into Terminal    ${DTS_FUM_MENU_OPT}

--- a/lib/dts-lib.robot
+++ b/lib/dts-lib.robot
@@ -79,7 +79,7 @@ Boot Dasharo Tools Suite Via IPXE Shell
     # 4) Try to boot via the link:
     Write Bare Into Terminal    chain ${dts_chain_link}\n    interval=0.2
     Set DUT Response Timeout    5m
-    Read From Terminal Until    .cpio.gz...
+    Read From Terminal Until Regexp    \.cpio\.gz\.\.\.|[0-9]\.efi
     Read From Terminal Until    ok
 
 Boot Dasharo Tools Suite Via IPXE Menu
@@ -95,7 +95,7 @@ Boot Dasharo Tools Suite Via IPXE Menu
     # 3) Boot DTS:
     Enter Submenu From Snapshot    ${ipxe_menu}    Dasharo Tools Suite
     Set DUT Response Timeout    5m
-    Read From Terminal Until    .cpio.gz...
+    Read From Terminal Until Regexp    \.cpio\.gz\.\.\.|[0-9]\.efi
     Read From Terminal Until    ok
 
 Boot Dasharo Tools Suite

--- a/scripts/ci/ipxe-run.sh
+++ b/scripts/ci/ipxe-run.sh
@@ -4,27 +4,106 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-if [[ $# -ne 2 ]]; then
-    echo "Usage: $0 <dts-base-image-path> <bzImage-path>"
-    exit 1
+set -e
+
+print_help() {
+cat <<EOF
+$(basename "$0") [OPTION]... <dts-base-image-path> <bzImage-path>
+$(basename "$0") [OPTION]... --uki <ipxe-uki-path>
+Prepare ipxe folder so it can be used to boot DTS via iPXE, create dts.ipxe script and start HTTP server.
+
+Options:
+  -u|--uki                  Add this flag if you want to use UKI file (ipxe-dtsx64.efi) instead.
+  -p|--port <port>          Start HTTP server on port <port>
+  -v|--verbose              Enable trace output
+  -h|--help                 Print this help
+EOF
+}
+
+print_usage_error() {
+  print_help
+  error_exit "$1"
+}
+
+print_error() {
+  local red="\033[31m"
+  local reset="\033[0m"
+  echo -e "${red}ERROR: $1${reset}"
+}
+
+error_exit() {
+  print_error "$1"
+  exit 1
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      -u|--uki)
+        UKI=Y
+        shift
+        ;;
+      -p|--port)
+        PORT="$2"
+        shift 2
+        ;;
+      -v|--verbose)
+        set -x
+        shift
+        ;;
+      -h|--help)
+        print_help
+        exit 0
+        ;;
+      -*)
+        print_usage_error "Unknown option $1"
+        ;;
+      *)
+        POSITIONAL_ARGS+=( "$1" )
+        shift
+        ;;
+    esac
+  done
+}
+
+POSITIONAL_ARGS=()
+UKI=N
+PORT=4321
+parse_args "$@"
+set -- "${POSITIONAL_ARGS[@]}"
+
+if [[ "$UKI" = "Y" && $# -ne 1 ]]; then
+  print_usage_error "Script requires 1 positional argument with --uki option, got $# instead."
+fi
+
+if [[ "$UKI" = "N" && $# -ne 2 ]]; then
+  print_usage_error "Script requires 2 positional arguments, got $# instead"
 fi
 
 DTS_IMAGE_PATH=$1
-DTS_IMAGE_FILENAME=$( basename "$DTS_IMAGE_PATH" )
-BZ_IMAGE_PATH=$2
-BZ_IMAGE_FILENAME=$( basename "$BZ_IMAGE_PATH" )
+DTS_IMAGE_FILENAME=$(basename "$DTS_IMAGE_PATH")
+if [[ "$UKI" = "N" ]]; then
+  BZ_IMAGE_PATH=$2
+  BZ_IMAGE_FILENAME=$(basename "$BZ_IMAGE_PATH")
+fi
 IPXE_PATH=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)/../../ipxe
 
 mkdir -p "$IPXE_PATH"
 ln -srf "$DTS_IMAGE_PATH" "$IPXE_PATH"/"$DTS_IMAGE_FILENAME"
-ln -srf "$BZ_IMAGE_PATH" "$IPXE_PATH"/"$BZ_IMAGE_FILENAME"
-
-cat <<EOF > "$IPXE_PATH/dts.ipxe"
+if [[ "$UKI" = "N" ]]; then
+  ln -srf "$BZ_IMAGE_PATH" "$IPXE_PATH"/"$BZ_IMAGE_FILENAME"
+  cat <<EOF > "$IPXE_PATH/dts.ipxe"
 #!ipxe
 imgfetch --name file_kernel $BZ_IMAGE_FILENAME
 imgfetch --name file_initrd $DTS_IMAGE_FILENAME
 kernel file_kernel initrd=file_initrd console=ttyUSB0
 boot
 EOF
+else
+  cat <<EOF > "$IPXE_PATH/dts.ipxe"
+#!ipxe
+chain $DTS_IMAGE_FILENAME
+EOF
+fi
 
-cd "$IPXE_PATH" && python3 -m http.server 4321
+cd "$IPXE_PATH" && python3 -m http.server "$PORT"


### PR DESCRIPTION
Related PR: https://github.com/Dasharo/meta-dts/pull/233

Legacy boot path will wait for `.cpio.gz`:

```
bzimage-v1.2.3
dts-base-image-v1.2.3.cpio.gz << wait for this file
```

UEFI boot path will wait for DTS EFI file:

```
replace_fum_efivar.efi
ipxe_dtsx64-v1.2.3.efi << wait for this file
```

This commit also adds UKI support to `ipxe-run.sh` script.

I tested `Boot Dasharo Tools Suite` keyword for both `cpio.gz` and `.efi` path via:

```
*** Settings ***
Resource    keywords.robot
Suite Setup         Run Keywords
...                     Prepare Test Suite
Suite Teardown      Run Keyword
...                     Log Out And Close Connection

*** Test Cases ***
Test
    Boot Dasharo Tools Suite    iPXE
```

and command:

```sh
robot -v config:qemu -v snipeit:no -v rte_ip:127.0.0.1 \
    -v boot_dts_from_ipxe_shell:True \
    -v dts_ipxe_link:http://localhost:4321/dts.ipxe  \
    test.robot
```

@DaniilKl 