### PR TITLE
coreboot-base-port: add cbmem boot-log misconfiguration tests

### DIFF
--- a/dasharo-compatibility/coreboot-base-port.robot
+++ b/dasharo-compatibility/coreboot-base-port.robot
@@ -6,9 +6,11 @@ Library             String
 Library             Telnet    timeout=20 seconds    connection_timeout=120 seconds
 Library             SSHLibrary    timeout=90 seconds
 Library             RequestsLibrary
+Library             ../lib/coreboot_boot_log.py
 Resource            ../variables.robot
 Resource            ../keywords.robot
 Resource            ../keys.robot
+Resource            ../lib/cbmem.robot
 
 Suite Setup         Run Keyword
 ...                     Prepare Test Suite
@@ -73,3 +75,71 @@ CBP006.101 Resource allocator v4 - allocating resources (EDK2 UEFI)
     Power On
     Set DUT Response Timeout    120s
     Read From Terminal Until    Pass 2 (allocating resources)
+
+CBP007.201 No ASSERTION ERROR in boot log (Ubuntu)
+    [Documentation]    Check that the coreboot console log does not contain
+    ...    ASSERTION ERROR, which indicates a failed ASSERT() such as
+    ...    missing PMC GPE routes.
+    ...
+    ...    References: dasharo-issues#1409 dasharo-issues#1364
+    ...    coreboot src/include/assert.h
+    Skip If    not ${BASE_PORT_LOG_CHECK_SUPPORT}    CBP007.201 not supported
+    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    CBP007.201 not supported
+    ${boot_log}=    Get Coreboot Console Log
+    Coreboot Boot Log Should Not Contain    ${boot_log}    ASSERTION ERROR
+
+CBP008.201 No missing static PCI devices in boot log (Ubuntu)
+    [Documentation]    Check that the coreboot console log does not contain
+    ...    static PCI devices that were not found and were disabled.
+    ...    Those messages come from incorrect enabled entries in
+    ...    devicetree.cb. Hidden PMC/P2SB devices can also emit this
+    ...    line; enable the flag only on ports where that is not
+    ...    accepted.
+    ...
+    ...    References: dasharo-issues#1409 dasharo-issues#1364
+    ...    coreboot src/device/pci_device.c
+    Skip If    not ${BASE_PORT_LOG_CHECK_SUPPORT}    CBP008.201 not supported
+    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    CBP008.201 not supported
+    ${boot_log}=    Get Coreboot Console Log
+    Coreboot Boot Log Should Not Contain    ${boot_log}    not found, disabling it.
+
+CBP009.201 No resource allocation failures in boot log (Ubuntu)
+    [Documentation]    Check that the coreboot console log does not contain
+    ...    resource allocator failures (Resource didn't fit!!!).
+    ...    Typical causes are PCI resource conflicts or hotplug
+    ...    windows that do not fit below 4G.
+    ...
+    ...    References: dasharo-issues#1364
+    ...    coreboot src/device/resource_allocator_v4.c
+    Skip If    not ${BASE_PORT_LOG_CHECK_SUPPORT}    CBP009.201 not supported
+    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    CBP009.201 not supported
+    ${boot_log}=    Get Coreboot Console Log
+    Coreboot Boot Log Should Not Contain    ${boot_log}    Resource didn't fit!!!
+
+CBP010.201 No BUG messages in boot log (Ubuntu)
+    [Documentation]    Check that the coreboot console log does not contain
+    ...    BUG: printks or the BUG() macro text ERROR: BUG ENCOUNTERED.
+    ...
+    ...    References: dasharo-issues#1364
+    ...    coreboot src/include/assert.h
+    Skip If    not ${BASE_PORT_LOG_CHECK_SUPPORT}    CBP010.201 not supported
+    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    CBP010.201 not supported
+    ${boot_log}=    Get Coreboot Console Log
+    Coreboot Boot Log Should Not Contain    ${boot_log}    BUG:    ERROR: BUG ENCOUNTERED
+
+CBP011.201 No leftover static devices in boot log (Ubuntu)
+    [Documentation]    Check that the coreboot console log does not ask to
+    ...    Check your devicetree.cb (leftover static devices).
+    ...
+    ...    This is a BIOS_WARNING present on almost all boards and is
+    ...    safe to ignore according to dasharo-issues#1409. It is
+    ...    therefore gated by BASE_PORT_DEVICETREE_CHECK_SUPPORT
+    ...    (default FALSE, not enabled on QEMU) rather than treated as
+    ...    a hard failure of BASE_PORT_LOG_CHECK_SUPPORT.
+    ...
+    ...    References: dasharo-issues#1409 dasharo-issues#1364
+    ...    coreboot src/device/pci_device.c
+    Skip If    not ${BASE_PORT_DEVICETREE_CHECK_SUPPORT}    CBP011.201 not supported
+    Skip If    not ${TESTS_IN_UBUNTU_SUPPORT}    CBP011.201 not supported
+    ${boot_log}=    Get Coreboot Console Log
+    Coreboot Boot Log Should Not Contain    ${boot_log}    Check your devicetree.cb

--- a/lib/cbmem.robot
+++ b/lib/cbmem.robot
@@ -1,10 +1,47 @@
 *** Settings ***
-Documentation       Collection of keywords for getting boot time from cbmem in linux
+Documentation       Keywords for reading coreboot cbmem logs and timestamps in Linux
 
 Resource            ../keywords.robot
 
 
 *** Keywords ***
+Get Coreboot Console Log
+    [Documentation]
+    ...    Returns the coreboot console log collected with ``cbmem -1``.
+    ...    The first call in a suite boots Ubuntu, logs in as root, and
+    ...    caches the log. Later calls reuse that cache so CBP log-check
+    ...    tests do not each power-cycle the DUT.
+    ...
+    ...    === Requirements ===
+    ...    - The device has to be turned on, or this keyword will power it on
+    ...    - Ubuntu has to be bootable (``${TESTS_IN_UBUNTU_SUPPORT}``)
+    ...    - ``cbmem`` available as root (same as other OSFV cbmem tests)
+    ...
+    ...    === Arguments ===
+    ...    None
+    ...
+    ...    === Return Value ===
+    ...    - ``string`` - Full coreboot console log from ``cbmem -1``
+    ...
+    ...    === Effects ===
+    ...    - On cache miss: powers on the DUT, boots Ubuntu, logs in, and
+    ...    \ switches to root. On cache hit: none.
+    ${cached}=    Get Variable Value    ${COREBOOT_CONSOLE_LOG}    ${NONE}
+    IF    $cached is not None    RETURN    ${cached}
+    Power On
+    Boot And Login To OS    ${ENV_ID_UBUNTU}
+    Switch To Root User
+    ${boot_log}=    Execute Command In Terminal    cbmem -1    timeout=180s
+    ${boot_log}=    Strip String    ${boot_log}
+    Should Not Be Empty    ${boot_log}    cbmem -1 returned an empty coreboot console log
+    Should Not Contain
+    ...    ${boot_log}
+    ...    Operation not permitted
+    ...    msg=Cannot get cbmem log. Probably Secure Boot is enabled (kernel lockdown mode).
+    Should Not Contain    ${boot_log}    command not found    msg=cbmem is not installed on the DUT
+    VAR    ${COREBOOT_CONSOLE_LOG}=    ${boot_log}    scope=SUITE
+    RETURN    ${boot_log}
+
 Get Boot Time From Cbmem
     [Documentation]    Calculates boot time based on cbmem timestamps
     # fix for LT1000 and protectli platforms (output without tabs)

--- a/lib/coreboot_boot_log.py
+++ b/lib/coreboot_boot_log.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2026 3mdeb <contact@3mdeb.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Matchers for concerning coreboot console-log strings.
+
+The needles are taken from Dasharo porting issues and from coreboot itself:
+
+- ``ASSERTION ERROR`` — ``ASSERT()`` in coreboot ``src/include/assert.h``
+  (dasharo-issues#1409 / #1364, e.g. missing PMC GPE routes).
+- ``not found, disabling it.`` — static PCI device in ``devicetree.cb`` that
+  was not found on the bus (``src/device/pci_device.c``, dasharo-issues#1409).
+- ``Resource didn't fit!!!`` — resource allocator v4 could not place a BAR
+  (``src/device/resource_allocator_v4.c``, dasharo-issues#1364).
+- ``BUG:`` — ad-hoc coreboot ``printk`` bugs (dasharo-issues#1364,
+  e.g. ``BUG: tbt_pcie_ports_present requests hidden ...``).
+- ``ERROR: BUG ENCOUNTERED`` — the ``BUG()`` macro in current coreboot
+  ``src/include/assert.h``.
+- ``Check your devicetree.cb`` — leftover static devices
+  (``src/device/pci_device.c``). This is a ``BIOS_WARNING`` present on almost
+  all boards; OSFV treats it as opt-in rather than a hard failure.
+"""
+
+from robot.api.deco import keyword
+
+# Substrings that indicate a real firmware misconfiguration (hard fail).
+HARD_FAIL_NEEDLES = (
+    "ASSERTION ERROR",
+    "not found, disabling it.",
+    "Resource didn't fit!!!",
+    "BUG:",
+    "ERROR: BUG ENCOUNTERED",
+)
+
+# Leftover static devices: documented as expected on almost all boards.
+# See dasharo-issues#1409 and coreboot src/device/pci_device.c (BIOS_WARNING).
+DEVICETREE_WARN_NEEDLES = ("Check your devicetree.cb",)
+
+
+def find_needle_hits(log, needles):
+    """Return ``[(needle, matching_lines), ...]`` for needles found in ``log``.
+
+    ``log``: ``str`` — coreboot console text (typically ``cbmem -1``).
+    ``needles``: iterable of ``str`` — literal substrings to search for.
+    """
+    lines = log.splitlines()
+    hits = []
+    for needle in needles:
+        matched = [line for line in lines if needle in line]
+        if matched:
+            hits.append((needle, matched))
+    return hits
+
+
+def format_needle_hits(hits, max_lines=10):
+    """Format ``find_needle_hits`` results for a failure message."""
+    parts = []
+    for needle, matched in hits:
+        excerpt = "\n".join(matched[:max_lines])
+        extra = ""
+        if len(matched) > max_lines:
+            extra = f"\n... ({len(matched) - max_lines} more matching line(s))"
+        parts.append(f"pattern {needle!r}:\n{excerpt}{extra}")
+    return "\n".join(parts)
+
+
+@keyword("Coreboot Boot Log Should Not Contain")
+def coreboot_boot_log_should_not_contain(log, *needles):
+    """Fail if the coreboot console log contains any of ``needles``.
+
+    === Requirements ===
+    - ``${log}`` is the text of the coreboot console (``cbmem -1``).
+
+    === Arguments ===
+    - ``${log}``: ``string`` - coreboot console log
+    - ``@{needles}``: ``string`` - one or more literal substrings that must
+      not appear in the log
+
+    === Return Value ===
+    - None
+
+    === Effects ===
+    - None. Fails the test if a needle is present, including an excerpt of
+      matching lines in the error message.
+    """
+    if not needles:
+        raise AssertionError("At least one forbidden log pattern is required")
+    hits = find_needle_hits(log, needles)
+    if hits:
+        raise AssertionError(
+            "Forbidden coreboot boot-log pattern(s) found:\n" + format_needle_hits(hits)
+        )

--- a/lib/coreboot_boot_log_test.py
+++ b/lib/coreboot_boot_log_test.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: 2026 3mdeb <contact@3mdeb.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Offline checks for coreboot boot-log needles (no QEMU / DUT required).
+
+Sample lines are taken from dasharo-issues#1364 / #1409 and from coreboot
+``src/include/assert.h``.
+"""
+
+import pytest
+
+from coreboot_boot_log import (
+    DEVICETREE_WARN_NEEDLES,
+    HARD_FAIL_NEEDLES,
+    coreboot_boot_log_should_not_contain,
+    find_needle_hits,
+)
+
+# Condensed excerpt of the console log attached to dasharo-issues#1364.
+ISSUE_1364_LOG = """\
+ASSERTION ERROR: file 'src/soc/intel/meteorlake/pmutil.c', line 159
+  PCI: 00:00:07.0 24 *  [0x99200000 - 0xb51fffff] limit: b51fffff prefmem
+Resource didn't fit!!!
+  PCI: 00:00:07.0 20 *  size: 0xc200000 limit: ffffffff mem
+BUG: tbt_pcie_ports_present requests hidden 00:07.1
+BUG: tbt_pcie_ports_present requests hidden 00:07.2
+BUG: tbt_pcie_ports_present requests hidden 00:07.3
+PCI: Static device PCI: 00:00:1f.1 not found, disabling it.
+PCI: Leftover static devices:
+PCI: 00:00:04.0
+PCI: Check your devicetree.cb.
+"""
+
+CLEAN_QEMU_LOG = """\
+coreboot-qemu_q35_v0.2.1 ramstage starting...
+FMAP: area COREBOOT found @ 20000 (16711680 bytes)
+CBFS: 'COREBOOT' located CBFS at [20000:ffffc0]
+Enumerating buses...
+PCI: 00:00:1f.2 enabled
+Devices initialized
+"""
+
+BUG_MACRO_LOG = (
+    "ERROR: BUG ENCOUNTERED at file 'src/soc/intel/common/block/tbt/tbt.c'"
+    ", line 42\n"
+)
+
+
+def test_issue_1364_hits_every_documented_hard_fail_needle():
+    hits = find_needle_hits(ISSUE_1364_LOG, HARD_FAIL_NEEDLES)
+    found = {needle for needle, _ in hits}
+    assert "ASSERTION ERROR" in found
+    assert "not found, disabling it." in found
+    assert "Resource didn't fit!!!" in found
+    assert "BUG:" in found
+
+
+def test_issue_1364_hits_devicetree_warning():
+    hits = find_needle_hits(ISSUE_1364_LOG, DEVICETREE_WARN_NEEDLES)
+    assert hits
+    assert hits[0][0] == "Check your devicetree.cb"
+
+
+def test_clean_log_has_no_hard_fail_or_devicetree_hits():
+    assert find_needle_hits(CLEAN_QEMU_LOG, HARD_FAIL_NEEDLES) == []
+    assert find_needle_hits(CLEAN_QEMU_LOG, DEVICETREE_WARN_NEEDLES) == []
+
+
+def test_bug_macro_from_current_coreboot_assert_h():
+    hits = find_needle_hits(BUG_MACRO_LOG, HARD_FAIL_NEEDLES)
+    found = {needle for needle, _ in hits}
+    assert "ERROR: BUG ENCOUNTERED" in found
+    # The BUG() macro does not emit the older "BUG:" printk used in #1364.
+    assert "BUG:" not in found
+
+
+def test_keyword_passes_on_clean_log():
+    coreboot_boot_log_should_not_contain(CLEAN_QEMU_LOG, *HARD_FAIL_NEEDLES)
+
+
+def test_keyword_fails_with_matching_line_excerpt():
+    with pytest.raises(AssertionError, match="ASSERTION ERROR") as exc:
+        coreboot_boot_log_should_not_contain(ISSUE_1364_LOG, "ASSERTION ERROR")
+    assert "pmutil.c" in str(exc.value)
+
+
+def test_keyword_requires_at_least_one_needle():
+    with pytest.raises(AssertionError, match="At least one"):
+        coreboot_boot_log_should_not_contain(CLEAN_QEMU_LOG)

--- a/platform-configs/include/default.robot
+++ b/platform-configs/include/default.robot
@@ -193,6 +193,11 @@ ${BASE_PORT_BOOTBLOCK_SUPPORT}=                     ${FALSE}
 ${BASE_PORT_ROMSTAGE_SUPPORT}=                      ${FALSE}
 ${BASE_PORT_POSTCAR_SUPPORT}=                       ${FALSE}
 ${BASE_PORT_RAMSTAGE_SUPPORT}=                      ${FALSE}
+# CBP007-CBP010: concerning coreboot console errors via cbmem -1
+${BASE_PORT_LOG_CHECK_SUPPORT}=                     ${FALSE}
+# CBP011: leftover static devices / Check your devicetree.cb. BIOS_WARNING
+# present on almost all boards (dasharo-issues#1409) - opt-in only.
+${BASE_PORT_DEVICETREE_CHECK_SUPPORT}=              ${FALSE}
 ${BOOT_BLOCKING_SUPPORT}=                           ${FALSE}
 ${FAN_SPEED_MEASURE_SUPPORT}=                       ${FALSE}
 ${FAN_MEASUREMENT_METHOD}=                          Run Prepare Sensors first ${TBD}

--- a/platform-configs/qemu.robot
+++ b/platform-configs/qemu.robot
@@ -39,6 +39,9 @@ ${DASHARO_NETWORKING_MENU_SUPPORT}=         ${TRUE}
 ${DASHARO_CHIPSET_MENU_SUPPORT}=            ${TRUE}
 
 # Test module: dasharo-compatibility
+# CBP007-CBP010 (cbmem -1). CBP011 leftover-devicetree is opt-in and stays off:
+# that warning is expected on almost all boards (dasharo-issues#1409).
+${BASE_PORT_LOG_CHECK_SUPPORT}=             ${TRUE}
 ${CUSTOM_BOOT_MENU_KEY_SUPPORT}=            ${TRUE}
 ${CUSTOM_SETUP_MENU_KEY_SUPPORT}=           ${TRUE}
 ${CUSTOM_NETWORK_BOOT_ENTRIES_SUPPORT}=     ${TRUE}

--- a/test_cases.json
+++ b/test_cases.json
@@ -806,6 +806,41 @@
   },
   {
     "doc": {
+      "_id": "CBP007.201",
+      "name": "No ASSERTION ERROR in boot log (Ubuntu)",
+      "module": "Dasharo Compatibility"
+    }
+  },
+  {
+    "doc": {
+      "_id": "CBP008.201",
+      "name": "No missing static PCI devices in boot log (Ubuntu)",
+      "module": "Dasharo Compatibility"
+    }
+  },
+  {
+    "doc": {
+      "_id": "CBP009.201",
+      "name": "No resource allocation failures in boot log (Ubuntu)",
+      "module": "Dasharo Compatibility"
+    }
+  },
+  {
+    "doc": {
+      "_id": "CBP010.201",
+      "name": "No BUG messages in boot log (Ubuntu)",
+      "module": "Dasharo Compatibility"
+    }
+  },
+  {
+    "doc": {
+      "_id": "CBP011.201",
+      "name": "No leftover static devices in boot log (Ubuntu)",
+      "module": "Dasharo Compatibility"
+    }
+  },
+  {
+    "doc": {
       "_id": "CCC001.201",
       "name": "Check core count with HT disabled (Ubuntu)",
       "module": "Dasharo Compatibility"


### PR DESCRIPTION
Closes #921

Adds CBP007–CBP011 so the coreboot base-port suite can catch documented firmware misconfiguration strings in the coreboot console log (`cbmem -1`). The checks are runnable on QEMU: they skip unless `${BASE_PORT_LOG_CHECK_SUPPORT}` is set, and they pass when the log does not contain those strings.

## Patterns

| Test | Pattern | Severity | Source |
|------|---------|----------|--------|
| CBP007.201 | `ASSERTION ERROR` | hard fail | dasharo-issues#1409 / #1364 |
| CBP008.201 | `not found, disabling it.` | hard fail | dasharo-issues#1409 / #1364 |
| CBP009.201 | `Resource didn't fit!!!` | hard fail | dasharo-issues#1364 |
| CBP010.201 | `BUG:` and `ERROR: BUG ENCOUNTERED` | hard fail | dasharo-issues#1364 + current coreboot BUG() |
| CBP011.201 | `Check your devicetree.cb` | **opt-in skip** | dasharo-issues#1409 / #1364 |

## CBP011: not a hard fail (open question from #1251)

Dasharo maintainers documented this as expected noise on almost all boards. CBP011 is gated by `${BASE_PORT_DEVICETREE_CHECK_SUPPORT}` (default off, not on QEMU). CBP007–CBP010 use `${BASE_PORT_LOG_CHECK_SUPPORT}` (enabled for QEMU).

## vs stale #1251 / #1272

- `.201` Ubuntu IDs + `test_cases.json`
- One `cbmem -1` per suite via cached `Get Coreboot Console Log`
- CBP011 decided as opt-in
- Does not enable ramstage/allocator v4 on QEMU
- Fails on empty/cbmem errors so a missing log cannot look like a pass
- Offline matcher tests on #1364 log lines

## Verification

Robot parse, pytest (7), test-id scripts, robocop, black, REUSE. Full Robot-on-QEMU boot not run in this environment (issue allows pass when log is clean).