### PR TITLE
test: add coreboot boot log checks

### DIFF
--- a/dasharo-compatibility/coreboot-base-port.robot
+++ b/dasharo-compatibility/coreboot-base-port.robot
@@ -73,3 +73,63 @@ CBP006.001 Resource allocator v4 - allocating resources
     Power On
     Set DUT Response Timeout    120s
     Read From Terminal Until    Pass 2 (allocating resources)
+
+CBP007.001 No ASSERTION ERROR in boot log
+    [Documentation]    Check whether the coreboot boot log is free from
+    ...    assertion failures reported by coreboot.
+    Skip If    not ${BASE_PORT_LOG_CHECK_SUPPORT}    CBP007.001 not supported
+    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    CBP007.001 not supported
+    ${boot_log}=    Boot Ubuntu And Read Coreboot Boot Log
+    Coreboot Boot Log Should Not Contain    ${boot_log}    ASSERTION ERROR
+
+CBP008.001 No missing static PCI devices in boot log
+    [Documentation]    Check whether the coreboot boot log is free from
+    ...    static PCI device entries that were not found and disabled.
+    Skip If    not ${BASE_PORT_LOG_CHECK_SUPPORT}    CBP008.001 not supported
+    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    CBP008.001 not supported
+    ${boot_log}=    Boot Ubuntu And Read Coreboot Boot Log
+    Coreboot Boot Log Should Not Contain    ${boot_log}    not found, disabling it.
+
+CBP009.001 No resource allocation failures in boot log
+    [Documentation]    Check whether the coreboot boot log is free from
+    ...    resource allocator failures.
+    Skip If    not ${BASE_PORT_LOG_CHECK_SUPPORT}    CBP009.001 not supported
+    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    CBP009.001 not supported
+    ${boot_log}=    Boot Ubuntu And Read Coreboot Boot Log
+    Coreboot Boot Log Should Not Contain    ${boot_log}    Resource didn't fit!!!
+
+CBP010.001 No BUG messages in boot log
+    [Documentation]    Check whether the coreboot boot log is free from
+    ...    BUG messages emitted by coreboot.
+    Skip If    not ${BASE_PORT_LOG_CHECK_SUPPORT}    CBP010.001 not supported
+    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    CBP010.001 not supported
+    ${boot_log}=    Boot Ubuntu And Read Coreboot Boot Log
+    Coreboot Boot Log Should Not Contain    ${boot_log}    BUG:
+
+CBP011.001 No devicetree.cb warnings in boot log
+    [Documentation]    Check whether the coreboot boot log is free from
+    ...    warnings that ask maintainers to fix devicetree.cb.
+    Skip If    not ${BASE_PORT_LOG_CHECK_SUPPORT}    CBP011.001 not supported
+    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    CBP011.001 not supported
+    ${boot_log}=    Boot Ubuntu And Read Coreboot Boot Log
+    Coreboot Boot Log Should Not Contain    ${boot_log}    Check your devicetree.cb
+
+
+*** Keywords ***
+Boot Ubuntu And Read Coreboot Boot Log
+    [Documentation]    Boots Ubuntu, switches to root and returns the coreboot
+    ...    boot log collected with cbmem.
+    Power On
+    Boot And Login To OS    ${ENV_ID_UBUNTU}
+    Switch To Root User
+    ${boot_log}=    Execute Command In Terminal    cbmem -1
+    Should Not Contain
+    ...    ${boot_log}
+    ...    Operation not permitted
+    ...    msg=Cannot get cbmem log. Probably Secure Boot is enabled (kernel lockdown mode).
+    RETURN    ${boot_log}
+
+Coreboot Boot Log Should Not Contain
+    [Documentation]    Fails if a forbidden coreboot boot-log pattern is present.
+    [Arguments]    ${boot_log}    ${pattern}
+    Should Not Contain    ${boot_log}    ${pattern}

--- a/platform-configs/include/default.robot
+++ b/platform-configs/include/default.robot
@@ -171,6 +171,7 @@ ${BASE_PORT_BOOTBLOCK_SUPPORT}=                     ${FALSE}
 ${BASE_PORT_ROMSTAGE_SUPPORT}=                      ${FALSE}
 ${BASE_PORT_POSTCAR_SUPPORT}=                       ${FALSE}
 ${BASE_PORT_RAMSTAGE_SUPPORT}=                      ${FALSE}
+${BASE_PORT_LOG_CHECK_SUPPORT}=                     ${FALSE}
 ${BOOT_BLOCKING_SUPPORT}=                           ${FALSE}
 ${FAN_SPEED_MEASURE_SUPPORT}=                       ${FALSE}
 ${DOCKING_STATION_AUDIO_SUPPORT}=                   ${FALSE}

--- a/platform-configs/qemu.robot
+++ b/platform-configs/qemu.robot
@@ -68,6 +68,9 @@ ${SECURE_BOOT_SUPPORT}=                     ${TRUE}
 ${USB_STACK_SUPPORT}=                       ${TRUE}
 ${USB_MASS_STORAGE_SUPPORT}=                ${TRUE}
 ${UEFI_PASSWORD_SUPPORT}=                   ${TRUE}
+${BASE_PORT_RAMSTAGE_SUPPORT}=              ${TRUE}
+${BASE_PORT_LOG_CHECK_SUPPORT}=             ${TRUE}
+${BASE_PORT_ALLOCATOR_V4_SUPPORT}=          ${TRUE}
 
 # Test module: dasharo-performance
 ${SERIAL_BOOT_MEASURE}=                     ${TRUE}


### PR DESCRIPTION
## Summary
- Adds coreboot base-port checks for common boot-log issues:
  - `ASSERTION ERROR`
  - missing static PCI devices (`not found, disabling it.`)
  - resource allocation failures (`Resource didn't fit!!!`)
  - `BUG:` messages
  - `Check your devicetree.cb` warnings
- Adds a `BASE_PORT_LOG_CHECK_SUPPORT` flag, defaulting to false and enabled for QEMU.
- Adds shared Robot keywords to boot Ubuntu, switch to root, collect `cbmem -1`, and assert that forbidden boot-log patterns are absent.

Closes #921

## Verification
- `git diff --check`
- static content assertions for all new CBP test IDs and forbidden patterns
- Robot parser check with `TestSuiteBuilder().build('dasharo-compatibility/coreboot-base-port.robot')`
- `python scripts/ci/test_ids/test_ids_legal.py id-valid --print-invalid`
- `python scripts/ci/test_ids/test_ids_legal.py os-valid --print-invalid`

Note: I could not run the full QEMU/Robot boot flow in this environment because it requires a complete OSFV testbed.
