### PR TITLE
test: cover DTS nightly iPXE menu entry

### DIFF
--- a/dasharo-compatibility/network-boot.robot
+++ b/dasharo-compatibility/network-boot.robot
@@ -50,9 +50,10 @@ PXE002.001 Dasharo network boot menu boot options order is correct
     Enter Submenu From Snapshot    ${boot_menu}    ${IPXE_BOOT_ENTRY}
     ${ipxe_menu}=    Get IPXE Boot Menu Construction
     Should Contain    ${ipxe_menu}[0]    Autoboot (DHCP)
-    Should Contain    ${ipxe_menu}[1]    Dasharo Tools Suite
-    Should Contain    ${ipxe_menu}[2]    OS installation (netboot.xyz official server)
-    Should Contain    ${ipxe_menu}[3]    iPXE Shell
+    Should Contain    ${ipxe_menu}[1]    ${DTS_IPXE_MENU_ENTRY}
+    Should Contain    ${ipxe_menu}[2]    ${DTS_IPXE_NIGHTLY_MENU_ENTRY}
+    Should Contain    ${ipxe_menu}[3]    OS installation (netboot.xyz official server)
+    Should Contain    ${ipxe_menu}[4]    iPXE Shell
 
 PXE003.001 Autoboot option is available and works correctly
     [Documentation]    This test aims to verify that the Autoboot option in
@@ -75,7 +76,26 @@ PXE004.001 DTS option is available and works correctly
     ${boot_menu}=    Enter Boot Menu Tianocore And Return Construction
     Enter Submenu From Snapshot    ${boot_menu}    ${IPXE_BOOT_ENTRY}
     ${ipxe_menu}=    Get IPXE Boot Menu Construction
-    Enter Submenu From Snapshot    ${ipxe_menu}    Dasharo Tools Suite
+    Enter Submenu From Snapshot    ${ipxe_menu}    ${DTS_IPXE_MENU_ENTRY}
+    Set DUT Response Timeout    5m
+    ${out}=    Read From Terminal Until    Enter an option
+    Should Contain    ${out}    Dasharo HCL report
+    Should Contain    ${out}    Load your DPP keys
+    Should Contain    ${out}    launch SSH server
+    Should Contain    ${out}    enter shell
+    Should Contain    ${out}    poweroff
+    Should Contain    ${out}    reboot
+
+PXE008.001 DTS nightly option is available and works correctly
+    [Documentation]    This test aims to verify that the Dasharo Tools Suite
+    ...    Nightly option in Dasharo Network Boot Menu allows booting into DTS.
+    [Tags]    automated    minimal-regression
+    Skip If    not ${TESTS_IN_FIRMWARE_SUPPORT}    PXE008.001 not supported
+    Power On
+    ${boot_menu}=    Enter Boot Menu Tianocore And Return Construction
+    Enter Submenu From Snapshot    ${boot_menu}    ${IPXE_BOOT_ENTRY}
+    ${ipxe_menu}=    Get IPXE Boot Menu Construction
+    Enter Submenu From Snapshot    ${ipxe_menu}    ${DTS_IPXE_NIGHTLY_MENU_ENTRY}
     Set DUT Response Timeout    5m
     ${out}=    Read From Terminal Until    Enter an option
     Should Contain    ${out}    Dasharo HCL report
@@ -122,7 +142,7 @@ PXE007.001 Dasharo Network Boot over https not http
     ${boot_menu}=    Enter Boot Menu Tianocore And Return Construction
     Enter Submenu From Snapshot    ${boot_menu}    ${IPXE_BOOT_ENTRY}
     ${ipxe_menu}=    Get IPXE Boot Menu Construction
-    Enter Submenu From Snapshot    ${ipxe_menu}    Dasharo Tools Suite
+    Enter Submenu From Snapshot    ${ipxe_menu}    ${DTS_IPXE_MENU_ENTRY}
     ${out}=    Read From Terminal Until    Enter an option
     Log    ${out}
     Should Contain    ${out}    https://

--- a/lib/dts-lib.robot
+++ b/lib/dts-lib.robot
@@ -37,6 +37,8 @@ ${DTS_DPP_SEA_MENUPOINT}=                       DPP version (coreboot + SeaBIOS)
 ${DTS_DPP_SLIM_BOOTLOADER_UEFI_MENUPOINT}=      DPP version (Slim Bootloader + UEFI)
 # Default DTS boot type, can be overwritten by CMD:
 ${DTS_BOOT_TYPE}=                               iPXE
+${DTS_IPXE_MENU_ENTRY}=                         Dasharo Tools Suite
+${DTS_IPXE_NIGHTLY_MENU_ENTRY}=                 Dasharo Tools Suite (Nightly)
 # DTS options:
 ${DTS_HCL_OPT}=                                 1
 ${DTS_DEPLOY_OPT}=                              2
@@ -84,6 +86,7 @@ Boot Dasharo Tools Suite Via IPXE Shell
 
 Boot Dasharo Tools Suite Via IPXE Menu
     [Documentation]    Boots DTS via option available in Dasharo iPXE menu.
+    [Arguments]    ${dts_ipxe_menu_entry}=${DTS_IPXE_MENU_ENTRY}
     # 1) Check and enable network boot, it is disabled by default:
     Make Sure That Network Boot Is Enabled
 
@@ -93,7 +96,7 @@ Boot Dasharo Tools Suite Via IPXE Menu
     ${ipxe_menu}=    Get IPXE Boot Menu Construction
 
     # 3) Boot DTS:
-    Enter Submenu From Snapshot    ${ipxe_menu}    Dasharo Tools Suite
+    Enter Submenu From Snapshot    ${ipxe_menu}    ${dts_ipxe_menu_entry}
     Set DUT Response Timeout    5m
     Read From Terminal Until Regexp    \.cpio\.gz\.\.\.|[0-9]\.efi
     Read From Terminal Until    ok

--- a/test_cases.json
+++ b/test_cases.json
@@ -6146,6 +6146,20 @@
   },
   {
     "doc": {
+      "_id": "PXE007.001",
+      "name": "Dasharo Network Boot over https not http",
+      "module": "Dasharo Compatibility"
+    }
+  },
+  {
+    "doc": {
+      "_id": "PXE008.001",
+      "name": "DTS nightly option is available and works correctly",
+      "module": "Dasharo Compatibility"
+    }
+  },
+  {
+    "doc": {
       "_id": "QBS001.001",
       "name": "Qubes OS installation",
       "module": "Dasharo Compatibility"


### PR DESCRIPTION
## Summary
- Updates the expected Dasharo Network Boot menu order for the new `Dasharo Tools Suite (Nightly)` item.
- Adds reusable DTS iPXE menu-entry variables.
- Lets `Boot Dasharo Tools Suite Via IPXE Menu` select a provided DTS menu entry while defaulting to stable DTS.
- Adds PXE008.001 coverage for booting the nightly DTS menu item.
- Adds missing PXE007.001/PXE008.001 entries to `test_cases.json`.

Part of Dasharo/dasharo-issues#1041.
Companion dasharo-blobs PR: https://github.com/Dasharo/dasharo-blobs/pull/57

## Verification
- `python3 -m json.tool test_cases.json >/tmp/osfv-1041-test-cases.json`
- static content assertions for the new variables, menu order, and PXE008 test
- `python - <<'PY' ... TestSuiteBuilder().build('dasharo-compatibility/network-boot.robot') ... PY`
- `git diff --check`

Note: I could not run the QEMU/Robot boot flow in this environment because it requires the full OSFV testbed.
