### PR TITLE
Include Python libraries in keyword docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,10 +533,10 @@ The output file can be opened in any web-browser like so:
 $ firefox keywords.html
 ```
 
-Or use the provided `create-docs.sh` script, which automatically concatenates
-all of the keyword-containing libraries from `lib/` directory with
-`keywords.robot`, and generates one big html file containing all the
-keywords within this repo.
+Or use the provided `create-docs.sh` script, which automatically combines
+`keywords.robot`, keyword-containing Robot Framework libraries from `lib/`,
+and Python keyword libraries from `lib/**/*.py`, then generates one big html
+file containing all the keywords within this repo.
 
 ```bash
 $(venv) ./scripts/create-docs.sh

--- a/scripts/create-docs.sh
+++ b/scripts/create-docs.sh
@@ -6,10 +6,52 @@
 
 TEMP_DIR=$(mktemp -d)
 FILE_NAME="$TEMP_DIR/all-keywords.robot"
+ROBOT_JSON="$TEMP_DIR/all-keywords.robot.json"
+COMBINED_JSON="$TEMP_DIR/all-keywords.combined.json"
+QEMU_MONITOR_PLACEHOLDER="$TEMP_DIR/qemu-monitor-placeholder"
 
-python3 scripts/create-docs.py $FILE_NAME
+cleanup() {
+  rm -rf "$TEMP_DIR"
+}
+trap cleanup EXIT
 
-libdoc "$TEMP_DIR/all-keywords.robot" "$TEMP_DIR/all-keywords.html" >/dev/null 2>&1
+python3 scripts/create-docs.py "$FILE_NAME"
+
+libdoc --format JSON "$FILE_NAME" "$ROBOT_JSON" >/dev/null 2>&1
+
+if [ $? -ne 0 ]; then
+  echo "libdoc command failed"
+  exit 1
+fi
+
+touch "$QEMU_MONITOR_PLACEHOLDER"
+
+python_libdoc_json=()
+while IFS= read -r -d '' python_library; do
+  libdoc_input="$python_library"
+  if [ "$python_library" = "lib/QemuMonitor.py" ]; then
+    libdoc_input="${python_library}::${QEMU_MONITOR_PLACEHOLDER}"
+  fi
+
+  python_json="$TEMP_DIR/$(echo "$python_library" | tr '/.' '__').json"
+  libdoc --format JSON "$libdoc_input" "$python_json" >/dev/null 2>&1
+  if [ $? -ne 0 ]; then
+    echo "libdoc command failed for $python_library"
+    exit 1
+  fi
+  python_libdoc_json+=("$python_json")
+done < <(find lib -type f -name '*.py' -print0 | sort -z)
+
+if [ "${#python_libdoc_json[@]}" -gt 0 ]; then
+  python3 scripts/merge-libdoc-json.py \
+    "$ROBOT_JSON" \
+    "$COMBINED_JSON" \
+    "${python_libdoc_json[@]}"
+else
+  cp "$ROBOT_JSON" "$COMBINED_JSON"
+fi
+
+libdoc --format HTML "$COMBINED_JSON" "$TEMP_DIR/all-keywords.html" >/dev/null 2>&1
 
 if [ $? -ne 0 ]; then
   echo "libdoc command failed"
@@ -17,9 +59,5 @@ if [ $? -ne 0 ]; then
 fi
 
 cp "$TEMP_DIR/all-keywords.html" ./docs/index.html
-
-rm "$TEMP_DIR/all-keywords.robot"
-rm "$TEMP_DIR/all-keywords.html"
-rmdir "$TEMP_DIR"
 
 echo "Documentation generated and saved as ./docs/index.html"

--- a/scripts/merge-libdoc-json.py
+++ b/scripts/merge-libdoc-json.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2026 3mdeb <contact@3mdeb.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import copy
+import json
+import os
+import sys
+
+
+def _keyword_prefix(libdoc):
+    source = libdoc.get("source", "")
+    return os.path.splitext(os.path.basename(source))[0] + "."
+
+
+def _read_json(path):
+    with open(path, "r", encoding="utf8") as json_file:
+        return json.load(json_file)
+
+
+def main():
+    if len(sys.argv) < 4:
+        print(
+            "Usage: merge-libdoc-json.py <base-json> <output-json> <library-json>...",
+            file=sys.stderr,
+        )
+        return 1
+
+    base_json = sys.argv[1]
+    output_json = sys.argv[2]
+    library_jsons = sys.argv[3:]
+
+    combined_doc = _read_json(base_json)
+
+    for library_json in library_jsons:
+        library_doc = _read_json(library_json)
+        prefix = _keyword_prefix(library_doc)
+        for keyword in library_doc.get("keywords", []):
+            prefixed_keyword = copy.deepcopy(keyword)
+            prefixed_keyword["name"] = prefix + prefixed_keyword["name"]
+            combined_doc.setdefault("keywords", []).append(prefixed_keyword)
+
+    combined_doc["keywords"].sort(key=lambda keyword: keyword["name"].lower())
+
+    with open(output_json, "w", encoding="utf8") as json_file:
+        json.dump(combined_doc, json_file, ensure_ascii=False, indent=2)
+        json_file.write("\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- generate Libdoc JSON for the existing combined Robot keyword file
- generate Libdoc JSON for Python keyword libraries under `lib/**/*.py` and merge their keywords into the combined docs
- handle `lib/QemuMonitor.py` with a temporary placeholder constructor argument
- update README docs-generation wording

Fixes #602

## Verification
- `PATH=/tmp/osfv-libdoc-venv/bin:$PATH ./scripts/create-docs.sh`
- `grep -o 'menus\\.Check if menu line is an option\\|QemuMonitor\\.Add HDD To Qemu\\|fan_curve_tests\\.Plot Fan Curve' docs/index.html | sort | uniq -c`\n- `bash -n scripts/create-docs.sh`\n- `python3 -m py_compile scripts/merge-libdoc-json.py`\n- `git diff --check`\n\nAI-assisted with OpenAI Codex.