### PR TITLE
Add dependencies for Fedora to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ The osfv uses the
 
 ## Getting started
 
+### Installing dependencies
+#### Fedora:
+```bash
+dnf install g++ python-devel
+dnf group install development-tools
+```
+
 ### Initializing environment
 
 * Clone repository and setup virtualenv:


### PR DESCRIPTION
I am not certain what exactly is required in the development-tools package group. Users of other distros will have to figure this out themselves.