### PR TITLE
test: check coreboot boot log diagnostics

### DIFF
--- a/dasharo-compatibility/coreboot-base-port.robot
+++ b/dasharo-compatibility/coreboot-base-port.robot
@@ -73,3 +73,28 @@ CBP006.001 Resource allocator v4 - allocating resources
     Power On
     Set DUT Response Timeout    120s
     Read From Terminal Until    Pass 2 (allocating resources)
+
+CBP007.201 No unexpected warnings or errors in coreboot boot log (Ubuntu)
+    [Documentation]    Check whether the coreboot boot log does not contain
+    ...    unexpected diagnostics that may point to base port misconfiguration.
+    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    CBP007.201 not supported
+    Boot System Or From Connected Disk    ${ENV_ID_UBUNTU}
+    Login To Linux
+    ${diagnostics}=    Get Coreboot Boot Log Diagnostics
+    Should Be Empty
+    ...    ${diagnostics}
+    ...    msg=Unexpected diagnostics found in coreboot boot log:\n${diagnostics}
+
+
+*** Keywords ***
+Get Coreboot Boot Log Diagnostics
+    [Documentation]    Returns coreboot boot log lines that contain common
+    ...    warning or error markers. The grep pattern is assembled in shell so
+    ...    the echoed command itself does not trigger a false positive.
+    ${diagnostics}=    Execute Command In Terminal
+    ...    p='w''arn(ing)?|e''rror|f''ail(ed|ure)?|e''xception|p''anic|a''ssert|i''nvalid'; cbmem -1 | grep -Eini "$p" || true
+    ${diagnostics}=    Remove String Using Regexp
+    ...    ${diagnostics}
+    ...    (?m)^.*cbmem -1.*grep -Eini.*\\n?
+    ${diagnostics}=    Strip String    ${diagnostics}
+    RETURN    ${diagnostics}


### PR DESCRIPTION
## Summary

- Add a `CBP007.201` Ubuntu test to scan `cbmem -1` coreboot boot logs for common warning/error diagnostics.
- Reuse the existing `coreboot-base-port.robot` suite and standard Ubuntu boot/login flow.
- Build the grep pattern in shell so an echoed command does not create a false positive diagnostic line.

Closes Dasharo/dasharo-issues#921.

## Validation

- Static assertion: verified the new CBP007.201 test, helper keyword, `cbmem -1` command, and Ubuntu support guard are present.
- Attempted Robot Framework dry-run locally with a temporary venv. It could not complete because this workstation lacks the OSFV runtime environment and dependencies (`telnetlib` on Python 3.14, SSHLibrary, RequestsLibrary, osfv RTE library, QMP socket, and platform resources). No full hardware/QEMU execution was performed locally.