### PR TITLE
docs: include Python library keywords in generated libdoc output

### DIFF
--- a/scripts/create-docs.py
+++ b/scripts/create-docs.py
@@ -4,6 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import ast
 import os
 import re
 import sys
@@ -11,25 +12,163 @@ import sys
 lib_dir = "lib"
 output_resource = sys.argv[1] if len(sys.argv) > 1 else "all-keywords.robot"
 
-# Collect all .robot files
+delimiter = "."  # Between filename and the keyword
+
+
+def get_file_prefix(path):
+    return os.path.splitext(os.path.basename(path))[0] + delimiter
+
+
+def get_keyword_name(node):
+    for decorator in node.decorator_list:
+        if isinstance(decorator, ast.Name) and decorator.id == "keyword":
+            return printable_keyword_name(node.name)
+
+        if not (
+            isinstance(decorator, ast.Call)
+            and isinstance(decorator.func, ast.Name)
+            and decorator.func.id == "keyword"
+        ):
+            continue
+
+        if decorator.args and isinstance(decorator.args[0], ast.Constant):
+            return decorator.args[0].value
+
+        for keyword_arg in decorator.keywords:
+            if keyword_arg.arg == "name" and isinstance(
+                keyword_arg.value, ast.Constant
+            ):
+                return keyword_arg.value.value
+
+        return printable_keyword_name(node.name)
+
+    return None
+
+
+def printable_keyword_name(name):
+    return name.replace("_", " ").title()
+
+
+def format_argument_default(default):
+    if isinstance(default, ast.Constant):
+        if default.value is True:
+            return "${TRUE}"
+        if default.value is False:
+            return "${FALSE}"
+        if default.value is None:
+            return "${NONE}"
+        return str(default.value)
+
+    return ast.unparse(default)
+
+
+def get_argument_tokens(node, skip_first=False):
+    args = list(node.args.args)
+
+    if skip_first and args and args[0].arg in ("self", "cls"):
+        args = args[1:]
+
+    defaults = [None] * (len(args) - len(node.args.defaults)) + list(node.args.defaults)
+    tokens = []
+
+    for arg, default in zip(args, defaults):
+        token = f"${{{arg.arg}}}"
+        if default is not None:
+            token += f"={format_argument_default(default)}"
+        tokens.append(token)
+
+    if node.args.vararg:
+        tokens.append(f"@{{{node.args.vararg.arg}}}")
+
+    kw_defaults = list(node.args.kw_defaults)
+    for arg, default in zip(node.args.kwonlyargs, kw_defaults):
+        token = f"${{{arg.arg}}}"
+        if default is not None:
+            token += f"={format_argument_default(default)}"
+        tokens.append(token)
+
+    if node.args.kwarg:
+        tokens.append(f"&{{{node.args.kwarg.arg}}}")
+
+    return tokens
+
+
+def get_python_keywords(path):
+    with open(path, "r", encoding="utf8") as source:
+        tree = ast.parse(source.read(), filename=path)
+
+    keywords = []
+
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef):
+            name = get_keyword_name(node)
+            if name:
+                keywords.append(
+                    (name, ast.get_docstring(node), get_argument_tokens(node))
+                )
+
+        if isinstance(node, ast.ClassDef):
+            for item in node.body:
+                if not isinstance(item, ast.FunctionDef):
+                    continue
+
+                name = get_keyword_name(item)
+                if name:
+                    keywords.append(
+                        (
+                            name,
+                            ast.get_docstring(item),
+                            get_argument_tokens(item, skip_first=True),
+                        )
+                    )
+
+    return keywords
+
+
+def write_python_keywords(res_file, python_file):
+    keywords = get_python_keywords(python_file)
+
+    if not keywords:
+        return
+
+    file_prefix = get_file_prefix(python_file)
+    res_file.write("\n\n*** Keywords ***\n")
+
+    for keyword_name, documentation, arguments in keywords:
+        res_file.write(f"{file_prefix}{keyword_name}\n")
+
+        if documentation:
+            lines = documentation.splitlines()
+            res_file.write(f"    [Documentation]    {lines[0]}\n")
+            for line in lines[1:]:
+                res_file.write(f"    ...    {line}\n")
+
+        if arguments:
+            res_file.write("    [Arguments]    " + "    ".join(arguments) + "\n")
+
+        res_file.write("\n")
+
+
+# Collect all .robot and .py files
 robot_files = ["keywords.robot"]
+python_files = []
 for root, dirs, files in os.walk(lib_dir):
     for file in files:
         if file.endswith(".robot"):
             robot_files.append(os.path.join(root, file))
+        elif file.endswith(".py"):
+            python_files.append(os.path.join(root, file))
 
 # Regex pattern to detect keyword definitions
 keyword_pattern = re.compile(
     r"^(?:(?!Library|Resource|Variables|Documentation)[A-Z][a-z0-9_]+[\ ]+.*)"
 )
 
-delimiter = "."  # Between filename and the keyword
-
 # Create the combined resource file with prefixed keywords
 with open(output_resource, "w", encoding="utf8") as res_file:
 
     for robot_file in robot_files:
-        file_prefix = os.path.splitext(os.path.basename(robot_file))[0] + delimiter
+        file_prefix = get_file_prefix(robot_file)
         index_offset = 0
 
         with open(robot_file, "r", encoding="utf8") as read_file:
@@ -38,3 +177,6 @@ with open(output_resource, "w", encoding="utf8") as res_file:
                     res_file.write(file_prefix + line)
                 else:
                     res_file.write(line)
+
+    for python_file in python_files:
+        write_python_keywords(res_file, python_file)


### PR DESCRIPTION
## Summary
- collect Python keyword libraries from `lib/**/*.py` while building the combined libdoc resource
- read `@keyword` decorators with Python AST so docs generation does not need to import Python libraries or satisfy constructor arguments
- emit keyword documentation and arguments into the generated resource alongside existing `.robot` keywords

Fixes #602

## Verification
- `python3 scripts/create-docs.py /private/tmp/all-keywords-with-py.robot`
- `/private/tmp/osfv-docs-venv/bin/libdoc /private/tmp/all-keywords-with-py.robot /private/tmp/all-keywords-with-py.html`
- confirmed generated resource contains `menus.Check if menu line is an option`, `QemuMonitor.Add HDD To Qemu`, and `fan_curve_tests.Plot Fan Curve`
- `/private/tmp/osfv-docs-venv/bin/black --check scripts/create-docs.py`
- `/private/tmp/osfv-docs-venv/bin/isort --check-only scripts/create-docs.py`
- `PYTHONPYCACHEPREFIX=/private/tmp/python-cache-osfv python3 -m py_compile scripts/create-docs.py`
- `git diff --check`