### PR TITLE
Include Python keyword libraries in generated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,10 +533,10 @@ The output file can be opened in any web-browser like so:
 $ firefox keywords.html
 ```
 
-Or use the provided `create-docs.sh` script, which automatically concatenates
-all of the keyword-containing libraries from `lib/` directory with
-`keywords.robot`, and generates one big html file containing all the
-keywords within this repo.
+Or use the provided `create-docs.sh` script, which automatically combines
+`keywords.robot` with keyword-containing Robot and Python libraries from the
+`lib/` directory, and generates one big html file containing all the keywords
+within this repo.
 
 ```bash
 $(venv) ./scripts/create-docs.sh

--- a/scripts/create-docs.py
+++ b/scripts/create-docs.py
@@ -7,16 +7,32 @@
 import os
 import re
 import sys
+from pathlib import Path
+
+from robot.libdocpkg import LibraryDocumentation
 
 lib_dir = "lib"
 output_resource = sys.argv[1] if len(sys.argv) > 1 else "all-keywords.robot"
+output_html = sys.argv[2] if len(sys.argv) > 2 else None
+
+python_libdoc_args = {
+    os.path.join("lib", "QemuMonitor.py"): ["libdoc-qemu-monitor-placeholder"],
+}
+created_placeholders = []
+
+
+def collect_files(extension):
+    collected = []
+    for root, dirs, files in os.walk(lib_dir):
+        dirs.sort()
+        for file in sorted(files):
+            if file.endswith(extension):
+                collected.append(os.path.join(root, file))
+    return collected
+
 
 # Collect all .robot files
-robot_files = ["keywords.robot"]
-for root, dirs, files in os.walk(lib_dir):
-    for file in files:
-        if file.endswith(".robot"):
-            robot_files.append(os.path.join(root, file))
+robot_files = ["keywords.robot"] + collect_files(".robot")
 
 # Regex pattern to detect keyword definitions
 keyword_pattern = re.compile(
@@ -38,3 +54,43 @@ with open(output_resource, "w", encoding="utf8") as res_file:
                     res_file.write(file_prefix + line)
                 else:
                     res_file.write(line)
+
+
+def prefix_library_keywords(library_doc, file_path):
+    prefix = Path(file_path).stem + delimiter
+    for keyword in library_doc.keywords:
+        keyword.name = prefix + keyword.name
+    return library_doc.keywords
+
+
+def library_source(file_path, temp_dir):
+    args = python_libdoc_args.get(file_path, [])
+    if not args:
+        return file_path
+
+    resolved_args = []
+    for arg in args:
+        placeholder = Path(temp_dir) / arg
+        placeholder.touch()
+        created_placeholders.append(placeholder)
+        resolved_args.append(str(placeholder))
+    return "::".join([file_path, *resolved_args])
+
+
+def generate_html_docs(resource_file, html_file):
+    docs = LibraryDocumentation(resource_file)
+
+    temp_dir = Path(resource_file).parent
+    try:
+        for python_file in collect_files(".py"):
+            library_doc = LibraryDocumentation(library_source(python_file, temp_dir))
+            docs.keywords.extend(prefix_library_keywords(library_doc, python_file))
+
+        docs.save(html_file)
+    finally:
+        for placeholder in created_placeholders:
+            placeholder.unlink(missing_ok=True)
+
+
+if output_html:
+    generate_html_docs(output_resource, output_html)

--- a/scripts/create-docs.sh
+++ b/scripts/create-docs.sh
@@ -6,20 +6,19 @@
 
 TEMP_DIR=$(mktemp -d)
 FILE_NAME="$TEMP_DIR/all-keywords.robot"
+HTML_FILE="$TEMP_DIR/all-keywords.html"
 
-python3 scripts/create-docs.py $FILE_NAME
-
-libdoc "$TEMP_DIR/all-keywords.robot" "$TEMP_DIR/all-keywords.html" >/dev/null 2>&1
+python3 scripts/create-docs.py "$FILE_NAME" "$HTML_FILE"
 
 if [ $? -ne 0 ]; then
-  echo "libdoc command failed"
+  echo "documentation generation failed"
   exit 1
 fi
 
-cp "$TEMP_DIR/all-keywords.html" ./docs/index.html
+cp "$HTML_FILE" ./docs/index.html
 
 rm "$TEMP_DIR/all-keywords.robot"
-rm "$TEMP_DIR/all-keywords.html"
+rm "$HTML_FILE"
 rmdir "$TEMP_DIR"
 
 echo "Documentation generated and saved as ./docs/index.html"


### PR DESCRIPTION
## Summary
- merge libdoc metadata from Python keyword libraries under `lib/**/*.py` into the generated keyword docs
- keep existing Robot resource keyword aggregation and generated `docs/index.html` output path
- handle `lib/QemuMonitor.py` by supplying a temporary placeholder argument during documentation generation
- update README wording so the documented generator behavior mentions Python keyword libraries

## Verification
- `PATH="$PWD/.venv-docs/bin:$PATH" bash scripts/create-docs.sh`
- parsed generated `docs/index.html` and confirmed these Python-library keywords are present: `menus.Check if menu line is an option`, `QemuMonitor.Add HDD To Qemu`, `fan_curve_tests.Plot Fan Curve`
- `bash -n scripts/create-docs.sh`
- `python3 -m py_compile scripts/create-docs.py`
- `git diff --check`

/claim #602