### PR TITLE
network-boot: cover the Dasharo Tools Suite (Nightly) iPXE menu entry

### DIFF
--- a/dasharo-compatibility/network-boot.robot
+++ b/dasharo-compatibility/network-boot.robot
@@ -51,8 +51,15 @@ PXE002.101 Dasharo network boot menu boot options order is correct (EDK2 UEFI)
     ${ipxe_menu}=    Get IPXE Boot Menu Construction
     Should Contain    ${ipxe_menu}[0]    Autoboot (DHCP)
     Should Contain    ${ipxe_menu}[1]    Dasharo Tools Suite
-    Should Contain    ${ipxe_menu}[2]    OS installation (netboot.xyz official server)
-    Should Contain    ${ipxe_menu}[3]    iPXE Shell
+    Should Not Contain    ${ipxe_menu}[1]    Nightly
+    IF    ${IPXE_NIGHTLY_DTS_SUPPORT}
+        Should Contain    ${ipxe_menu}[2]    Dasharo Tools Suite (Nightly)
+        Should Contain    ${ipxe_menu}[3]    OS installation (netboot.xyz official server)
+        Should Contain    ${ipxe_menu}[4]    iPXE Shell
+    ELSE
+        Should Contain    ${ipxe_menu}[2]    OS installation (netboot.xyz official server)
+        Should Contain    ${ipxe_menu}[3]    iPXE Shell
+    END
 
 PXE003.101 Autoboot option is available and works correctly (EDK2 UEFI)
     [Documentation]    This test aims to verify that the Autoboot option in
@@ -142,3 +149,23 @@ PXE008.101 Firmware Update Mode (EDK2 UEFI)
     Execute Manual Step    [8/8] Press the requested number on the keyboard when prompted.
     Execute Manual Step
     ...    [Expected result] DTS is booted automatically when Firmware Update Mode is entered. DTS automatically begins to check for a firmware update.
+
+PXE009.101 DTS Nightly option is available and works correctly (EDK2 UEFI)
+    [Documentation]    This test aims to verify that the Dasharo Tools Suite
+    ...    (Nightly) option in Dasharo Network Boot Menu allows booting into
+    ...    the nightly DTS build, which is built from the develop branch.
+    Skip If    not ${TESTS_IN_FIRMWARE_SUPPORT}    PXE009.101 not supported
+    Skip If    not ${IPXE_NIGHTLY_DTS_SUPPORT}    PXE009.101 not supported
+    Power On
+    ${boot_menu}=    Enter Boot Menu Tianocore And Return Construction
+    Enter Submenu From Snapshot    ${boot_menu}    ${IPXE_BOOT_ENTRY}
+    ${ipxe_menu}=    Get IPXE Boot Menu Construction
+    Enter Submenu From Snapshot    ${ipxe_menu}    Dasharo Tools Suite (Nightly)
+    Set DUT Response Timeout    5m
+    ${out}=    Read From Terminal Until    Enter an option
+    Should Contain    ${out}    Dasharo HCL report
+    Should Contain    ${out}    Load your DPP keys
+    Should Contain    ${out}    launch SSH server
+    Should Contain    ${out}    enter shell
+    Should Contain    ${out}    poweroff
+    Should Contain    ${out}    reboot

--- a/lib/dts-lib.robot
+++ b/lib/dts-lib.robot
@@ -84,6 +84,11 @@ Boot Dasharo Tools Suite Via IPXE Shell
 
 Boot Dasharo Tools Suite Via IPXE Menu
     [Documentation]    Boots DTS via option available in Dasharo iPXE menu.
+    ...
+    ...    === Arguments ===
+    ...    - ``${menu_entry}``: ``string`` - the iPXE menu entry to boot. Use
+    ...    \ ``Dasharo Tools Suite (Nightly)`` to boot the nightly build.
+    [Arguments]    ${menu_entry}=Dasharo Tools Suite
     # 1) Check and enable network boot, it is disabled by default:
     Make Sure That Network Boot Is Enabled
 
@@ -93,7 +98,7 @@ Boot Dasharo Tools Suite Via IPXE Menu
     ${ipxe_menu}=    Get IPXE Boot Menu Construction
 
     # 3) Boot DTS:
-    Enter Submenu From Snapshot    ${ipxe_menu}    Dasharo Tools Suite
+    Enter Submenu From Snapshot    ${ipxe_menu}    ${menu_entry}
     Set DUT Response Timeout    5m
     Read From Terminal Until Regexp    \.cpio\.gz\.\.\.|[0-9]\.efi
     Read From Terminal Until    ok

--- a/platform-configs/include/default.robot
+++ b/platform-configs/include/default.robot
@@ -138,6 +138,9 @@ ${USB_CAMERA_DETECTION_SUPPORT}=                    ${FALSE}
 ${USB_TYPE_C_DISPLAY_SUPPORT}=                      ${FALSE}
 ${UEFI_COMPATIBLE_INTERFACE_SUPPORT}=               ${FALSE}
 ${IPXE_BOOT_SUPPORT}=                               ${FALSE}
+# Whether the firmware ships the "Dasharo Tools Suite (Nightly)" iPXE menu
+# entry. Enable on platforms whose firmware contains it.
+${IPXE_NIGHTLY_DTS_SUPPORT}=                        ${FALSE}
 ${NVME_DISK_SUPPORT}=                               ${FALSE}
 ${NVME_X2_SLOT_SUPPORT}=                            ${FALSE}
 ${NVME_SATA_DISABLING_SUPPORT}=                     ${FALSE}
@@ -339,6 +342,8 @@ ${USB_DETECTION_ITERATIONS_NUMBER}=                 0
 # DTS
 # Default DTS link for iPXE boot, can be overwritten by CMD:
 ${DTS_IPXE_LINK}=                                   http://boot.dasharo.com/dts/dts.ipxe
+# Nightly DTS builds from the develop branch, can be overwritten by CMD:
+${DTS_NIGHTLY_IPXE_LINK}=                           https://boot.dasharo.com/dts/nightly.ipxe
 ${BOOT_DTS_FROM_IPXE_SHELL}=                        ${FALSE}
 
 # Other platform flags and counters

--- a/platform-configs/qemu.robot
+++ b/platform-configs/qemu.robot
@@ -46,6 +46,8 @@ ${CUSTOM_LOGO_SUPPORT}=                     ${TRUE}
 ${USB_DISKS_DETECTION_SUPPORT}=             ${TRUE}
 ${USB_KEYBOARD_DETECTION_SUPPORT}=          ${TRUE}
 ${IPXE_BOOT_SUPPORT}=                       ${TRUE}
+# Requires firmware built with dasharo-blobs containing the nightly DTS entry
+${IPXE_NIGHTLY_DTS_SUPPORT}=                ${TRUE}
 ${AUDIO_SUBSYSTEM_SUPPORT}=                 ${TRUE}
 ${FIRMWARE_NUMBER_VERIFICATION}=            ${TRUE}
 ${PRODUCT_NAME_VERIFICATION}=               ${TRUE}

--- a/test_cases.json
+++ b/test_cases.json
@@ -5118,6 +5118,13 @@
   },
   {
     "doc": {
+      "_id": "PXE009.101",
+      "name": "DTS Nightly option is available and works correctly (EDK2 UEFI)",
+      "module": "Dasharo Compatibility"
+    }
+  },
+  {
+    "doc": {
       "_id": "QBS001.203",
       "name": "Qubes OS installation (Qubes OS)",
       "module": "Dasharo Compatibility"


### PR DESCRIPTION
# network-boot: cover the "Dasharo Tools Suite (Nightly)" iPXE menu entry

## Summary

Follow-up to [Dasharo/dasharo-blobs#53](https://github.com/Dasharo/dasharo-blobs/pull/53) (approved), which adds a `Dasharo Tools Suite (Nightly)` entry to `dasharo.ipxe`. That change shifts the iPXE menu layout, so the OSFV expectations and keywords need to follow.

Closes the OSFV half of [Dasharo/dasharo-issues#1041](https://github.com/Dasharo/dasharo-issues/issues/1041).

## Changes

### `platform-configs/include/default.robot`

- New `${IPXE_NIGHTLY_DTS_SUPPORT}` flag, defaulting to `${FALSE}`, so every platform whose firmware predates the blobs change keeps its current, passing expectations. Platforms opt in as their firmware picks up the new entry.
- New `${DTS_NIGHTLY_IPXE_LINK}` pointing at `https://boot.dasharo.com/dts/nightly.ipxe`, mirroring the existing `${DTS_IPXE_LINK}`.

### `platform-configs/qemu.robot`

- `${IPXE_NIGHTLY_DTS_SUPPORT}` set to `${TRUE}`.

### `dasharo-compatibility/network-boot.robot`

- `PXE002.001` (menu order) now branches on the flag: the 5-entry layout when the nightly entry is present, the existing 4-entry layout otherwise. It also asserts that index `[1]` is the *stable* DTS entry and not the nightly one, which the old positional check could not distinguish.
- New `PXE008.001 DTS Nightly option is available and works correctly`, mirroring `PXE004.001`: it selects the nightly entry, boots it, and asserts the DTS menu is reached. Skipped when the flag is `${FALSE}`.

### `lib/dts-lib.robot`

- `Boot Dasharo Tools Suite Via IPXE Menu` takes an optional `${menu_entry}` argument (default `Dasharo Tools Suite`), so the keyword can drive the nightly entry too. The single existing caller is unaffected.

### `test_cases.json`

- Registers `PXE008.001`.
- Also registers `PXE007.001`, which existed in `dasharo-compatibility/network-boot.robot` but was never added to the JSON. `scripts/check_tests_consistency.py` reported it as `[BRAK W JSON]` before this PR; the `PXE` suite is now clean. Happy to split that one line out if you would rather keep it separate.

## Validation

Run on QEMU Q35 against a locally built Dasharo (coreboot+UEFI) v0.2.1-rc1 ROM with the `dasharo-blobs#53` patch applied, using this repository's own harness. OSFV revision `v0.3.0-115-gf91580aa`, i.e. this branch rebased on current `develop`, with a clean tree and no `ALLOW_DIRTY` override.

```bash
QEMU_FW_FILE=./qemu_q35_nightly.rom ./scripts/ci/qemu-run.sh nographic firmware &
RTE_IP=127.0.0.1 CONFIG=qemu SNIPEIT_NO=1 \
  ./scripts/run.sh dasharo-compatibility/network-boot.robot
```

### Result: 8 tests, 8 passed, 0 failed

```text
PXE001.001 Dasharo Network Boot is available                       | PASS |
PXE002.001 Dasharo network boot menu boot options order is correct | PASS |
PXE003.001 Autoboot option is available and works correctly        | PASS |
PXE004.001 DTS option is available and works correctly             | PASS |
PXE005.001 OS installation option is available and works correctly | PASS |
PXE006.001 iPXE shell option is available and works correctly      | PASS |
PXE007.001 Dasharo Network Boot over https not http                | PASS |
PXE008.001 DTS Nightly option is available and works correctly     | PASS |
Network-Boot                                                       | PASS |
8 tests, 8 passed, 0 failed
```

### Menu layout observed by `PXE002.001`

```text
------------------------ Dasharo Network Boot Menu -----------------------
   Autoboot (DHCP)                                                     (3)
   Dasharo Tools Suite
   Dasharo Tools Suite (Nightly)
   OS installation (netboot.xyz official server)
   iPXE Shell
```

### Nightly DTS reached by `PXE008.001`

Selecting the new entry chains to `https://boot.dasharo.com/dts/nightly.ipxe`, fetches `nightly/bzImage` and `nightly/dts-base-image.cpio.gz`, and lands in the DTS menu:

```text
https://boot.dasharo.com/dts/nightly.ipxe...... ok
meta-dts revision: cce3fe5df88057a4d11da083cdbc39e1c4b42b13
dts-scripts revision: 3b6df51a62c78b6b89ec84d53ccd47c87454b34c
nightly/bzImage... ok
nightly/dts-base-image.cpio.gz... ok
...
 Dasharo Tools Suite Script 2.7.7
*********************************************************
**                HARDWARE INFORMATION
*********************************************************
**    System Inf.: Emulation QEMU x86 q35/ich9
**       CPU Inf.: Intel Core Processor (Skylake)
*********************************************************
**                FIRMWARE INFORMATION
*********************************************************
** BIOS Inf.: 3mdeb Dasharo (coreboot+UEFI) v0.2.1-rc1
*********************************************************
**     1) Dasharo HCL report
**     2) Update Dasharo Firmware
**     4) Load your DPP keys
**     6) Transition Dasharo Firmware
**     7) Fuse platform
*********************************************************
R to reboot  P to poweroff  S to enter shell
K to launch SSH server  L to enable sending DTS logs

Enter an option
```

I am attaching the Robot Framework report screenshot and the full `merged_log.html`, `merged_report.html` and `merged_debug.log` in a comment below.

## Unrelated finding: `qemu-run.sh firmware` gives the DUT too little RAM

Worth flagging separately, since it bit me while producing the logs above.

`scripts/ci/qemu-run.sh` sets `MEMORY="1G"` for the `firmware` action. The DTS initramfs is ~200 MB compressed (~600 MB+ unpacked), so any test that actually boots DTS cannot succeed at 1 GB. On my first run at 1 GB, three tests failed — including **`PXE004.001` and `PXE007.001`, which this PR does not touch**:

```text
PXE004.001 DTS option is available and works correctly             | FAIL |
  No match found for 'Enter an option' in 5 minutes. Output:
  https://boot.dasharo.com/dts/dts.ipxe..... ok
  v2.7.7/bzImage-v2.7.7... ok
  v2.7.7/dts-base-image-v2.7.7.cpio.gz... ok
PXE007.001 Dasharo Network Boot over https not http                | FAIL |
PXE008.001 DTS Nightly option is available and works correctly     | FAIL |
8 tests, 5 passed, 3 failed
```

In every case iPXE fetched the kernel and initramfs successfully and then the serial went silent — the payload loads, Linux just cannot come up in 1 GB. Re-running the identical suite with `-m 4G` and no other change gives 8/8, which is the run reported above.

I left `qemu-run.sh` alone here to keep this PR scoped. Happy to send a one-line follow-up bumping the `firmware` memory if you agree that is the right fix.

## Note on rollout

`${IPXE_NIGHTLY_DTS_SUPPORT}` is `${TRUE}` only for `qemu.robot`. If your QEMU regression runs against a *released* Dasharo QEMU image rather than a locally built one, that image will not contain the nightly entry until a release carrying `dasharo-blobs#53` ships — in that case `PXE002.001` would fail until then. Two options, whichever you prefer:

1. Keep it as is and merge this after a QEMU release containing the entry.
2. Flip `qemu.robot` back to `${FALSE}` in this PR and enable it in a one-line follow-up once the release lands.

Tell me which you want and I will adjust.
