### PR TITLE
feat: resolve firmware binaries from FW_URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,18 @@ platform config file.
 FW_FILE=$FW_FILE DEVICE_IP=$DEVICE_IP RTE_IP=$RTE_IP CONFIG=$CONFIG ./scripts/regression.sh
 ```
 
+`FW_FILE` can also be resolved automatically from a URI. When `FW_URI` is
+provided and `FW_FILE` is not set, the wrapper downloads the firmware binary to
+`${FW_CACHE_DIR:-$HOME/.cache/osfv/firmware}` and exports the cached path as
+`FW_FILE` before running tests. `FW_VERSION` is optional and, when provided, is
+used as a cache subdirectory to avoid collisions between releases.
+
+```bash
+FW_URI=https://dl.3mdeb.com/open-source-firmware/Dasharo/novacustom_v54x_mtl/v0.9.1/novacustom_v54x_mtl_v0.9.1.rom \
+FW_VERSION=novacustom_v54x_mtl_v0.9.1 \
+DEVICE_IP=$DEVICE_IP RTE_IP=$RTE_IP CONFIG=$CONFIG ./scripts/regression.sh
+```
+
 Running regression tests without snipeit works the same way as
 [running regular tests](#running-tests-via-wrapper).
 

--- a/scripts/lib/robot.sh
+++ b/scripts/lib/robot.sh
@@ -30,6 +30,48 @@ check_test_station_variables() {
   fi
 }
 
+resolve_fw_file() {
+  if [ -n "${FW_FILE}" ] || [ -z "${FW_URI}" ]; then
+    return
+  fi
+
+  local cache_root cache_dir uri_without_query file_name target_file tmp_file
+  cache_root="${FW_CACHE_DIR:-${HOME}/.cache/osfv/firmware}"
+
+  if [ -n "${FW_VERSION}" ]; then
+    cache_dir="${cache_root}/${FW_VERSION}"
+  else
+    cache_dir="${cache_root}"
+  fi
+
+  uri_without_query="${FW_URI%%\?*}"
+  file_name="$(basename "${uri_without_query}")"
+  if [ -z "${file_name}" ] || [ "${file_name}" = "." ] || [ "${file_name}" = "/" ]; then
+    file_name="$(printf '%s' "${FW_URI}" | sha256sum | cut -d ' ' -f 1).rom"
+  fi
+
+  mkdir -p "${cache_dir}"
+  target_file="${cache_dir}/${file_name}"
+
+  if [ ! -f "${target_file}" ]; then
+    tmp_file="${target_file}.tmp.$$"
+    echo "Downloading firmware binary from ${FW_URI} to ${target_file}"
+    if command -v curl >/dev/null 2>&1; then
+      curl --fail --location --retry 3 --output "${tmp_file}" "${FW_URI}"
+    elif command -v wget >/dev/null 2>&1; then
+      wget --output-document="${tmp_file}" "${FW_URI}"
+    else
+      echo "Error: curl or wget is required to download FW_URI."
+      exit 1
+    fi
+    mv "${tmp_file}" "${target_file}"
+  else
+    echo "Using cached firmware binary ${target_file}"
+  fi
+
+  export FW_FILE="${target_file}"
+}
+
 handle_ctrl_c() {
   echo "Ctrl+C pressed. Exiting."
   # You can add cleanup tasks here if needed
@@ -240,6 +282,8 @@ execute_robot() {
   else
     rte_ip_option=""
   fi
+
+  resolve_fw_file
 
   # FW_FILE environment variable is optional for some tests
   if [ -n "${FW_FILE}" ]; then

--- a/scripts/regression.sh
+++ b/scripts/regression.sh
@@ -8,6 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib/robot.sh"
 
 # FW_FILE and DEVICE_IP are required for full regression
+resolve_fw_file
 check_env_variable "FW_FILE"
 check_env_variable "DEVICE_IP"
 


### PR DESCRIPTION
## Summary

- Add `FW_URI` support for resolving firmware binaries automatically while preserving existing `FW_FILE` behavior.
- Cache downloaded binaries under `${FW_CACHE_DIR:-$HOME/.cache/osfv/firmware}`.
- Use `FW_VERSION` as an optional cache subdirectory to keep release binaries separate.
- Document the new regression wrapper usage.

Closes #980

## Test plan

- `bash -n scripts/lib/robot.sh`
- `bash -n scripts/regression.sh`
- Verified `resolve_fw_file` downloads a `file://` test ROM into `FW_CACHE_DIR/FW_VERSION/` and exports `FW_FILE`.
- Verified a second `resolve_fw_file` call reuses the cached binary.
- `git diff --check`
