### PR TITLE
Sync iPXE time before HTTPS netboot tests

### DIFF
--- a/dasharo-compatibility/network-boot.robot
+++ b/dasharo-compatibility/network-boot.robot
@@ -74,7 +74,7 @@ PXE004.001 DTS option is available and works correctly
     Power On
     ${boot_menu}=    Enter Boot Menu Tianocore And Return Construction
     Enter Submenu From Snapshot    ${boot_menu}    ${IPXE_BOOT_ENTRY}
-    ${ipxe_menu}=    Get IPXE Boot Menu Construction
+    ${ipxe_menu}=    Synchronize IPXE Time And Return Menu
     Enter Submenu From Snapshot    ${ipxe_menu}    Dasharo Tools Suite
     Set DUT Response Timeout    5m
     ${out}=    Read From Terminal Until    Enter an option
@@ -92,7 +92,7 @@ PXE005.001 OS installation option is available and works correctly
     Power On
     ${boot_menu}=    Enter Boot Menu Tianocore And Return Construction
     Enter Submenu From Snapshot    ${boot_menu}    ${IPXE_BOOT_ENTRY}
-    ${ipxe_menu}=    Get IPXE Boot Menu Construction
+    ${ipxe_menu}=    Synchronize IPXE Time And Return Menu
     Enter Submenu From Snapshot    ${ipxe_menu}    OS installation
     ${out}=    Read From Terminal Until    netboot.xyz [ enabled: true ]
     Should Contain    ${out}    netboot.xyz
@@ -127,3 +127,19 @@ PXE007.001 Dasharo Network Boot over https not http
     Log    ${out}
     Should Contain    ${out}    https://
     Should Not Contain    ${out}    http://
+
+
+*** Keywords ***
+Synchronize IPXE Time And Return Menu
+    [Documentation]    Synchronizes iPXE time before HTTPS network boot entries.
+    [Arguments]    ${ntp_server}=pool.ntp.org
+    ${ipxe_menu}=    Get IPXE Boot Menu Construction
+    Enter Submenu From Snapshot    ${ipxe_menu}    iPXE Shell
+    Set Prompt For Terminal    iPXE>
+    Read From Terminal Until Prompt
+    Write Bare Into Terminal    ntp ${ntp_server}\n    0.1
+    ${out}=    Read From Terminal Until Prompt
+    Log    ${out}
+    Write Bare Into Terminal    exit\n    0.1
+    ${ipxe_menu}=    Get IPXE Boot Menu Construction
+    RETURN    ${ipxe_menu}


### PR DESCRIPTION
## Summary
- add a network boot helper that enters the iPXE shell, runs `ntp pool.ntp.org`, exits back to the Dasharo network boot menu, and returns the refreshed menu construction
- use that helper before the HTTPS-dependent PXE004 Dasharo Tools Suite path and PXE005 OS installation path

## Verification
- `git diff --check`
- parsed `dasharo-compatibility/network-boot.robot` with Robot Framework API: `errors=0`
- attempted `robot --dryrun --nostatusrc --output NONE --log NONE --report NONE dasharo-compatibility/network-boot.robot`; it reaches the suite but local dry-run is blocked by repository environment/dependency setup (`${CONFIG}`, `osfv`, `SSHLibrary`, `RequestsLibrary`), not by the changed file syntax

/claim #668